### PR TITLE
fix!: support Flutter 3.43+ IconData final-class change

### DIFF
--- a/bin/generate_package_icons.dart
+++ b/bin/generate_package_icons.dart
@@ -126,27 +126,55 @@ void generateStyleClass(List icons, {required StyleFileData style}) {
       (a, b) => a.name.compareTo(b.name),
     );
 
+  final allFields = [...fields];
+  if (style == StyleFileData.duotone) {
+    final mapEntries = <String>[];
+    for (final icon in icons) {
+      final properties = icon['properties'] as Map<String, dynamic>;
+      if (properties['codes'] == null) continue;
+      final graphCodes = (properties['codes'] as List).cast<int>();
+      final bg = '0x' + graphCodes.first.toRadixString(16);
+      final fg = '0x' + graphCodes.last.toRadixString(16);
+      mapEntries.add(
+        '$fg: IconData($bg, fontFamily: _f, fontPackage: _p, matchTextDirection: true),',
+      );
+    }
+    allFields.add(Field((b) => b
+      ..name = 'secondaryFor'
+      ..static = true
+      ..modifier = FieldModifier.constant
+      ..type = Reference('Map<int, IconData>')
+      ..docs.addAll([
+        '/// A map that contains the secondary IconData for each primary IconData of the duotone style.',
+        '/// The key is the `codePoint` of the primary IconData and the value is the secondary IconData.',
+        '/// `PhosphorIcon` reads this map to stack the secondary glyph beneath the primary, producing the duotone effect.',
+      ])
+      ..assignment = Code('{${mapEntries.join('\n')}}')));
+  }
+
   final phosphorIconsClass = Class((classBuilder) => classBuilder
     ..abstract = false
     ..name = style.className
-    ..fields.addAll(fields)
+    ..fields.addAll(allFields)
     ..annotations.add(CodeExpression(Code('staticIconProvider')))
     ..constructors.add(Constructor(
         (constructorBuilder) => constructorBuilder..constant = true)));
 
+  final fontFamilyConst = Field((b) => b
+    ..name = '_f'
+    ..type = Reference('String')
+    ..modifier = FieldModifier.constant
+    ..assignment = Code("'Phosphor${style.styleName.capitalize()}'"));
+  final fontPackageConst = Field((b) => b
+    ..name = '_p'
+    ..type = Reference('String')
+    ..modifier = FieldModifier.constant
+    ..assignment = Code("'phosphor_flutter'"));
+
   final phosphorLib = Library(
     (libraryBuilder) => libraryBuilder
-      ..directives.add(
-        Directive.import(
-          'package:phosphor_flutter/src/phosphor_icon_data.dart',
-        ),
-      )
-      ..directives.add(
-        Directive.import(
-          'package:flutter/widgets.dart',
-        ),
-      )
-      ..body.add(phosphorIconsClass),
+      ..directives.add(Directive.import('package:flutter/widgets.dart'))
+      ..body.addAll([fontFamilyConst, fontPackageConst, phosphorIconsClass]),
   );
 
   final emitter = DartEmitter();
@@ -170,19 +198,17 @@ Field buildFieldIconByStyle(dynamic icon, {required StyleFileData style}) {
 
   late Code codeStatement;
 
+  String iconDataLiteral(String hex) =>
+      "IconData($hex, fontFamily: _f, fontPackage: _p, matchTextDirection: true)";
+
   if (style == StyleFileData.duotone && properties['codes'] != null) {
     final graphCodes = (properties['codes'] as List).cast<int>();
-    final backgroundHexCode = '0x' + graphCodes.first.toRadixString(16);
     final foregroundHexCode = '0x' + graphCodes.last.toRadixString(16);
-    codeStatement = Code(
-      "PhosphorDuotoneIconData($foregroundHexCode, PhosphorIconData($backgroundHexCode, 'Duotone'),)",
-    );
+    codeStatement = Code(iconDataLiteral(foregroundHexCode));
   } else {
     final graphCode = properties['code'] as int;
     final hexCode = '0x' + graphCode.toRadixString(16);
-    codeStatement = Code(
-      "PhosphorFlatIconData($hexCode, '${style.styleName.capitalize()}')",
-    );
+    codeStatement = Code(iconDataLiteral(hexCode));
   }
 
   return Field(

--- a/bin/pubspec.lock
+++ b/bin/pubspec.lock
@@ -5,50 +5,50 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "65.0.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.1"
   archive:
     dependency: "direct main"
     description:
       name: archive
-      sha256: "7e0d52067d05f2e0324268097ba723b71cb41ac8a6a2b24d1edf9c536b987b03"
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.6"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   built_collection:
     dependency: transitive
     description:
@@ -61,98 +61,98 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "723b4021e903217dfc445ec4cf5b42e27975aece1fc4ebbc1ca6329c2d9fb54e"
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.7.0"
+    version: "8.12.6"
   code_builder:
     dependency: "direct main"
     description:
       name: code_builder
-      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
+      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.11.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.7"
   dart_style:
     dependency: "direct main"
     description:
       name: dart_style
-      sha256: abd7625e16f51f554ea244d090292945ec4d4be7bfbaf2ec8cccea568919d334
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.6"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
+    version: "4.1.2"
   lints:
     dependency: "direct dev"
     description:
@@ -165,121 +165,129 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.20"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.18.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
-  pointycastle:
+    version: "1.9.1"
+  posix:
     dependency: transitive
     description:
-      name: pointycastle
-      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.3"
+    version: "6.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"

--- a/bin/pubspec.yaml
+++ b/bin/pubspec.yaml
@@ -6,13 +6,13 @@ repository: https://github.com/phosphor-icons/phosphor-flutter
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  archive: ^3.3.6
+  archive: ^4.0.0
   code_builder: ^4.4.0
   dart_style: ^2.3.0
-  http: ^0.13.5
+  http: ^1.0.0
 
 dev_dependencies:
   lints: ^2.0.1

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -26,54 +26,54 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.18.0"
   phosphor_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "2.1.0"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.10.0-0 <4.0.0"
+  flutter: ">=3.0.0"

--- a/lib/src/phosphor_icon.dart
+++ b/lib/src/phosphor_icon.dart
@@ -35,18 +35,24 @@ class PhosphorIcon extends Icon {
   final double duotoneSecondaryOpacity;
   final Color? duotoneSecondaryColor;
 
+  static const String _duotoneFontFamily = 'PhosphorDuotone';
+
+  IconData? _resolveSecondary() {
+    if (icon?.fontFamily != _duotoneFontFamily) return null;
+    return PhosphorIconsDuotone.secondaryFor[icon?.codePoint];
+  }
+
   @override
   Widget build(BuildContext context) {
-    if (icon is PhosphorDuotoneIconData) {
-      final duotoneIcon = icon as PhosphorDuotoneIconData;
+    final secondary = _resolveSecondary();
+    if (secondary != null) {
       return Stack(
         alignment: Alignment.center,
         children: [
           Opacity(
             opacity: duotoneSecondaryOpacity,
             child: Icon(
-              duotoneIcon.secondary,
-              key: key,
+              secondary,
               size: size,
               fill: fill,
               weight: weight,

--- a/lib/src/phosphor_icon_data.dart
+++ b/lib/src/phosphor_icon_data.dart
@@ -2,24 +2,7 @@ library phosphor_flutter;
 
 import 'package:flutter/widgets.dart';
 
-class PhosphorIconData extends IconData {
-  const PhosphorIconData(int codePoint, String style)
-      : super(
-          codePoint,
-          fontFamily: 'Phosphor$style',
-          fontPackage: 'phosphor_flutter',
-          matchTextDirection: true,
-        );
-}
-
-class PhosphorFlatIconData extends PhosphorIconData {
-  const PhosphorFlatIconData(int codePoint, String style)
-      : super(codePoint, style);
-}
-
-class PhosphorDuotoneIconData extends PhosphorIconData {
-  const PhosphorDuotoneIconData(int codePoint, this.secondary)
-      : super(codePoint, 'Duotone');
-
-  final PhosphorIconData secondary;
-}
+/// Alias retained for backward compatibility with prior `PhosphorIconData`
+/// references. Flutter marked [IconData] as `final` in 3.43+, so it can no
+/// longer be subclassed.
+typedef PhosphorIconData = IconData;

--- a/lib/src/phosphor_icons_bold.dart
+++ b/lib/src/phosphor_icons_bold.dart
@@ -1,4547 +1,6060 @@
 // Auto generated File
 // DON'T EDIT BY HAND
 
-import 'package:phosphor_flutter/src/phosphor_icon_data.dart';
 import 'package:flutter/widgets.dart';
+
+const String _f = 'PhosphorBold';
+const String _p = 'phosphor_flutter';
 
 @staticIconProvider
 class PhosphorIconsBold {
   const PhosphorIconsBold();
 
   /// ![acorn-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/acorn-bold.svg)
-  static const acorn = PhosphorFlatIconData(0xeb9a, 'Bold');
+  static const acorn = IconData(0xeb9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/address-book-bold.svg)
-  static const addressBook = PhosphorFlatIconData(0xe6f8, 'Bold');
+  static const addressBook = IconData(0xe6f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-tabs-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/address-book-tabs-bold.svg)
-  static const addressBookTabs = PhosphorFlatIconData(0xee4e, 'Bold');
+  static const addressBookTabs = IconData(0xee4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![air-traffic-control-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/air-traffic-control-bold.svg)
-  static const airTrafficControl = PhosphorFlatIconData(0xecd8, 'Bold');
+  static const airTrafficControl = IconData(0xecd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/airplane-bold.svg)
-  static const airplane = PhosphorFlatIconData(0xe002, 'Bold');
+  static const airplane = IconData(0xe002,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-in-flight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/airplane-in-flight-bold.svg)
-  static const airplaneInFlight = PhosphorFlatIconData(0xe4fe, 'Bold');
+  static const airplaneInFlight = IconData(0xe4fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-landing-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/airplane-landing-bold.svg)
-  static const airplaneLanding = PhosphorFlatIconData(0xe502, 'Bold');
+  static const airplaneLanding = IconData(0xe502,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-takeoff-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/airplane-takeoff-bold.svg)
-  static const airplaneTakeoff = PhosphorFlatIconData(0xe504, 'Bold');
+  static const airplaneTakeoff = IconData(0xe504,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-taxiing-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/airplane-taxiing-bold.svg)
-  static const airplaneTaxiing = PhosphorFlatIconData(0xe500, 'Bold');
+  static const airplaneTaxiing = IconData(0xe500,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-tilt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/airplane-tilt-bold.svg)
-  static const airplaneTilt = PhosphorFlatIconData(0xe5d6, 'Bold');
+  static const airplaneTilt = IconData(0xe5d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplay-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/airplay-bold.svg)
-  static const airplay = PhosphorFlatIconData(0xe004, 'Bold');
+  static const airplay = IconData(0xe004,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alarm-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/alarm-bold.svg)
-  static const alarm = PhosphorFlatIconData(0xe006, 'Bold');
+  static const alarm = IconData(0xe006,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alien-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/alien-bold.svg)
-  static const alien = PhosphorFlatIconData(0xe8a6, 'Bold');
+  static const alien = IconData(0xe8a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-bottom-bold.svg)
-  static const alignBottom = PhosphorFlatIconData(0xe506, 'Bold');
+  static const alignBottom = IconData(0xe506,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-bottom-simple-bold.svg)
-  static const alignBottomSimple = PhosphorFlatIconData(0xeb0c, 'Bold');
+  static const alignBottomSimple = IconData(0xeb0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-center-horizontal-bold.svg)
-  static const alignCenterHorizontal = PhosphorFlatIconData(0xe50a, 'Bold');
+  static const alignCenterHorizontal = IconData(0xe50a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-center-horizontal-simple-bold.svg)
-  static const alignCenterHorizontalSimple =
-      PhosphorFlatIconData(0xeb0e, 'Bold');
+  static const alignCenterHorizontalSimple = IconData(0xeb0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-center-vertical-bold.svg)
-  static const alignCenterVertical = PhosphorFlatIconData(0xe50c, 'Bold');
+  static const alignCenterVertical = IconData(0xe50c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-center-vertical-simple-bold.svg)
-  static const alignCenterVerticalSimple = PhosphorFlatIconData(0xeb10, 'Bold');
+  static const alignCenterVerticalSimple = IconData(0xeb10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-left-bold.svg)
-  static const alignLeft = PhosphorFlatIconData(0xe50e, 'Bold');
+  static const alignLeft = IconData(0xe50e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-left-simple-bold.svg)
-  static const alignLeftSimple = PhosphorFlatIconData(0xeaee, 'Bold');
+  static const alignLeftSimple = IconData(0xeaee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-right-bold.svg)
-  static const alignRight = PhosphorFlatIconData(0xe510, 'Bold');
+  static const alignRight = IconData(0xe510,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-right-simple-bold.svg)
-  static const alignRightSimple = PhosphorFlatIconData(0xeb12, 'Bold');
+  static const alignRightSimple = IconData(0xeb12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-top-bold.svg)
-  static const alignTop = PhosphorFlatIconData(0xe512, 'Bold');
+  static const alignTop = IconData(0xe512,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/align-top-simple-bold.svg)
-  static const alignTopSimple = PhosphorFlatIconData(0xeb14, 'Bold');
+  static const alignTopSimple = IconData(0xeb14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![amazon-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/amazon-logo-bold.svg)
-  static const amazonLogo = PhosphorFlatIconData(0xe96c, 'Bold');
+  static const amazonLogo = IconData(0xe96c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ambulance-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ambulance-bold.svg)
-  static const ambulance = PhosphorFlatIconData(0xe572, 'Bold');
+  static const ambulance = IconData(0xe572,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/anchor-bold.svg)
-  static const anchor = PhosphorFlatIconData(0xe514, 'Bold');
+  static const anchor = IconData(0xe514,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/anchor-simple-bold.svg)
-  static const anchorSimple = PhosphorFlatIconData(0xe5d8, 'Bold');
+  static const anchorSimple = IconData(0xe5d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![android-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/android-logo-bold.svg)
-  static const androidLogo = PhosphorFlatIconData(0xe008, 'Bold');
+  static const androidLogo = IconData(0xe008,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/angle-bold.svg)
-  static const angle = PhosphorFlatIconData(0xe7bc, 'Bold');
+  static const angle = IconData(0xe7bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angular-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/angular-logo-bold.svg)
-  static const angularLogo = PhosphorFlatIconData(0xeb80, 'Bold');
+  static const angularLogo = IconData(0xeb80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![aperture-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/aperture-bold.svg)
-  static const aperture = PhosphorFlatIconData(0xe00a, 'Bold');
+  static const aperture = IconData(0xe00a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-store-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/app-store-logo-bold.svg)
-  static const appStoreLogo = PhosphorFlatIconData(0xe974, 'Bold');
+  static const appStoreLogo = IconData(0xe974,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-window-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/app-window-bold.svg)
-  static const appWindow = PhosphorFlatIconData(0xe5da, 'Bold');
+  static const appWindow = IconData(0xe5da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/apple-logo-bold.svg)
-  static const appleLogo = PhosphorFlatIconData(0xe516, 'Bold');
+  static const appleLogo = IconData(0xe516,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-podcasts-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/apple-podcasts-logo-bold.svg)
-  static const applePodcastsLogo = PhosphorFlatIconData(0xeb96, 'Bold');
+  static const applePodcastsLogo = IconData(0xeb96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![approximate-equals-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/approximate-equals-bold.svg)
-  static const approximateEquals = PhosphorFlatIconData(0xedaa, 'Bold');
+  static const approximateEquals = IconData(0xedaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![archive-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/archive-bold.svg)
-  static const archive = PhosphorFlatIconData(0xe00c, 'Bold');
+  static const archive = IconData(0xe00c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![armchair-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/armchair-bold.svg)
-  static const armchair = PhosphorFlatIconData(0xe012, 'Bold');
+  static const armchair = IconData(0xe012,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-arc-left-bold.svg)
-  static const arrowArcLeft = PhosphorFlatIconData(0xe014, 'Bold');
+  static const arrowArcLeft = IconData(0xe014,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-arc-right-bold.svg)
-  static const arrowArcRight = PhosphorFlatIconData(0xe016, 'Bold');
+  static const arrowArcRight = IconData(0xe016,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-double-up-left-bold.svg)
-  static const arrowBendDoubleUpLeft = PhosphorFlatIconData(0xe03a, 'Bold');
+  static const arrowBendDoubleUpLeft = IconData(0xe03a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-double-up-right-bold.svg)
-  static const arrowBendDoubleUpRight = PhosphorFlatIconData(0xe03c, 'Bold');
+  static const arrowBendDoubleUpRight = IconData(0xe03c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-down-left-bold.svg)
-  static const arrowBendDownLeft = PhosphorFlatIconData(0xe018, 'Bold');
+  static const arrowBendDownLeft = IconData(0xe018,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-down-right-bold.svg)
-  static const arrowBendDownRight = PhosphorFlatIconData(0xe01a, 'Bold');
+  static const arrowBendDownRight = IconData(0xe01a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-left-down-bold.svg)
-  static const arrowBendLeftDown = PhosphorFlatIconData(0xe01c, 'Bold');
+  static const arrowBendLeftDown = IconData(0xe01c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-left-up-bold.svg)
-  static const arrowBendLeftUp = PhosphorFlatIconData(0xe01e, 'Bold');
+  static const arrowBendLeftUp = IconData(0xe01e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-right-down-bold.svg)
-  static const arrowBendRightDown = PhosphorFlatIconData(0xe020, 'Bold');
+  static const arrowBendRightDown = IconData(0xe020,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-right-up-bold.svg)
-  static const arrowBendRightUp = PhosphorFlatIconData(0xe022, 'Bold');
+  static const arrowBendRightUp = IconData(0xe022,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-up-left-bold.svg)
-  static const arrowBendUpLeft = PhosphorFlatIconData(0xe024, 'Bold');
+  static const arrowBendUpLeft = IconData(0xe024,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-bend-up-right-bold.svg)
-  static const arrowBendUpRight = PhosphorFlatIconData(0xe026, 'Bold');
+  static const arrowBendUpRight = IconData(0xe026,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-circle-down-bold.svg)
-  static const arrowCircleDown = PhosphorFlatIconData(0xe028, 'Bold');
+  static const arrowCircleDown = IconData(0xe028,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-circle-down-left-bold.svg)
-  static const arrowCircleDownLeft = PhosphorFlatIconData(0xe02a, 'Bold');
+  static const arrowCircleDownLeft = IconData(0xe02a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-circle-down-right-bold.svg)
-  static const arrowCircleDownRight = PhosphorFlatIconData(0xe02c, 'Bold');
+  static const arrowCircleDownRight = IconData(0xe02c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-circle-left-bold.svg)
-  static const arrowCircleLeft = PhosphorFlatIconData(0xe05a, 'Bold');
+  static const arrowCircleLeft = IconData(0xe05a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-circle-right-bold.svg)
-  static const arrowCircleRight = PhosphorFlatIconData(0xe02e, 'Bold');
+  static const arrowCircleRight = IconData(0xe02e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-circle-up-bold.svg)
-  static const arrowCircleUp = PhosphorFlatIconData(0xe030, 'Bold');
+  static const arrowCircleUp = IconData(0xe030,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-circle-up-left-bold.svg)
-  static const arrowCircleUpLeft = PhosphorFlatIconData(0xe032, 'Bold');
+  static const arrowCircleUpLeft = IconData(0xe032,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-circle-up-right-bold.svg)
-  static const arrowCircleUpRight = PhosphorFlatIconData(0xe034, 'Bold');
+  static const arrowCircleUpRight = IconData(0xe034,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-clockwise-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-clockwise-bold.svg)
-  static const arrowClockwise = PhosphorFlatIconData(0xe036, 'Bold');
+  static const arrowClockwise = IconData(0xe036,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-counter-clockwise-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-counter-clockwise-bold.svg)
-  static const arrowCounterClockwise = PhosphorFlatIconData(0xe038, 'Bold');
+  static const arrowCounterClockwise = IconData(0xe038,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-down-bold.svg)
-  static const arrowDown = PhosphorFlatIconData(0xe03e, 'Bold');
+  static const arrowDown = IconData(0xe03e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-down-left-bold.svg)
-  static const arrowDownLeft = PhosphorFlatIconData(0xe040, 'Bold');
+  static const arrowDownLeft = IconData(0xe040,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-down-right-bold.svg)
-  static const arrowDownRight = PhosphorFlatIconData(0xe042, 'Bold');
+  static const arrowDownRight = IconData(0xe042,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-down-left-bold.svg)
-  static const arrowElbowDownLeft = PhosphorFlatIconData(0xe044, 'Bold');
+  static const arrowElbowDownLeft = IconData(0xe044,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-down-right-bold.svg)
-  static const arrowElbowDownRight = PhosphorFlatIconData(0xe046, 'Bold');
+  static const arrowElbowDownRight = IconData(0xe046,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-left-bold.svg)
-  static const arrowElbowLeft = PhosphorFlatIconData(0xe048, 'Bold');
+  static const arrowElbowLeft = IconData(0xe048,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-left-down-bold.svg)
-  static const arrowElbowLeftDown = PhosphorFlatIconData(0xe04a, 'Bold');
+  static const arrowElbowLeftDown = IconData(0xe04a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-left-up-bold.svg)
-  static const arrowElbowLeftUp = PhosphorFlatIconData(0xe04c, 'Bold');
+  static const arrowElbowLeftUp = IconData(0xe04c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-right-bold.svg)
-  static const arrowElbowRight = PhosphorFlatIconData(0xe04e, 'Bold');
+  static const arrowElbowRight = IconData(0xe04e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-right-down-bold.svg)
-  static const arrowElbowRightDown = PhosphorFlatIconData(0xe050, 'Bold');
+  static const arrowElbowRightDown = IconData(0xe050,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-right-up-bold.svg)
-  static const arrowElbowRightUp = PhosphorFlatIconData(0xe052, 'Bold');
+  static const arrowElbowRightUp = IconData(0xe052,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-up-left-bold.svg)
-  static const arrowElbowUpLeft = PhosphorFlatIconData(0xe054, 'Bold');
+  static const arrowElbowUpLeft = IconData(0xe054,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-elbow-up-right-bold.svg)
-  static const arrowElbowUpRight = PhosphorFlatIconData(0xe056, 'Bold');
+  static const arrowElbowUpRight = IconData(0xe056,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-down-bold.svg)
-  static const arrowFatDown = PhosphorFlatIconData(0xe518, 'Bold');
+  static const arrowFatDown = IconData(0xe518,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-left-bold.svg)
-  static const arrowFatLeft = PhosphorFlatIconData(0xe51a, 'Bold');
+  static const arrowFatLeft = IconData(0xe51a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-line-down-bold.svg)
-  static const arrowFatLineDown = PhosphorFlatIconData(0xe51c, 'Bold');
+  static const arrowFatLineDown = IconData(0xe51c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-line-left-bold.svg)
-  static const arrowFatLineLeft = PhosphorFlatIconData(0xe51e, 'Bold');
+  static const arrowFatLineLeft = IconData(0xe51e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-line-right-bold.svg)
-  static const arrowFatLineRight = PhosphorFlatIconData(0xe520, 'Bold');
+  static const arrowFatLineRight = IconData(0xe520,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-line-up-bold.svg)
-  static const arrowFatLineUp = PhosphorFlatIconData(0xe522, 'Bold');
+  static const arrowFatLineUp = IconData(0xe522,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-lines-down-bold.svg)
-  static const arrowFatLinesDown = PhosphorFlatIconData(0xe524, 'Bold');
+  static const arrowFatLinesDown = IconData(0xe524,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-lines-left-bold.svg)
-  static const arrowFatLinesLeft = PhosphorFlatIconData(0xe526, 'Bold');
+  static const arrowFatLinesLeft = IconData(0xe526,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-lines-right-bold.svg)
-  static const arrowFatLinesRight = PhosphorFlatIconData(0xe528, 'Bold');
+  static const arrowFatLinesRight = IconData(0xe528,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-lines-up-bold.svg)
-  static const arrowFatLinesUp = PhosphorFlatIconData(0xe52a, 'Bold');
+  static const arrowFatLinesUp = IconData(0xe52a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-right-bold.svg)
-  static const arrowFatRight = PhosphorFlatIconData(0xe52c, 'Bold');
+  static const arrowFatRight = IconData(0xe52c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-fat-up-bold.svg)
-  static const arrowFatUp = PhosphorFlatIconData(0xe52e, 'Bold');
+  static const arrowFatUp = IconData(0xe52e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-left-bold.svg)
-  static const arrowLeft = PhosphorFlatIconData(0xe058, 'Bold');
+  static const arrowLeft = IconData(0xe058,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-line-down-bold.svg)
-  static const arrowLineDown = PhosphorFlatIconData(0xe05c, 'Bold');
+  static const arrowLineDown = IconData(0xe05c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-line-down-left-bold.svg)
-  static const arrowLineDownLeft = PhosphorFlatIconData(0xe05e, 'Bold');
+  static const arrowLineDownLeft = IconData(0xe05e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-line-down-right-bold.svg)
-  static const arrowLineDownRight = PhosphorFlatIconData(0xe060, 'Bold');
+  static const arrowLineDownRight = IconData(0xe060,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-line-left-bold.svg)
-  static const arrowLineLeft = PhosphorFlatIconData(0xe062, 'Bold');
+  static const arrowLineLeft = IconData(0xe062,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-line-right-bold.svg)
-  static const arrowLineRight = PhosphorFlatIconData(0xe064, 'Bold');
+  static const arrowLineRight = IconData(0xe064,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-line-up-bold.svg)
-  static const arrowLineUp = PhosphorFlatIconData(0xe066, 'Bold');
+  static const arrowLineUp = IconData(0xe066,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-line-up-left-bold.svg)
-  static const arrowLineUpLeft = PhosphorFlatIconData(0xe068, 'Bold');
+  static const arrowLineUpLeft = IconData(0xe068,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-line-up-right-bold.svg)
-  static const arrowLineUpRight = PhosphorFlatIconData(0xe06a, 'Bold');
+  static const arrowLineUpRight = IconData(0xe06a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-right-bold.svg)
-  static const arrowRight = PhosphorFlatIconData(0xe06c, 'Bold');
+  static const arrowRight = IconData(0xe06c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-down-bold.svg)
-  static const arrowSquareDown = PhosphorFlatIconData(0xe06e, 'Bold');
+  static const arrowSquareDown = IconData(0xe06e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-down-left-bold.svg)
-  static const arrowSquareDownLeft = PhosphorFlatIconData(0xe070, 'Bold');
+  static const arrowSquareDownLeft = IconData(0xe070,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-down-right-bold.svg)
-  static const arrowSquareDownRight = PhosphorFlatIconData(0xe072, 'Bold');
+  static const arrowSquareDownRight = IconData(0xe072,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-in-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-in-bold.svg)
-  static const arrowSquareIn = PhosphorFlatIconData(0xe5dc, 'Bold');
+  static const arrowSquareIn = IconData(0xe5dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-left-bold.svg)
-  static const arrowSquareLeft = PhosphorFlatIconData(0xe074, 'Bold');
+  static const arrowSquareLeft = IconData(0xe074,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-out-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-out-bold.svg)
-  static const arrowSquareOut = PhosphorFlatIconData(0xe5de, 'Bold');
+  static const arrowSquareOut = IconData(0xe5de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-right-bold.svg)
-  static const arrowSquareRight = PhosphorFlatIconData(0xe076, 'Bold');
+  static const arrowSquareRight = IconData(0xe076,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-up-bold.svg)
-  static const arrowSquareUp = PhosphorFlatIconData(0xe078, 'Bold');
+  static const arrowSquareUp = IconData(0xe078,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-up-left-bold.svg)
-  static const arrowSquareUpLeft = PhosphorFlatIconData(0xe07a, 'Bold');
+  static const arrowSquareUpLeft = IconData(0xe07a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-square-up-right-bold.svg)
-  static const arrowSquareUpRight = PhosphorFlatIconData(0xe07c, 'Bold');
+  static const arrowSquareUpRight = IconData(0xe07c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-u-down-left-bold.svg)
-  static const arrowUDownLeft = PhosphorFlatIconData(0xe07e, 'Bold');
+  static const arrowUDownLeft = IconData(0xe07e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-u-down-right-bold.svg)
-  static const arrowUDownRight = PhosphorFlatIconData(0xe080, 'Bold');
+  static const arrowUDownRight = IconData(0xe080,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-u-left-down-bold.svg)
-  static const arrowULeftDown = PhosphorFlatIconData(0xe082, 'Bold');
+  static const arrowULeftDown = IconData(0xe082,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-u-left-up-bold.svg)
-  static const arrowULeftUp = PhosphorFlatIconData(0xe084, 'Bold');
+  static const arrowULeftUp = IconData(0xe084,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-u-right-down-bold.svg)
-  static const arrowURightDown = PhosphorFlatIconData(0xe086, 'Bold');
+  static const arrowURightDown = IconData(0xe086,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-u-right-up-bold.svg)
-  static const arrowURightUp = PhosphorFlatIconData(0xe088, 'Bold');
+  static const arrowURightUp = IconData(0xe088,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-u-up-left-bold.svg)
-  static const arrowUUpLeft = PhosphorFlatIconData(0xe08a, 'Bold');
+  static const arrowUUpLeft = IconData(0xe08a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-u-up-right-bold.svg)
-  static const arrowUUpRight = PhosphorFlatIconData(0xe08c, 'Bold');
+  static const arrowUUpRight = IconData(0xe08c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-up-bold.svg)
-  static const arrowUp = PhosphorFlatIconData(0xe08e, 'Bold');
+  static const arrowUp = IconData(0xe08e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-up-left-bold.svg)
-  static const arrowUpLeft = PhosphorFlatIconData(0xe090, 'Bold');
+  static const arrowUpLeft = IconData(0xe090,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrow-up-right-bold.svg)
-  static const arrowUpRight = PhosphorFlatIconData(0xe092, 'Bold');
+  static const arrowUpRight = IconData(0xe092,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-clockwise-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-clockwise-bold.svg)
-  static const arrowsClockwise = PhosphorFlatIconData(0xe094, 'Bold');
+  static const arrowsClockwise = IconData(0xe094,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-counter-clockwise-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-counter-clockwise-bold.svg)
-  static const arrowsCounterClockwise = PhosphorFlatIconData(0xe096, 'Bold');
+  static const arrowsCounterClockwise = IconData(0xe096,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-down-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-down-up-bold.svg)
-  static const arrowsDownUp = PhosphorFlatIconData(0xe098, 'Bold');
+  static const arrowsDownUp = IconData(0xe098,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-horizontal-bold.svg)
-  static const arrowsHorizontal = PhosphorFlatIconData(0xeb06, 'Bold');
+  static const arrowsHorizontal = IconData(0xeb06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-in-bold.svg)
-  static const arrowsIn = PhosphorFlatIconData(0xe09a, 'Bold');
+  static const arrowsIn = IconData(0xe09a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-cardinal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-in-cardinal-bold.svg)
-  static const arrowsInCardinal = PhosphorFlatIconData(0xe09c, 'Bold');
+  static const arrowsInCardinal = IconData(0xe09c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-in-line-horizontal-bold.svg)
-  static const arrowsInLineHorizontal = PhosphorFlatIconData(0xe530, 'Bold');
+  static const arrowsInLineHorizontal = IconData(0xe530,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-in-line-vertical-bold.svg)
-  static const arrowsInLineVertical = PhosphorFlatIconData(0xe532, 'Bold');
+  static const arrowsInLineVertical = IconData(0xe532,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-in-simple-bold.svg)
-  static const arrowsInSimple = PhosphorFlatIconData(0xe09e, 'Bold');
+  static const arrowsInSimple = IconData(0xe09e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-left-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-left-right-bold.svg)
-  static const arrowsLeftRight = PhosphorFlatIconData(0xe0a0, 'Bold');
+  static const arrowsLeftRight = IconData(0xe0a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-merge-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-merge-bold.svg)
-  static const arrowsMerge = PhosphorFlatIconData(0xed3e, 'Bold');
+  static const arrowsMerge = IconData(0xed3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-out-bold.svg)
-  static const arrowsOut = PhosphorFlatIconData(0xe0a2, 'Bold');
+  static const arrowsOut = IconData(0xe0a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-cardinal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-out-cardinal-bold.svg)
-  static const arrowsOutCardinal = PhosphorFlatIconData(0xe0a4, 'Bold');
+  static const arrowsOutCardinal = IconData(0xe0a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-out-line-horizontal-bold.svg)
-  static const arrowsOutLineHorizontal = PhosphorFlatIconData(0xe534, 'Bold');
+  static const arrowsOutLineHorizontal = IconData(0xe534,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-out-line-vertical-bold.svg)
-  static const arrowsOutLineVertical = PhosphorFlatIconData(0xe536, 'Bold');
+  static const arrowsOutLineVertical = IconData(0xe536,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-out-simple-bold.svg)
-  static const arrowsOutSimple = PhosphorFlatIconData(0xe0a6, 'Bold');
+  static const arrowsOutSimple = IconData(0xe0a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-split-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-split-bold.svg)
-  static const arrowsSplit = PhosphorFlatIconData(0xed3c, 'Bold');
+  static const arrowsSplit = IconData(0xed3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/arrows-vertical-bold.svg)
-  static const arrowsVertical = PhosphorFlatIconData(0xeb04, 'Bold');
+  static const arrowsVertical = IconData(0xeb04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/article-bold.svg)
-  static const article = PhosphorFlatIconData(0xe0a8, 'Bold');
+  static const article = IconData(0xe0a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-medium-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/article-medium-bold.svg)
-  static const articleMedium = PhosphorFlatIconData(0xe5e0, 'Bold');
+  static const articleMedium = IconData(0xe5e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-ny-times-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/article-ny-times-bold.svg)
-  static const articleNyTimes = PhosphorFlatIconData(0xe5e2, 'Bold');
+  static const articleNyTimes = IconData(0xe5e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asclepius-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/asclepius-bold.svg)
-  static const asclepius = PhosphorFlatIconData(0xee34, 'Bold');
+  static const asclepius = IconData(0xee34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/asterisk-bold.svg)
-  static const asterisk = PhosphorFlatIconData(0xe0aa, 'Bold');
+  static const asterisk = IconData(0xe0aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/asterisk-simple-bold.svg)
-  static const asteriskSimple = PhosphorFlatIconData(0xe832, 'Bold');
+  static const asteriskSimple = IconData(0xe832,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![at-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/at-bold.svg)
-  static const at = PhosphorFlatIconData(0xe0ac, 'Bold');
+  static const at = IconData(0xe0ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![atom-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/atom-bold.svg)
-  static const atom = PhosphorFlatIconData(0xe5e4, 'Bold');
+  static const atom = IconData(0xe5e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![avocado-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/avocado-bold.svg)
-  static const avocado = PhosphorFlatIconData(0xee04, 'Bold');
+  static const avocado = IconData(0xee04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![axe-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/axe-bold.svg)
-  static const axe = PhosphorFlatIconData(0xe9fc, 'Bold');
+  static const axe = IconData(0xe9fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/baby-bold.svg)
-  static const baby = PhosphorFlatIconData(0xe774, 'Bold');
+  static const baby = IconData(0xe774,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-carriage-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/baby-carriage-bold.svg)
-  static const babyCarriage = PhosphorFlatIconData(0xe818, 'Bold');
+  static const babyCarriage = IconData(0xe818,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backpack-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/backpack-bold.svg)
-  static const backpack = PhosphorFlatIconData(0xe922, 'Bold');
+  static const backpack = IconData(0xe922,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backspace-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/backspace-bold.svg)
-  static const backspace = PhosphorFlatIconData(0xe0ae, 'Bold');
+  static const backspace = IconData(0xe0ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bag-bold.svg)
-  static const bag = PhosphorFlatIconData(0xe0b0, 'Bold');
+  static const bag = IconData(0xe0b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bag-simple-bold.svg)
-  static const bagSimple = PhosphorFlatIconData(0xe5e6, 'Bold');
+  static const bagSimple = IconData(0xe5e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![balloon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/balloon-bold.svg)
-  static const balloon = PhosphorFlatIconData(0xe76c, 'Bold');
+  static const balloon = IconData(0xe76c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bandaids-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bandaids-bold.svg)
-  static const bandaids = PhosphorFlatIconData(0xe0b2, 'Bold');
+  static const bandaids = IconData(0xe0b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bank-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bank-bold.svg)
-  static const bank = PhosphorFlatIconData(0xe0b4, 'Bold');
+  static const bank = IconData(0xe0b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barbell-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/barbell-bold.svg)
-  static const barbell = PhosphorFlatIconData(0xe0b6, 'Bold');
+  static const barbell = IconData(0xe0b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barcode-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/barcode-bold.svg)
-  static const barcode = PhosphorFlatIconData(0xe0b8, 'Bold');
+  static const barcode = IconData(0xe0b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barn-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/barn-bold.svg)
-  static const barn = PhosphorFlatIconData(0xec72, 'Bold');
+  static const barn = IconData(0xec72,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barricade-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/barricade-bold.svg)
-  static const barricade = PhosphorFlatIconData(0xe948, 'Bold');
+  static const barricade = IconData(0xe948,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/baseball-bold.svg)
-  static const baseball = PhosphorFlatIconData(0xe71a, 'Bold');
+  static const baseball = IconData(0xe71a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-cap-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/baseball-cap-bold.svg)
-  static const baseballCap = PhosphorFlatIconData(0xea28, 'Bold');
+  static const baseballCap = IconData(0xea28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-helmet-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/baseball-helmet-bold.svg)
-  static const baseballHelmet = PhosphorFlatIconData(0xee4a, 'Bold');
+  static const baseballHelmet = IconData(0xee4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basket-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/basket-bold.svg)
-  static const basket = PhosphorFlatIconData(0xe964, 'Bold');
+  static const basket = IconData(0xe964,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basketball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/basketball-bold.svg)
-  static const basketball = PhosphorFlatIconData(0xe724, 'Bold');
+  static const basketball = IconData(0xe724,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bathtub-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bathtub-bold.svg)
-  static const bathtub = PhosphorFlatIconData(0xe81e, 'Bold');
+  static const bathtub = IconData(0xe81e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-charging-bold.svg)
-  static const batteryCharging = PhosphorFlatIconData(0xe0ba, 'Bold');
+  static const batteryCharging = IconData(0xe0ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-charging-vertical-bold.svg)
-  static const batteryChargingVertical = PhosphorFlatIconData(0xe0bc, 'Bold');
+  static const batteryChargingVertical = IconData(0xe0bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-empty-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-empty-bold.svg)
-  static const batteryEmpty = PhosphorFlatIconData(0xe0be, 'Bold');
+  static const batteryEmpty = IconData(0xe0be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-full-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-full-bold.svg)
-  static const batteryFull = PhosphorFlatIconData(0xe0c0, 'Bold');
+  static const batteryFull = IconData(0xe0c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-high-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-high-bold.svg)
-  static const batteryHigh = PhosphorFlatIconData(0xe0c2, 'Bold');
+  static const batteryHigh = IconData(0xe0c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-low-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-low-bold.svg)
-  static const batteryLow = PhosphorFlatIconData(0xe0c4, 'Bold');
+  static const batteryLow = IconData(0xe0c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-medium-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-medium-bold.svg)
-  static const batteryMedium = PhosphorFlatIconData(0xe0c6, 'Bold');
+  static const batteryMedium = IconData(0xe0c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-plus-bold.svg)
-  static const batteryPlus = PhosphorFlatIconData(0xe808, 'Bold');
+  static const batteryPlus = IconData(0xe808,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-plus-vertical-bold.svg)
-  static const batteryPlusVertical = PhosphorFlatIconData(0xec50, 'Bold');
+  static const batteryPlusVertical = IconData(0xec50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-empty-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-vertical-empty-bold.svg)
-  static const batteryVerticalEmpty = PhosphorFlatIconData(0xe7c6, 'Bold');
+  static const batteryVerticalEmpty = IconData(0xe7c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-full-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-vertical-full-bold.svg)
-  static const batteryVerticalFull = PhosphorFlatIconData(0xe7c4, 'Bold');
+  static const batteryVerticalFull = IconData(0xe7c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-high-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-vertical-high-bold.svg)
-  static const batteryVerticalHigh = PhosphorFlatIconData(0xe7c2, 'Bold');
+  static const batteryVerticalHigh = IconData(0xe7c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-low-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-vertical-low-bold.svg)
-  static const batteryVerticalLow = PhosphorFlatIconData(0xe7be, 'Bold');
+  static const batteryVerticalLow = IconData(0xe7be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-medium-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-vertical-medium-bold.svg)
-  static const batteryVerticalMedium = PhosphorFlatIconData(0xe7c0, 'Bold');
+  static const batteryVerticalMedium = IconData(0xe7c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-warning-bold.svg)
-  static const batteryWarning = PhosphorFlatIconData(0xe0c8, 'Bold');
+  static const batteryWarning = IconData(0xe0c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/battery-warning-vertical-bold.svg)
-  static const batteryWarningVertical = PhosphorFlatIconData(0xe0ca, 'Bold');
+  static const batteryWarningVertical = IconData(0xe0ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beach-ball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/beach-ball-bold.svg)
-  static const beachBall = PhosphorFlatIconData(0xed24, 'Bold');
+  static const beachBall = IconData(0xed24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beanie-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/beanie-bold.svg)
-  static const beanie = PhosphorFlatIconData(0xea2a, 'Bold');
+  static const beanie = IconData(0xea2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bed-bold.svg)
-  static const bed = PhosphorFlatIconData(0xe0cc, 'Bold');
+  static const bed = IconData(0xe0cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-bottle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/beer-bottle-bold.svg)
-  static const beerBottle = PhosphorFlatIconData(0xe7b0, 'Bold');
+  static const beerBottle = IconData(0xe7b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-stein-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/beer-stein-bold.svg)
-  static const beerStein = PhosphorFlatIconData(0xeb62, 'Bold');
+  static const beerStein = IconData(0xeb62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![behance-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/behance-logo-bold.svg)
-  static const behanceLogo = PhosphorFlatIconData(0xe7f4, 'Bold');
+  static const behanceLogo = IconData(0xe7f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bell-bold.svg)
-  static const bell = PhosphorFlatIconData(0xe0ce, 'Bold');
+  static const bell = IconData(0xe0ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-ringing-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bell-ringing-bold.svg)
-  static const bellRinging = PhosphorFlatIconData(0xe5e8, 'Bold');
+  static const bellRinging = IconData(0xe5e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bell-simple-bold.svg)
-  static const bellSimple = PhosphorFlatIconData(0xe0d0, 'Bold');
+  static const bellSimple = IconData(0xe0d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-ringing-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bell-simple-ringing-bold.svg)
-  static const bellSimpleRinging = PhosphorFlatIconData(0xe5ea, 'Bold');
+  static const bellSimpleRinging = IconData(0xe5ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bell-simple-slash-bold.svg)
-  static const bellSimpleSlash = PhosphorFlatIconData(0xe0d2, 'Bold');
+  static const bellSimpleSlash = IconData(0xe0d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-z-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bell-simple-z-bold.svg)
-  static const bellSimpleZ = PhosphorFlatIconData(0xe5ec, 'Bold');
+  static const bellSimpleZ = IconData(0xe5ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bell-slash-bold.svg)
-  static const bellSlash = PhosphorFlatIconData(0xe0d4, 'Bold');
+  static const bellSlash = IconData(0xe0d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-z-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bell-z-bold.svg)
-  static const bellZ = PhosphorFlatIconData(0xe5ee, 'Bold');
+  static const bellZ = IconData(0xe5ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![belt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/belt-bold.svg)
-  static const belt = PhosphorFlatIconData(0xea2c, 'Bold');
+  static const belt = IconData(0xea2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bezier-curve-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bezier-curve-bold.svg)
-  static const bezierCurve = PhosphorFlatIconData(0xeb00, 'Bold');
+  static const bezierCurve = IconData(0xeb00,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bicycle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bicycle-bold.svg)
-  static const bicycle = PhosphorFlatIconData(0xe0d6, 'Bold');
+  static const bicycle = IconData(0xe0d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binary-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/binary-bold.svg)
-  static const binary = PhosphorFlatIconData(0xee60, 'Bold');
+  static const binary = IconData(0xee60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binoculars-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/binoculars-bold.svg)
-  static const binoculars = PhosphorFlatIconData(0xea64, 'Bold');
+  static const binoculars = IconData(0xea64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![biohazard-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/biohazard-bold.svg)
-  static const biohazard = PhosphorFlatIconData(0xe9e0, 'Bold');
+  static const biohazard = IconData(0xe9e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bird-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bird-bold.svg)
-  static const bird = PhosphorFlatIconData(0xe72c, 'Bold');
+  static const bird = IconData(0xe72c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![blueprint-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/blueprint-bold.svg)
-  static const blueprint = PhosphorFlatIconData(0xeda0, 'Bold');
+  static const blueprint = IconData(0xeda0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bluetooth-bold.svg)
-  static const bluetooth = PhosphorFlatIconData(0xe0da, 'Bold');
+  static const bluetooth = IconData(0xe0da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-connected-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bluetooth-connected-bold.svg)
-  static const bluetoothConnected = PhosphorFlatIconData(0xe0dc, 'Bold');
+  static const bluetoothConnected = IconData(0xe0dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bluetooth-slash-bold.svg)
-  static const bluetoothSlash = PhosphorFlatIconData(0xe0de, 'Bold');
+  static const bluetoothSlash = IconData(0xe0de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bluetooth-x-bold.svg)
-  static const bluetoothX = PhosphorFlatIconData(0xe0e0, 'Bold');
+  static const bluetoothX = IconData(0xe0e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/boat-bold.svg)
-  static const boat = PhosphorFlatIconData(0xe786, 'Bold');
+  static const boat = IconData(0xe786,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bomb-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bomb-bold.svg)
-  static const bomb = PhosphorFlatIconData(0xee0a, 'Bold');
+  static const bomb = IconData(0xee0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bone-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bone-bold.svg)
-  static const bone = PhosphorFlatIconData(0xe7f2, 'Bold');
+  static const bone = IconData(0xe7f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/book-bold.svg)
-  static const book = PhosphorFlatIconData(0xe0e2, 'Bold');
+  static const book = IconData(0xe0e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-bookmark-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/book-bookmark-bold.svg)
-  static const bookBookmark = PhosphorFlatIconData(0xe0e4, 'Bold');
+  static const bookBookmark = IconData(0xe0e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/book-open-bold.svg)
-  static const bookOpen = PhosphorFlatIconData(0xe0e6, 'Bold');
+  static const bookOpen = IconData(0xe0e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-text-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/book-open-text-bold.svg)
-  static const bookOpenText = PhosphorFlatIconData(0xe8f2, 'Bold');
+  static const bookOpenText = IconData(0xe8f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-user-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/book-open-user-bold.svg)
-  static const bookOpenUser = PhosphorFlatIconData(0xede0, 'Bold');
+  static const bookOpenUser = IconData(0xede0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bookmark-bold.svg)
-  static const bookmark = PhosphorFlatIconData(0xe0e8, 'Bold');
+  static const bookmark = IconData(0xe0e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bookmark-simple-bold.svg)
-  static const bookmarkSimple = PhosphorFlatIconData(0xe0ea, 'Bold');
+  static const bookmarkSimple = IconData(0xe0ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bookmarks-bold.svg)
-  static const bookmarks = PhosphorFlatIconData(0xe0ec, 'Bold');
+  static const bookmarks = IconData(0xe0ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bookmarks-simple-bold.svg)
-  static const bookmarksSimple = PhosphorFlatIconData(0xe5f0, 'Bold');
+  static const bookmarksSimple = IconData(0xe5f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![books-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/books-bold.svg)
-  static const books = PhosphorFlatIconData(0xe758, 'Bold');
+  static const books = IconData(0xe758,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boot-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/boot-bold.svg)
-  static const boot = PhosphorFlatIconData(0xecca, 'Bold');
+  static const boot = IconData(0xecca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boules-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/boules-bold.svg)
-  static const boules = PhosphorFlatIconData(0xe722, 'Bold');
+  static const boules = IconData(0xe722,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bounding-box-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bounding-box-bold.svg)
-  static const boundingBox = PhosphorFlatIconData(0xe6ce, 'Bold');
+  static const boundingBox = IconData(0xe6ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-food-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bowl-food-bold.svg)
-  static const bowlFood = PhosphorFlatIconData(0xeaa4, 'Bold');
+  static const bowlFood = IconData(0xeaa4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-steam-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bowl-steam-bold.svg)
-  static const bowlSteam = PhosphorFlatIconData(0xe8e4, 'Bold');
+  static const bowlSteam = IconData(0xe8e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowling-ball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bowling-ball-bold.svg)
-  static const bowlingBall = PhosphorFlatIconData(0xea34, 'Bold');
+  static const bowlingBall = IconData(0xea34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/box-arrow-down-bold.svg)
-  static const boxArrowDown = PhosphorFlatIconData(0xe00e, 'Bold');
+  static const boxArrowDown = IconData(0xe00e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/box-arrow-up-bold.svg)
-  static const boxArrowUp = PhosphorFlatIconData(0xee54, 'Bold');
+  static const boxArrowUp = IconData(0xee54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boxing-glove-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/boxing-glove-bold.svg)
-  static const boxingGlove = PhosphorFlatIconData(0xea36, 'Bold');
+  static const boxingGlove = IconData(0xea36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-angle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/brackets-angle-bold.svg)
-  static const bracketsAngle = PhosphorFlatIconData(0xe862, 'Bold');
+  static const bracketsAngle = IconData(0xe862,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-curly-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/brackets-curly-bold.svg)
-  static const bracketsCurly = PhosphorFlatIconData(0xe860, 'Bold');
+  static const bracketsCurly = IconData(0xe860,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-round-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/brackets-round-bold.svg)
-  static const bracketsRound = PhosphorFlatIconData(0xe864, 'Bold');
+  static const bracketsRound = IconData(0xe864,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/brackets-square-bold.svg)
-  static const bracketsSquare = PhosphorFlatIconData(0xe85e, 'Bold');
+  static const bracketsSquare = IconData(0xe85e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brain-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/brain-bold.svg)
-  static const brain = PhosphorFlatIconData(0xe74e, 'Bold');
+  static const brain = IconData(0xe74e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brandy-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/brandy-bold.svg)
-  static const brandy = PhosphorFlatIconData(0xe6b4, 'Bold');
+  static const brandy = IconData(0xe6b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bread-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bread-bold.svg)
-  static const bread = PhosphorFlatIconData(0xe81c, 'Bold');
+  static const bread = IconData(0xe81c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bridge-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bridge-bold.svg)
-  static const bridge = PhosphorFlatIconData(0xea68, 'Bold');
+  static const bridge = IconData(0xea68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/briefcase-bold.svg)
-  static const briefcase = PhosphorFlatIconData(0xe0ee, 'Bold');
+  static const briefcase = IconData(0xe0ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-metal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/briefcase-metal-bold.svg)
-  static const briefcaseMetal = PhosphorFlatIconData(0xe5f2, 'Bold');
+  static const briefcaseMetal = IconData(0xe5f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broadcast-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/broadcast-bold.svg)
-  static const broadcast = PhosphorFlatIconData(0xe0f2, 'Bold');
+  static const broadcast = IconData(0xe0f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broom-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/broom-bold.svg)
-  static const broom = PhosphorFlatIconData(0xec54, 'Bold');
+  static const broom = IconData(0xec54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browser-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/browser-bold.svg)
-  static const browser = PhosphorFlatIconData(0xe0f4, 'Bold');
+  static const browser = IconData(0xe0f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browsers-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/browsers-bold.svg)
-  static const browsers = PhosphorFlatIconData(0xe0f6, 'Bold');
+  static const browsers = IconData(0xe0f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bug-bold.svg)
-  static const bug = PhosphorFlatIconData(0xe5f4, 'Bold');
+  static const bug = IconData(0xe5f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-beetle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bug-beetle-bold.svg)
-  static const bugBeetle = PhosphorFlatIconData(0xe5f6, 'Bold');
+  static const bugBeetle = IconData(0xe5f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-droid-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bug-droid-bold.svg)
-  static const bugDroid = PhosphorFlatIconData(0xe5f8, 'Bold');
+  static const bugDroid = IconData(0xe5f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/building-bold.svg)
-  static const building = PhosphorFlatIconData(0xe100, 'Bold');
+  static const building = IconData(0xe100,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-apartment-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/building-apartment-bold.svg)
-  static const buildingApartment = PhosphorFlatIconData(0xe0fe, 'Bold');
+  static const buildingApartment = IconData(0xe0fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-office-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/building-office-bold.svg)
-  static const buildingOffice = PhosphorFlatIconData(0xe0ff, 'Bold');
+  static const buildingOffice = IconData(0xe0ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![buildings-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/buildings-bold.svg)
-  static const buildings = PhosphorFlatIconData(0xe102, 'Bold');
+  static const buildings = IconData(0xe102,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bulldozer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bulldozer-bold.svg)
-  static const bulldozer = PhosphorFlatIconData(0xec6c, 'Bold');
+  static const bulldozer = IconData(0xec6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/bus-bold.svg)
-  static const bus = PhosphorFlatIconData(0xe106, 'Bold');
+  static const bus = IconData(0xe106,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![butterfly-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/butterfly-bold.svg)
-  static const butterfly = PhosphorFlatIconData(0xea6e, 'Bold');
+  static const butterfly = IconData(0xea6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cable-car-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cable-car-bold.svg)
-  static const cableCar = PhosphorFlatIconData(0xe49c, 'Bold');
+  static const cableCar = IconData(0xe49c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cactus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cactus-bold.svg)
-  static const cactus = PhosphorFlatIconData(0xe918, 'Bold');
+  static const cactus = IconData(0xe918,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cake-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cake-bold.svg)
-  static const cake = PhosphorFlatIconData(0xe780, 'Bold');
+  static const cake = IconData(0xe780,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calculator-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calculator-bold.svg)
-  static const calculator = PhosphorFlatIconData(0xe538, 'Bold');
+  static const calculator = IconData(0xe538,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-bold.svg)
-  static const calendar = PhosphorFlatIconData(0xe108, 'Bold');
+  static const calendar = IconData(0xe108,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-blank-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-blank-bold.svg)
-  static const calendarBlank = PhosphorFlatIconData(0xe10a, 'Bold');
+  static const calendarBlank = IconData(0xe10a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-check-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-check-bold.svg)
-  static const calendarCheck = PhosphorFlatIconData(0xe712, 'Bold');
+  static const calendarCheck = IconData(0xe712,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dot-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-dot-bold.svg)
-  static const calendarDot = PhosphorFlatIconData(0xe7b2, 'Bold');
+  static const calendarDot = IconData(0xe7b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dots-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-dots-bold.svg)
-  static const calendarDots = PhosphorFlatIconData(0xe7b4, 'Bold');
+  static const calendarDots = IconData(0xe7b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-heart-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-heart-bold.svg)
-  static const calendarHeart = PhosphorFlatIconData(0xe8b0, 'Bold');
+  static const calendarHeart = IconData(0xe8b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-minus-bold.svg)
-  static const calendarMinus = PhosphorFlatIconData(0xea14, 'Bold');
+  static const calendarMinus = IconData(0xea14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-plus-bold.svg)
-  static const calendarPlus = PhosphorFlatIconData(0xe714, 'Bold');
+  static const calendarPlus = IconData(0xe714,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-slash-bold.svg)
-  static const calendarSlash = PhosphorFlatIconData(0xea12, 'Bold');
+  static const calendarSlash = IconData(0xea12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-star-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-star-bold.svg)
-  static const calendarStar = PhosphorFlatIconData(0xe8b2, 'Bold');
+  static const calendarStar = IconData(0xe8b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/calendar-x-bold.svg)
-  static const calendarX = PhosphorFlatIconData(0xe10c, 'Bold');
+  static const calendarX = IconData(0xe10c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![call-bell-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/call-bell-bold.svg)
-  static const callBell = PhosphorFlatIconData(0xe7de, 'Bold');
+  static const callBell = IconData(0xe7de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/camera-bold.svg)
-  static const camera = PhosphorFlatIconData(0xe10e, 'Bold');
+  static const camera = IconData(0xe10e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/camera-plus-bold.svg)
-  static const cameraPlus = PhosphorFlatIconData(0xec58, 'Bold');
+  static const cameraPlus = IconData(0xec58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-rotate-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/camera-rotate-bold.svg)
-  static const cameraRotate = PhosphorFlatIconData(0xe7a4, 'Bold');
+  static const cameraRotate = IconData(0xe7a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/camera-slash-bold.svg)
-  static const cameraSlash = PhosphorFlatIconData(0xe110, 'Bold');
+  static const cameraSlash = IconData(0xe110,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![campfire-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/campfire-bold.svg)
-  static const campfire = PhosphorFlatIconData(0xe9d8, 'Bold');
+  static const campfire = IconData(0xe9d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/car-bold.svg)
-  static const car = PhosphorFlatIconData(0xe112, 'Bold');
+  static const car = IconData(0xe112,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-battery-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/car-battery-bold.svg)
-  static const carBattery = PhosphorFlatIconData(0xee30, 'Bold');
+  static const carBattery = IconData(0xee30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-profile-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/car-profile-bold.svg)
-  static const carProfile = PhosphorFlatIconData(0xe8cc, 'Bold');
+  static const carProfile = IconData(0xe8cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/car-simple-bold.svg)
-  static const carSimple = PhosphorFlatIconData(0xe114, 'Bold');
+  static const carSimple = IconData(0xe114,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cardholder-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cardholder-bold.svg)
-  static const cardholder = PhosphorFlatIconData(0xe5fa, 'Bold');
+  static const cardholder = IconData(0xe5fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cards-bold.svg)
-  static const cards = PhosphorFlatIconData(0xe0f8, 'Bold');
+  static const cards = IconData(0xe0f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cards-three-bold.svg)
-  static const cardsThree = PhosphorFlatIconData(0xee50, 'Bold');
+  static const cardsThree = IconData(0xee50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-double-down-bold.svg)
-  static const caretCircleDoubleDown = PhosphorFlatIconData(0xe116, 'Bold');
+  static const caretCircleDoubleDown = IconData(0xe116,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-double-left-bold.svg)
-  static const caretCircleDoubleLeft = PhosphorFlatIconData(0xe118, 'Bold');
+  static const caretCircleDoubleLeft = IconData(0xe118,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-double-right-bold.svg)
-  static const caretCircleDoubleRight = PhosphorFlatIconData(0xe11a, 'Bold');
+  static const caretCircleDoubleRight = IconData(0xe11a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-double-up-bold.svg)
-  static const caretCircleDoubleUp = PhosphorFlatIconData(0xe11c, 'Bold');
+  static const caretCircleDoubleUp = IconData(0xe11c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-down-bold.svg)
-  static const caretCircleDown = PhosphorFlatIconData(0xe11e, 'Bold');
+  static const caretCircleDown = IconData(0xe11e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-left-bold.svg)
-  static const caretCircleLeft = PhosphorFlatIconData(0xe120, 'Bold');
+  static const caretCircleLeft = IconData(0xe120,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-right-bold.svg)
-  static const caretCircleRight = PhosphorFlatIconData(0xe122, 'Bold');
+  static const caretCircleRight = IconData(0xe122,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-up-bold.svg)
-  static const caretCircleUp = PhosphorFlatIconData(0xe124, 'Bold');
+  static const caretCircleUp = IconData(0xe124,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-circle-up-down-bold.svg)
-  static const caretCircleUpDown = PhosphorFlatIconData(0xe13e, 'Bold');
+  static const caretCircleUpDown = IconData(0xe13e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-double-down-bold.svg)
-  static const caretDoubleDown = PhosphorFlatIconData(0xe126, 'Bold');
+  static const caretDoubleDown = IconData(0xe126,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-double-left-bold.svg)
-  static const caretDoubleLeft = PhosphorFlatIconData(0xe128, 'Bold');
+  static const caretDoubleLeft = IconData(0xe128,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-double-right-bold.svg)
-  static const caretDoubleRight = PhosphorFlatIconData(0xe12a, 'Bold');
+  static const caretDoubleRight = IconData(0xe12a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-double-up-bold.svg)
-  static const caretDoubleUp = PhosphorFlatIconData(0xe12c, 'Bold');
+  static const caretDoubleUp = IconData(0xe12c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-down-bold.svg)
-  static const caretDown = PhosphorFlatIconData(0xe136, 'Bold');
+  static const caretDown = IconData(0xe136,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-left-bold.svg)
-  static const caretLeft = PhosphorFlatIconData(0xe138, 'Bold');
+  static const caretLeft = IconData(0xe138,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-line-down-bold.svg)
-  static const caretLineDown = PhosphorFlatIconData(0xe134, 'Bold');
+  static const caretLineDown = IconData(0xe134,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-line-left-bold.svg)
-  static const caretLineLeft = PhosphorFlatIconData(0xe132, 'Bold');
+  static const caretLineLeft = IconData(0xe132,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-line-right-bold.svg)
-  static const caretLineRight = PhosphorFlatIconData(0xe130, 'Bold');
+  static const caretLineRight = IconData(0xe130,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-line-up-bold.svg)
-  static const caretLineUp = PhosphorFlatIconData(0xe12e, 'Bold');
+  static const caretLineUp = IconData(0xe12e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-right-bold.svg)
-  static const caretRight = PhosphorFlatIconData(0xe13a, 'Bold');
+  static const caretRight = IconData(0xe13a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-up-bold.svg)
-  static const caretUp = PhosphorFlatIconData(0xe13c, 'Bold');
+  static const caretUp = IconData(0xe13c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/caret-up-down-bold.svg)
-  static const caretUpDown = PhosphorFlatIconData(0xe140, 'Bold');
+  static const caretUpDown = IconData(0xe140,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![carrot-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/carrot-bold.svg)
-  static const carrot = PhosphorFlatIconData(0xed38, 'Bold');
+  static const carrot = IconData(0xed38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cash-register-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cash-register-bold.svg)
-  static const cashRegister = PhosphorFlatIconData(0xed80, 'Bold');
+  static const cashRegister = IconData(0xed80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cassette-tape-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cassette-tape-bold.svg)
-  static const cassetteTape = PhosphorFlatIconData(0xed2e, 'Bold');
+  static const cassetteTape = IconData(0xed2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![castle-turret-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/castle-turret-bold.svg)
-  static const castleTurret = PhosphorFlatIconData(0xe9d0, 'Bold');
+  static const castleTurret = IconData(0xe9d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cat-bold.svg)
-  static const cat = PhosphorFlatIconData(0xe748, 'Bold');
+  static const cat = IconData(0xe748,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-full-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cell-signal-full-bold.svg)
-  static const cellSignalFull = PhosphorFlatIconData(0xe142, 'Bold');
+  static const cellSignalFull = IconData(0xe142,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-high-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cell-signal-high-bold.svg)
-  static const cellSignalHigh = PhosphorFlatIconData(0xe144, 'Bold');
+  static const cellSignalHigh = IconData(0xe144,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-low-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cell-signal-low-bold.svg)
-  static const cellSignalLow = PhosphorFlatIconData(0xe146, 'Bold');
+  static const cellSignalLow = IconData(0xe146,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-medium-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cell-signal-medium-bold.svg)
-  static const cellSignalMedium = PhosphorFlatIconData(0xe148, 'Bold');
+  static const cellSignalMedium = IconData(0xe148,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-none-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cell-signal-none-bold.svg)
-  static const cellSignalNone = PhosphorFlatIconData(0xe14a, 'Bold');
+  static const cellSignalNone = IconData(0xe14a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cell-signal-slash-bold.svg)
-  static const cellSignalSlash = PhosphorFlatIconData(0xe14c, 'Bold');
+  static const cellSignalSlash = IconData(0xe14c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cell-signal-x-bold.svg)
-  static const cellSignalX = PhosphorFlatIconData(0xe14e, 'Bold');
+  static const cellSignalX = IconData(0xe14e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-tower-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cell-tower-bold.svg)
-  static const cellTower = PhosphorFlatIconData(0xebaa, 'Bold');
+  static const cellTower = IconData(0xebaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![certificate-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/certificate-bold.svg)
-  static const certificate = PhosphorFlatIconData(0xe766, 'Bold');
+  static const certificate = IconData(0xe766,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chair-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chair-bold.svg)
-  static const chair = PhosphorFlatIconData(0xe950, 'Bold');
+  static const chair = IconData(0xe950,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chalkboard-bold.svg)
-  static const chalkboard = PhosphorFlatIconData(0xe5fc, 'Bold');
+  static const chalkboard = IconData(0xe5fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chalkboard-simple-bold.svg)
-  static const chalkboardSimple = PhosphorFlatIconData(0xe5fe, 'Bold');
+  static const chalkboardSimple = IconData(0xe5fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-teacher-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chalkboard-teacher-bold.svg)
-  static const chalkboardTeacher = PhosphorFlatIconData(0xe600, 'Bold');
+  static const chalkboardTeacher = IconData(0xe600,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![champagne-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/champagne-bold.svg)
-  static const champagne = PhosphorFlatIconData(0xeaca, 'Bold');
+  static const champagne = IconData(0xeaca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![charging-station-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/charging-station-bold.svg)
-  static const chargingStation = PhosphorFlatIconData(0xe8d0, 'Bold');
+  static const chargingStation = IconData(0xe8d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-bar-bold.svg)
-  static const chartBar = PhosphorFlatIconData(0xe150, 'Bold');
+  static const chartBar = IconData(0xe150,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-bar-horizontal-bold.svg)
-  static const chartBarHorizontal = PhosphorFlatIconData(0xe152, 'Bold');
+  static const chartBarHorizontal = IconData(0xe152,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-donut-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-donut-bold.svg)
-  static const chartDonut = PhosphorFlatIconData(0xeaa6, 'Bold');
+  static const chartDonut = IconData(0xeaa6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-line-bold.svg)
-  static const chartLine = PhosphorFlatIconData(0xe154, 'Bold');
+  static const chartLine = IconData(0xe154,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-line-down-bold.svg)
-  static const chartLineDown = PhosphorFlatIconData(0xe8b6, 'Bold');
+  static const chartLineDown = IconData(0xe8b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-line-up-bold.svg)
-  static const chartLineUp = PhosphorFlatIconData(0xe156, 'Bold');
+  static const chartLineUp = IconData(0xe156,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-pie-bold.svg)
-  static const chartPie = PhosphorFlatIconData(0xe158, 'Bold');
+  static const chartPie = IconData(0xe158,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-slice-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-pie-slice-bold.svg)
-  static const chartPieSlice = PhosphorFlatIconData(0xe15a, 'Bold');
+  static const chartPieSlice = IconData(0xe15a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-polar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-polar-bold.svg)
-  static const chartPolar = PhosphorFlatIconData(0xeaa8, 'Bold');
+  static const chartPolar = IconData(0xeaa8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-scatter-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chart-scatter-bold.svg)
-  static const chartScatter = PhosphorFlatIconData(0xeaac, 'Bold');
+  static const chartScatter = IconData(0xeaac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-bold.svg)
-  static const chat = PhosphorFlatIconData(0xe15c, 'Bold');
+  static const chat = IconData(0xe15c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-centered-bold.svg)
-  static const chatCentered = PhosphorFlatIconData(0xe160, 'Bold');
+  static const chatCentered = IconData(0xe160,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-dots-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-centered-dots-bold.svg)
-  static const chatCenteredDots = PhosphorFlatIconData(0xe164, 'Bold');
+  static const chatCenteredDots = IconData(0xe164,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-centered-slash-bold.svg)
-  static const chatCenteredSlash = PhosphorFlatIconData(0xe162, 'Bold');
+  static const chatCenteredSlash = IconData(0xe162,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-text-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-centered-text-bold.svg)
-  static const chatCenteredText = PhosphorFlatIconData(0xe166, 'Bold');
+  static const chatCenteredText = IconData(0xe166,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-circle-bold.svg)
-  static const chatCircle = PhosphorFlatIconData(0xe168, 'Bold');
+  static const chatCircle = IconData(0xe168,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-dots-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-circle-dots-bold.svg)
-  static const chatCircleDots = PhosphorFlatIconData(0xe16c, 'Bold');
+  static const chatCircleDots = IconData(0xe16c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-circle-slash-bold.svg)
-  static const chatCircleSlash = PhosphorFlatIconData(0xe16a, 'Bold');
+  static const chatCircleSlash = IconData(0xe16a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-text-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-circle-text-bold.svg)
-  static const chatCircleText = PhosphorFlatIconData(0xe16e, 'Bold');
+  static const chatCircleText = IconData(0xe16e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-dots-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-dots-bold.svg)
-  static const chatDots = PhosphorFlatIconData(0xe170, 'Bold');
+  static const chatDots = IconData(0xe170,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-slash-bold.svg)
-  static const chatSlash = PhosphorFlatIconData(0xe15e, 'Bold');
+  static const chatSlash = IconData(0xe15e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-teardrop-bold.svg)
-  static const chatTeardrop = PhosphorFlatIconData(0xe172, 'Bold');
+  static const chatTeardrop = IconData(0xe172,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-dots-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-teardrop-dots-bold.svg)
-  static const chatTeardropDots = PhosphorFlatIconData(0xe176, 'Bold');
+  static const chatTeardropDots = IconData(0xe176,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-teardrop-slash-bold.svg)
-  static const chatTeardropSlash = PhosphorFlatIconData(0xe174, 'Bold');
+  static const chatTeardropSlash = IconData(0xe174,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-text-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-teardrop-text-bold.svg)
-  static const chatTeardropText = PhosphorFlatIconData(0xe178, 'Bold');
+  static const chatTeardropText = IconData(0xe178,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-text-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chat-text-bold.svg)
-  static const chatText = PhosphorFlatIconData(0xe17a, 'Bold');
+  static const chatText = IconData(0xe17a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chats-bold.svg)
-  static const chats = PhosphorFlatIconData(0xe17c, 'Bold');
+  static const chats = IconData(0xe17c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chats-circle-bold.svg)
-  static const chatsCircle = PhosphorFlatIconData(0xe17e, 'Bold');
+  static const chatsCircle = IconData(0xe17e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-teardrop-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chats-teardrop-bold.svg)
-  static const chatsTeardrop = PhosphorFlatIconData(0xe180, 'Bold');
+  static const chatsTeardrop = IconData(0xe180,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/check-bold.svg)
-  static const check = PhosphorFlatIconData(0xe182, 'Bold');
+  static const check = IconData(0xe182,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/check-circle-bold.svg)
-  static const checkCircle = PhosphorFlatIconData(0xe184, 'Bold');
+  static const checkCircle = IconData(0xe184,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-fat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/check-fat-bold.svg)
-  static const checkFat = PhosphorFlatIconData(0xeba6, 'Bold');
+  static const checkFat = IconData(0xeba6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/check-square-bold.svg)
-  static const checkSquare = PhosphorFlatIconData(0xe186, 'Bold');
+  static const checkSquare = IconData(0xe186,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-offset-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/check-square-offset-bold.svg)
-  static const checkSquareOffset = PhosphorFlatIconData(0xe188, 'Bold');
+  static const checkSquareOffset = IconData(0xe188,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checkerboard-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/checkerboard-bold.svg)
-  static const checkerboard = PhosphorFlatIconData(0xe8c4, 'Bold');
+  static const checkerboard = IconData(0xe8c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checks-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/checks-bold.svg)
-  static const checks = PhosphorFlatIconData(0xe53a, 'Bold');
+  static const checks = IconData(0xe53a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheers-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cheers-bold.svg)
-  static const cheers = PhosphorFlatIconData(0xea4a, 'Bold');
+  static const cheers = IconData(0xea4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheese-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cheese-bold.svg)
-  static const cheese = PhosphorFlatIconData(0xe9fe, 'Bold');
+  static const cheese = IconData(0xe9fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chef-hat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/chef-hat-bold.svg)
-  static const chefHat = PhosphorFlatIconData(0xed8e, 'Bold');
+  static const chefHat = IconData(0xed8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cherries-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cherries-bold.svg)
-  static const cherries = PhosphorFlatIconData(0xe830, 'Bold');
+  static const cherries = IconData(0xe830,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![church-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/church-bold.svg)
-  static const church = PhosphorFlatIconData(0xecea, 'Bold');
+  static const church = IconData(0xecea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cigarette-bold.svg)
-  static const cigarette = PhosphorFlatIconData(0xed90, 'Bold');
+  static const cigarette = IconData(0xed90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cigarette-slash-bold.svg)
-  static const cigaretteSlash = PhosphorFlatIconData(0xed92, 'Bold');
+  static const cigaretteSlash = IconData(0xed92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circle-bold.svg)
-  static const circle = PhosphorFlatIconData(0xe18a, 'Bold');
+  static const circle = IconData(0xe18a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-dashed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circle-dashed-bold.svg)
-  static const circleDashed = PhosphorFlatIconData(0xe602, 'Bold');
+  static const circleDashed = IconData(0xe602,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circle-half-bold.svg)
-  static const circleHalf = PhosphorFlatIconData(0xe18c, 'Bold');
+  static const circleHalf = IconData(0xe18c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-tilt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circle-half-tilt-bold.svg)
-  static const circleHalfTilt = PhosphorFlatIconData(0xe18e, 'Bold');
+  static const circleHalfTilt = IconData(0xe18e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-notch-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circle-notch-bold.svg)
-  static const circleNotch = PhosphorFlatIconData(0xeb44, 'Bold');
+  static const circleNotch = IconData(0xeb44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circles-four-bold.svg)
-  static const circlesFour = PhosphorFlatIconData(0xe190, 'Bold');
+  static const circlesFour = IconData(0xe190,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circles-three-bold.svg)
-  static const circlesThree = PhosphorFlatIconData(0xe192, 'Bold');
+  static const circlesThree = IconData(0xe192,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circles-three-plus-bold.svg)
-  static const circlesThreePlus = PhosphorFlatIconData(0xe194, 'Bold');
+  static const circlesThreePlus = IconData(0xe194,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circuitry-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/circuitry-bold.svg)
-  static const circuitry = PhosphorFlatIconData(0xe9c2, 'Bold');
+  static const circuitry = IconData(0xe9c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![city-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/city-bold.svg)
-  static const city = PhosphorFlatIconData(0xea6a, 'Bold');
+  static const city = IconData(0xea6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clipboard-bold.svg)
-  static const clipboard = PhosphorFlatIconData(0xe196, 'Bold');
+  static const clipboard = IconData(0xe196,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-text-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clipboard-text-bold.svg)
-  static const clipboardText = PhosphorFlatIconData(0xe198, 'Bold');
+  static const clipboardText = IconData(0xe198,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clock-bold.svg)
-  static const clock = PhosphorFlatIconData(0xe19a, 'Bold');
+  static const clock = IconData(0xe19a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-afternoon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clock-afternoon-bold.svg)
-  static const clockAfternoon = PhosphorFlatIconData(0xe19c, 'Bold');
+  static const clockAfternoon = IconData(0xe19c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-clockwise-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clock-clockwise-bold.svg)
-  static const clockClockwise = PhosphorFlatIconData(0xe19e, 'Bold');
+  static const clockClockwise = IconData(0xe19e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-countdown-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clock-countdown-bold.svg)
-  static const clockCountdown = PhosphorFlatIconData(0xed2c, 'Bold');
+  static const clockCountdown = IconData(0xed2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-counter-clockwise-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clock-counter-clockwise-bold.svg)
-  static const clockCounterClockwise = PhosphorFlatIconData(0xe1a0, 'Bold');
+  static const clockCounterClockwise = IconData(0xe1a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-user-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clock-user-bold.svg)
-  static const clockUser = PhosphorFlatIconData(0xedec, 'Bold');
+  static const clockUser = IconData(0xedec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![closed-captioning-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/closed-captioning-bold.svg)
-  static const closedCaptioning = PhosphorFlatIconData(0xe1a4, 'Bold');
+  static const closedCaptioning = IconData(0xe1a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-bold.svg)
-  static const cloud = PhosphorFlatIconData(0xe1aa, 'Bold');
+  static const cloud = IconData(0xe1aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-arrow-down-bold.svg)
-  static const cloudArrowDown = PhosphorFlatIconData(0xe1ac, 'Bold');
+  static const cloudArrowDown = IconData(0xe1ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-arrow-up-bold.svg)
-  static const cloudArrowUp = PhosphorFlatIconData(0xe1ae, 'Bold');
+  static const cloudArrowUp = IconData(0xe1ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-check-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-check-bold.svg)
-  static const cloudCheck = PhosphorFlatIconData(0xe1b0, 'Bold');
+  static const cloudCheck = IconData(0xe1b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-fog-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-fog-bold.svg)
-  static const cloudFog = PhosphorFlatIconData(0xe53c, 'Bold');
+  static const cloudFog = IconData(0xe53c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-lightning-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-lightning-bold.svg)
-  static const cloudLightning = PhosphorFlatIconData(0xe1b2, 'Bold');
+  static const cloudLightning = IconData(0xe1b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-moon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-moon-bold.svg)
-  static const cloudMoon = PhosphorFlatIconData(0xe53e, 'Bold');
+  static const cloudMoon = IconData(0xe53e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-rain-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-rain-bold.svg)
-  static const cloudRain = PhosphorFlatIconData(0xe1b4, 'Bold');
+  static const cloudRain = IconData(0xe1b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-slash-bold.svg)
-  static const cloudSlash = PhosphorFlatIconData(0xe1b6, 'Bold');
+  static const cloudSlash = IconData(0xe1b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-snow-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-snow-bold.svg)
-  static const cloudSnow = PhosphorFlatIconData(0xe1b8, 'Bold');
+  static const cloudSnow = IconData(0xe1b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-sun-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-sun-bold.svg)
-  static const cloudSun = PhosphorFlatIconData(0xe540, 'Bold');
+  static const cloudSun = IconData(0xe540,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-warning-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-warning-bold.svg)
-  static const cloudWarning = PhosphorFlatIconData(0xea98, 'Bold');
+  static const cloudWarning = IconData(0xea98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cloud-x-bold.svg)
-  static const cloudX = PhosphorFlatIconData(0xea96, 'Bold');
+  static const cloudX = IconData(0xea96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clover-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/clover-bold.svg)
-  static const clover = PhosphorFlatIconData(0xedc8, 'Bold');
+  static const clover = IconData(0xedc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![club-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/club-bold.svg)
-  static const club = PhosphorFlatIconData(0xe1ba, 'Bold');
+  static const club = IconData(0xe1ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coat-hanger-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/coat-hanger-bold.svg)
-  static const coatHanger = PhosphorFlatIconData(0xe7fe, 'Bold');
+  static const coatHanger = IconData(0xe7fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coda-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/coda-logo-bold.svg)
-  static const codaLogo = PhosphorFlatIconData(0xe7ce, 'Bold');
+  static const codaLogo = IconData(0xe7ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/code-bold.svg)
-  static const code = PhosphorFlatIconData(0xe1bc, 'Bold');
+  static const code = IconData(0xe1bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-block-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/code-block-bold.svg)
-  static const codeBlock = PhosphorFlatIconData(0xeafe, 'Bold');
+  static const codeBlock = IconData(0xeafe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/code-simple-bold.svg)
-  static const codeSimple = PhosphorFlatIconData(0xe1be, 'Bold');
+  static const codeSimple = IconData(0xe1be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codepen-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/codepen-logo-bold.svg)
-  static const codepenLogo = PhosphorFlatIconData(0xe978, 'Bold');
+  static const codepenLogo = IconData(0xe978,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codesandbox-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/codesandbox-logo-bold.svg)
-  static const codesandboxLogo = PhosphorFlatIconData(0xea06, 'Bold');
+  static const codesandboxLogo = IconData(0xea06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/coffee-bold.svg)
-  static const coffee = PhosphorFlatIconData(0xe1c2, 'Bold');
+  static const coffee = IconData(0xe1c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-bean-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/coffee-bean-bold.svg)
-  static const coffeeBean = PhosphorFlatIconData(0xe1c0, 'Bold');
+  static const coffeeBean = IconData(0xe1c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/coin-bold.svg)
-  static const coin = PhosphorFlatIconData(0xe60e, 'Bold');
+  static const coin = IconData(0xe60e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/coin-vertical-bold.svg)
-  static const coinVertical = PhosphorFlatIconData(0xeb48, 'Bold');
+  static const coinVertical = IconData(0xeb48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coins-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/coins-bold.svg)
-  static const coins = PhosphorFlatIconData(0xe78e, 'Bold');
+  static const coins = IconData(0xe78e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/columns-bold.svg)
-  static const columns = PhosphorFlatIconData(0xe546, 'Bold');
+  static const columns = IconData(0xe546,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/columns-plus-left-bold.svg)
-  static const columnsPlusLeft = PhosphorFlatIconData(0xe544, 'Bold');
+  static const columnsPlusLeft = IconData(0xe544,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/columns-plus-right-bold.svg)
-  static const columnsPlusRight = PhosphorFlatIconData(0xe542, 'Bold');
+  static const columnsPlusRight = IconData(0xe542,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![command-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/command-bold.svg)
-  static const command = PhosphorFlatIconData(0xe1c4, 'Bold');
+  static const command = IconData(0xe1c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/compass-bold.svg)
-  static const compass = PhosphorFlatIconData(0xe1c8, 'Bold');
+  static const compass = IconData(0xe1c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-rose-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/compass-rose-bold.svg)
-  static const compassRose = PhosphorFlatIconData(0xe1c6, 'Bold');
+  static const compassRose = IconData(0xe1c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-tool-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/compass-tool-bold.svg)
-  static const compassTool = PhosphorFlatIconData(0xea0e, 'Bold');
+  static const compassTool = IconData(0xea0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![computer-tower-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/computer-tower-bold.svg)
-  static const computerTower = PhosphorFlatIconData(0xe548, 'Bold');
+  static const computerTower = IconData(0xe548,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![confetti-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/confetti-bold.svg)
-  static const confetti = PhosphorFlatIconData(0xe81a, 'Bold');
+  static const confetti = IconData(0xe81a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![contactless-payment-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/contactless-payment-bold.svg)
-  static const contactlessPayment = PhosphorFlatIconData(0xed42, 'Bold');
+  static const contactlessPayment = IconData(0xed42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![control-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/control-bold.svg)
-  static const control = PhosphorFlatIconData(0xeca6, 'Bold');
+  static const control = IconData(0xeca6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cookie-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cookie-bold.svg)
-  static const cookie = PhosphorFlatIconData(0xe6ca, 'Bold');
+  static const cookie = IconData(0xe6ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cooking-pot-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cooking-pot-bold.svg)
-  static const cookingPot = PhosphorFlatIconData(0xe764, 'Bold');
+  static const cookingPot = IconData(0xe764,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/copy-bold.svg)
-  static const copy = PhosphorFlatIconData(0xe1ca, 'Bold');
+  static const copy = IconData(0xe1ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/copy-simple-bold.svg)
-  static const copySimple = PhosphorFlatIconData(0xe1cc, 'Bold');
+  static const copySimple = IconData(0xe1cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyleft-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/copyleft-bold.svg)
-  static const copyleft = PhosphorFlatIconData(0xe86a, 'Bold');
+  static const copyleft = IconData(0xe86a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyright-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/copyright-bold.svg)
-  static const copyright = PhosphorFlatIconData(0xe54a, 'Bold');
+  static const copyright = IconData(0xe54a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-in-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/corners-in-bold.svg)
-  static const cornersIn = PhosphorFlatIconData(0xe1ce, 'Bold');
+  static const cornersIn = IconData(0xe1ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-out-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/corners-out-bold.svg)
-  static const cornersOut = PhosphorFlatIconData(0xe1d0, 'Bold');
+  static const cornersOut = IconData(0xe1d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![couch-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/couch-bold.svg)
-  static const couch = PhosphorFlatIconData(0xe7f6, 'Bold');
+  static const couch = IconData(0xe7f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![court-basketball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/court-basketball-bold.svg)
-  static const courtBasketball = PhosphorFlatIconData(0xee36, 'Bold');
+  static const courtBasketball = IconData(0xee36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cow-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cow-bold.svg)
-  static const cow = PhosphorFlatIconData(0xeabe, 'Bold');
+  static const cow = IconData(0xeabe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cowboy-hat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cowboy-hat-bold.svg)
-  static const cowboyHat = PhosphorFlatIconData(0xed12, 'Bold');
+  static const cowboyHat = IconData(0xed12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cpu-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cpu-bold.svg)
-  static const cpu = PhosphorFlatIconData(0xe610, 'Bold');
+  static const cpu = IconData(0xe610,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/crane-bold.svg)
-  static const crane = PhosphorFlatIconData(0xed48, 'Bold');
+  static const crane = IconData(0xed48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-tower-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/crane-tower-bold.svg)
-  static const craneTower = PhosphorFlatIconData(0xed49, 'Bold');
+  static const craneTower = IconData(0xed49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![credit-card-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/credit-card-bold.svg)
-  static const creditCard = PhosphorFlatIconData(0xe1d2, 'Bold');
+  static const creditCard = IconData(0xe1d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cricket-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cricket-bold.svg)
-  static const cricket = PhosphorFlatIconData(0xee12, 'Bold');
+  static const cricket = IconData(0xee12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crop-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/crop-bold.svg)
-  static const crop = PhosphorFlatIconData(0xe1d4, 'Bold');
+  static const crop = IconData(0xe1d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cross-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cross-bold.svg)
-  static const cross = PhosphorFlatIconData(0xe8a0, 'Bold');
+  static const cross = IconData(0xe8a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/crosshair-bold.svg)
-  static const crosshair = PhosphorFlatIconData(0xe1d6, 'Bold');
+  static const crosshair = IconData(0xe1d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/crosshair-simple-bold.svg)
-  static const crosshairSimple = PhosphorFlatIconData(0xe1d8, 'Bold');
+  static const crosshairSimple = IconData(0xe1d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/crown-bold.svg)
-  static const crown = PhosphorFlatIconData(0xe614, 'Bold');
+  static const crown = IconData(0xe614,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-cross-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/crown-cross-bold.svg)
-  static const crownCross = PhosphorFlatIconData(0xee5e, 'Bold');
+  static const crownCross = IconData(0xee5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/crown-simple-bold.svg)
-  static const crownSimple = PhosphorFlatIconData(0xe616, 'Bold');
+  static const crownSimple = IconData(0xe616,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cube-bold.svg)
-  static const cube = PhosphorFlatIconData(0xe1da, 'Bold');
+  static const cube = IconData(0xe1da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-focus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cube-focus-bold.svg)
-  static const cubeFocus = PhosphorFlatIconData(0xed0a, 'Bold');
+  static const cubeFocus = IconData(0xed0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-transparent-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cube-transparent-bold.svg)
-  static const cubeTransparent = PhosphorFlatIconData(0xec7c, 'Bold');
+  static const cubeTransparent = IconData(0xec7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-btc-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-btc-bold.svg)
-  static const currencyBtc = PhosphorFlatIconData(0xe618, 'Bold');
+  static const currencyBtc = IconData(0xe618,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-circle-dollar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-circle-dollar-bold.svg)
-  static const currencyCircleDollar = PhosphorFlatIconData(0xe54c, 'Bold');
+  static const currencyCircleDollar = IconData(0xe54c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-cny-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-cny-bold.svg)
-  static const currencyCny = PhosphorFlatIconData(0xe54e, 'Bold');
+  static const currencyCny = IconData(0xe54e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-dollar-bold.svg)
-  static const currencyDollar = PhosphorFlatIconData(0xe550, 'Bold');
+  static const currencyDollar = IconData(0xe550,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-dollar-simple-bold.svg)
-  static const currencyDollarSimple = PhosphorFlatIconData(0xe552, 'Bold');
+  static const currencyDollarSimple = IconData(0xe552,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eth-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-eth-bold.svg)
-  static const currencyEth = PhosphorFlatIconData(0xeada, 'Bold');
+  static const currencyEth = IconData(0xeada,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eur-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-eur-bold.svg)
-  static const currencyEur = PhosphorFlatIconData(0xe554, 'Bold');
+  static const currencyEur = IconData(0xe554,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-gbp-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-gbp-bold.svg)
-  static const currencyGbp = PhosphorFlatIconData(0xe556, 'Bold');
+  static const currencyGbp = IconData(0xe556,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-inr-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-inr-bold.svg)
-  static const currencyInr = PhosphorFlatIconData(0xe558, 'Bold');
+  static const currencyInr = IconData(0xe558,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-jpy-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-jpy-bold.svg)
-  static const currencyJpy = PhosphorFlatIconData(0xe55a, 'Bold');
+  static const currencyJpy = IconData(0xe55a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-krw-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-krw-bold.svg)
-  static const currencyKrw = PhosphorFlatIconData(0xe55c, 'Bold');
+  static const currencyKrw = IconData(0xe55c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-kzt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-kzt-bold.svg)
-  static const currencyKzt = PhosphorFlatIconData(0xec4c, 'Bold');
+  static const currencyKzt = IconData(0xec4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-ngn-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-ngn-bold.svg)
-  static const currencyNgn = PhosphorFlatIconData(0xeb52, 'Bold');
+  static const currencyNgn = IconData(0xeb52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-rub-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/currency-rub-bold.svg)
-  static const currencyRub = PhosphorFlatIconData(0xe55e, 'Bold');
+  static const currencyRub = IconData(0xe55e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cursor-bold.svg)
-  static const cursor = PhosphorFlatIconData(0xe1dc, 'Bold');
+  static const cursor = IconData(0xe1dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-click-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cursor-click-bold.svg)
-  static const cursorClick = PhosphorFlatIconData(0xe7c8, 'Bold');
+  static const cursorClick = IconData(0xe7c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-text-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cursor-text-bold.svg)
-  static const cursorText = PhosphorFlatIconData(0xe7d8, 'Bold');
+  static const cursorText = IconData(0xe7d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cylinder-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/cylinder-bold.svg)
-  static const cylinder = PhosphorFlatIconData(0xe8fc, 'Bold');
+  static const cylinder = IconData(0xe8fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![database-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/database-bold.svg)
-  static const database = PhosphorFlatIconData(0xe1de, 'Bold');
+  static const database = IconData(0xe1de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desk-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/desk-bold.svg)
-  static const desk = PhosphorFlatIconData(0xed16, 'Bold');
+  static const desk = IconData(0xed16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/desktop-bold.svg)
-  static const desktop = PhosphorFlatIconData(0xe560, 'Bold');
+  static const desktop = IconData(0xe560,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-tower-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/desktop-tower-bold.svg)
-  static const desktopTower = PhosphorFlatIconData(0xe562, 'Bold');
+  static const desktopTower = IconData(0xe562,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![detective-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/detective-bold.svg)
-  static const detective = PhosphorFlatIconData(0xe83e, 'Bold');
+  static const detective = IconData(0xe83e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dev-to-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dev-to-logo-bold.svg)
-  static const devToLogo = PhosphorFlatIconData(0xed0e, 'Bold');
+  static const devToLogo = IconData(0xed0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/device-mobile-bold.svg)
-  static const deviceMobile = PhosphorFlatIconData(0xe1e0, 'Bold');
+  static const deviceMobile = IconData(0xe1e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-camera-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/device-mobile-camera-bold.svg)
-  static const deviceMobileCamera = PhosphorFlatIconData(0xe1e2, 'Bold');
+  static const deviceMobileCamera = IconData(0xe1e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/device-mobile-slash-bold.svg)
-  static const deviceMobileSlash = PhosphorFlatIconData(0xee46, 'Bold');
+  static const deviceMobileSlash = IconData(0xee46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-speaker-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/device-mobile-speaker-bold.svg)
-  static const deviceMobileSpeaker = PhosphorFlatIconData(0xe1e4, 'Bold');
+  static const deviceMobileSpeaker = IconData(0xe1e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-rotate-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/device-rotate-bold.svg)
-  static const deviceRotate = PhosphorFlatIconData(0xedf2, 'Bold');
+  static const deviceRotate = IconData(0xedf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/device-tablet-bold.svg)
-  static const deviceTablet = PhosphorFlatIconData(0xe1e6, 'Bold');
+  static const deviceTablet = IconData(0xe1e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-camera-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/device-tablet-camera-bold.svg)
-  static const deviceTabletCamera = PhosphorFlatIconData(0xe1e8, 'Bold');
+  static const deviceTabletCamera = IconData(0xe1e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-speaker-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/device-tablet-speaker-bold.svg)
-  static const deviceTabletSpeaker = PhosphorFlatIconData(0xe1ea, 'Bold');
+  static const deviceTabletSpeaker = IconData(0xe1ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![devices-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/devices-bold.svg)
-  static const devices = PhosphorFlatIconData(0xeba4, 'Bold');
+  static const devices = IconData(0xeba4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamond-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/diamond-bold.svg)
-  static const diamond = PhosphorFlatIconData(0xe1ec, 'Bold');
+  static const diamond = IconData(0xe1ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamonds-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/diamonds-four-bold.svg)
-  static const diamondsFour = PhosphorFlatIconData(0xe8f4, 'Bold');
+  static const diamondsFour = IconData(0xe8f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-five-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dice-five-bold.svg)
-  static const diceFive = PhosphorFlatIconData(0xe1ee, 'Bold');
+  static const diceFive = IconData(0xe1ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dice-four-bold.svg)
-  static const diceFour = PhosphorFlatIconData(0xe1f0, 'Bold');
+  static const diceFour = IconData(0xe1f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-one-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dice-one-bold.svg)
-  static const diceOne = PhosphorFlatIconData(0xe1f2, 'Bold');
+  static const diceOne = IconData(0xe1f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-six-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dice-six-bold.svg)
-  static const diceSix = PhosphorFlatIconData(0xe1f4, 'Bold');
+  static const diceSix = IconData(0xe1f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dice-three-bold.svg)
-  static const diceThree = PhosphorFlatIconData(0xe1f6, 'Bold');
+  static const diceThree = IconData(0xe1f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-two-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dice-two-bold.svg)
-  static const diceTwo = PhosphorFlatIconData(0xe1f8, 'Bold');
+  static const diceTwo = IconData(0xe1f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disc-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/disc-bold.svg)
-  static const disc = PhosphorFlatIconData(0xe564, 'Bold');
+  static const disc = IconData(0xe564,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disco-ball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/disco-ball-bold.svg)
-  static const discoBall = PhosphorFlatIconData(0xed98, 'Bold');
+  static const discoBall = IconData(0xed98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![discord-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/discord-logo-bold.svg)
-  static const discordLogo = PhosphorFlatIconData(0xe61a, 'Bold');
+  static const discordLogo = IconData(0xe61a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![divide-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/divide-bold.svg)
-  static const divide = PhosphorFlatIconData(0xe1fa, 'Bold');
+  static const divide = IconData(0xe1fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dna-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dna-bold.svg)
-  static const dna = PhosphorFlatIconData(0xe924, 'Bold');
+  static const dna = IconData(0xe924,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dog-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dog-bold.svg)
-  static const dog = PhosphorFlatIconData(0xe74a, 'Bold');
+  static const dog = IconData(0xe74a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/door-bold.svg)
-  static const door = PhosphorFlatIconData(0xe61c, 'Bold');
+  static const door = IconData(0xe61c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/door-open-bold.svg)
-  static const doorOpen = PhosphorFlatIconData(0xe7e6, 'Bold');
+  static const doorOpen = IconData(0xe7e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dot-bold.svg)
-  static const dot = PhosphorFlatIconData(0xecde, 'Bold');
+  static const dot = IconData(0xecde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-outline-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dot-outline-bold.svg)
-  static const dotOutline = PhosphorFlatIconData(0xece0, 'Bold');
+  static const dotOutline = IconData(0xece0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-nine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-nine-bold.svg)
-  static const dotsNine = PhosphorFlatIconData(0xe1fc, 'Bold');
+  static const dotsNine = IconData(0xe1fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-six-bold.svg)
-  static const dotsSix = PhosphorFlatIconData(0xe794, 'Bold');
+  static const dotsSix = IconData(0xe794,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-six-vertical-bold.svg)
-  static const dotsSixVertical = PhosphorFlatIconData(0xeae2, 'Bold');
+  static const dotsSixVertical = IconData(0xeae2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-three-bold.svg)
-  static const dotsThree = PhosphorFlatIconData(0xe1fe, 'Bold');
+  static const dotsThree = IconData(0xe1fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-three-circle-bold.svg)
-  static const dotsThreeCircle = PhosphorFlatIconData(0xe200, 'Bold');
+  static const dotsThreeCircle = IconData(0xe200,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-three-circle-vertical-bold.svg)
-  static const dotsThreeCircleVertical = PhosphorFlatIconData(0xe202, 'Bold');
+  static const dotsThreeCircleVertical = IconData(0xe202,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-three-outline-bold.svg)
-  static const dotsThreeOutline = PhosphorFlatIconData(0xe204, 'Bold');
+  static const dotsThreeOutline = IconData(0xe204,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-three-outline-vertical-bold.svg)
-  static const dotsThreeOutlineVertical = PhosphorFlatIconData(0xe206, 'Bold');
+  static const dotsThreeOutlineVertical = IconData(0xe206,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dots-three-vertical-bold.svg)
-  static const dotsThreeVertical = PhosphorFlatIconData(0xe208, 'Bold');
+  static const dotsThreeVertical = IconData(0xe208,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/download-bold.svg)
-  static const download = PhosphorFlatIconData(0xe20a, 'Bold');
+  static const download = IconData(0xe20a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/download-simple-bold.svg)
-  static const downloadSimple = PhosphorFlatIconData(0xe20c, 'Bold');
+  static const downloadSimple = IconData(0xe20c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dress-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dress-bold.svg)
-  static const dress = PhosphorFlatIconData(0xea7e, 'Bold');
+  static const dress = IconData(0xea7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dresser-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dresser-bold.svg)
-  static const dresser = PhosphorFlatIconData(0xe94e, 'Bold');
+  static const dresser = IconData(0xe94e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dribbble-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dribbble-logo-bold.svg)
-  static const dribbbleLogo = PhosphorFlatIconData(0xe20e, 'Bold');
+  static const dribbbleLogo = IconData(0xe20e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drone-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/drone-bold.svg)
-  static const drone = PhosphorFlatIconData(0xed74, 'Bold');
+  static const drone = IconData(0xed74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/drop-bold.svg)
-  static const drop = PhosphorFlatIconData(0xe210, 'Bold');
+  static const drop = IconData(0xe210,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/drop-half-bold.svg)
-  static const dropHalf = PhosphorFlatIconData(0xe566, 'Bold');
+  static const dropHalf = IconData(0xe566,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-bottom-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/drop-half-bottom-bold.svg)
-  static const dropHalfBottom = PhosphorFlatIconData(0xeb40, 'Bold');
+  static const dropHalfBottom = IconData(0xeb40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/drop-simple-bold.svg)
-  static const dropSimple = PhosphorFlatIconData(0xee32, 'Bold');
+  static const dropSimple = IconData(0xee32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/drop-slash-bold.svg)
-  static const dropSlash = PhosphorFlatIconData(0xe954, 'Bold');
+  static const dropSlash = IconData(0xe954,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dropbox-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/dropbox-logo-bold.svg)
-  static const dropboxLogo = PhosphorFlatIconData(0xe7d0, 'Bold');
+  static const dropboxLogo = IconData(0xe7d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ear-bold.svg)
-  static const ear = PhosphorFlatIconData(0xe70c, 'Bold');
+  static const ear = IconData(0xe70c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ear-slash-bold.svg)
-  static const earSlash = PhosphorFlatIconData(0xe70e, 'Bold');
+  static const earSlash = IconData(0xe70e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/egg-bold.svg)
-  static const egg = PhosphorFlatIconData(0xe812, 'Bold');
+  static const egg = IconData(0xe812,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-crack-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/egg-crack-bold.svg)
-  static const eggCrack = PhosphorFlatIconData(0xeb64, 'Bold');
+  static const eggCrack = IconData(0xeb64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eject-bold.svg)
-  static const eject = PhosphorFlatIconData(0xe212, 'Bold');
+  static const eject = IconData(0xe212,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eject-simple-bold.svg)
-  static const ejectSimple = PhosphorFlatIconData(0xe6ae, 'Bold');
+  static const ejectSimple = IconData(0xe6ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![elevator-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/elevator-bold.svg)
-  static const elevator = PhosphorFlatIconData(0xecc0, 'Bold');
+  static const elevator = IconData(0xecc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![empty-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/empty-bold.svg)
-  static const empty = PhosphorFlatIconData(0xedbc, 'Bold');
+  static const empty = IconData(0xedbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![engine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/engine-bold.svg)
-  static const engine = PhosphorFlatIconData(0xea80, 'Bold');
+  static const engine = IconData(0xea80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/envelope-bold.svg)
-  static const envelope = PhosphorFlatIconData(0xe214, 'Bold');
+  static const envelope = IconData(0xe214,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/envelope-open-bold.svg)
-  static const envelopeOpen = PhosphorFlatIconData(0xe216, 'Bold');
+  static const envelopeOpen = IconData(0xe216,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/envelope-simple-bold.svg)
-  static const envelopeSimple = PhosphorFlatIconData(0xe218, 'Bold');
+  static const envelopeSimple = IconData(0xe218,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/envelope-simple-open-bold.svg)
-  static const envelopeSimpleOpen = PhosphorFlatIconData(0xe21a, 'Bold');
+  static const envelopeSimpleOpen = IconData(0xe21a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equalizer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/equalizer-bold.svg)
-  static const equalizer = PhosphorFlatIconData(0xebbc, 'Bold');
+  static const equalizer = IconData(0xebbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equals-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/equals-bold.svg)
-  static const equals = PhosphorFlatIconData(0xe21c, 'Bold');
+  static const equals = IconData(0xe21c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eraser-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eraser-bold.svg)
-  static const eraser = PhosphorFlatIconData(0xe21e, 'Bold');
+  static const eraser = IconData(0xe21e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/escalator-down-bold.svg)
-  static const escalatorDown = PhosphorFlatIconData(0xecba, 'Bold');
+  static const escalatorDown = IconData(0xecba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/escalator-up-bold.svg)
-  static const escalatorUp = PhosphorFlatIconData(0xecbc, 'Bold');
+  static const escalatorUp = IconData(0xecbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exam-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/exam-bold.svg)
-  static const exam = PhosphorFlatIconData(0xe742, 'Bold');
+  static const exam = IconData(0xe742,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclamation-mark-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/exclamation-mark-bold.svg)
-  static const exclamationMark = PhosphorFlatIconData(0xee44, 'Bold');
+  static const exclamationMark = IconData(0xee44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/exclude-bold.svg)
-  static const exclude = PhosphorFlatIconData(0xe882, 'Bold');
+  static const exclude = IconData(0xe882,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/exclude-square-bold.svg)
-  static const excludeSquare = PhosphorFlatIconData(0xe880, 'Bold');
+  static const excludeSquare = IconData(0xe880,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![export-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/export-bold.svg)
-  static const export = PhosphorFlatIconData(0xeaf0, 'Bold');
+  static const export = IconData(0xeaf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eye-bold.svg)
-  static const eye = PhosphorFlatIconData(0xe220, 'Bold');
+  static const eye = IconData(0xe220,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-closed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eye-closed-bold.svg)
-  static const eyeClosed = PhosphorFlatIconData(0xe222, 'Bold');
+  static const eyeClosed = IconData(0xe222,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eye-slash-bold.svg)
-  static const eyeSlash = PhosphorFlatIconData(0xe224, 'Bold');
+  static const eyeSlash = IconData(0xe224,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eyedropper-bold.svg)
-  static const eyedropper = PhosphorFlatIconData(0xe568, 'Bold');
+  static const eyedropper = IconData(0xe568,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-sample-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eyedropper-sample-bold.svg)
-  static const eyedropperSample = PhosphorFlatIconData(0xeac4, 'Bold');
+  static const eyedropperSample = IconData(0xeac4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyeglasses-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eyeglasses-bold.svg)
-  static const eyeglasses = PhosphorFlatIconData(0xe7ba, 'Bold');
+  static const eyeglasses = IconData(0xe7ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyes-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/eyes-bold.svg)
-  static const eyes = PhosphorFlatIconData(0xee5c, 'Bold');
+  static const eyes = IconData(0xee5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![face-mask-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/face-mask-bold.svg)
-  static const faceMask = PhosphorFlatIconData(0xe56a, 'Bold');
+  static const faceMask = IconData(0xe56a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![facebook-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/facebook-logo-bold.svg)
-  static const facebookLogo = PhosphorFlatIconData(0xe226, 'Bold');
+  static const facebookLogo = IconData(0xe226,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![factory-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/factory-bold.svg)
-  static const factory = PhosphorFlatIconData(0xe760, 'Bold');
+  static const factory = IconData(0xe760,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/faders-bold.svg)
-  static const faders = PhosphorFlatIconData(0xe228, 'Bold');
+  static const faders = IconData(0xe228,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/faders-horizontal-bold.svg)
-  static const fadersHorizontal = PhosphorFlatIconData(0xe22a, 'Bold');
+  static const fadersHorizontal = IconData(0xe22a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fallout-shelter-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fallout-shelter-bold.svg)
-  static const falloutShelter = PhosphorFlatIconData(0xe9de, 'Bold');
+  static const falloutShelter = IconData(0xe9de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fan-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fan-bold.svg)
-  static const fan = PhosphorFlatIconData(0xe9f2, 'Bold');
+  static const fan = IconData(0xe9f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![farm-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/farm-bold.svg)
-  static const farm = PhosphorFlatIconData(0xec70, 'Bold');
+  static const farm = IconData(0xec70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fast-forward-bold.svg)
-  static const fastForward = PhosphorFlatIconData(0xe6a6, 'Bold');
+  static const fastForward = IconData(0xe6a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fast-forward-circle-bold.svg)
-  static const fastForwardCircle = PhosphorFlatIconData(0xe22c, 'Bold');
+  static const fastForwardCircle = IconData(0xe22c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![feather-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/feather-bold.svg)
-  static const feather = PhosphorFlatIconData(0xe9c0, 'Bold');
+  static const feather = IconData(0xe9c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fediverse-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fediverse-logo-bold.svg)
-  static const fediverseLogo = PhosphorFlatIconData(0xed66, 'Bold');
+  static const fediverseLogo = IconData(0xed66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![figma-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/figma-logo-bold.svg)
-  static const figmaLogo = PhosphorFlatIconData(0xe22e, 'Bold');
+  static const figmaLogo = IconData(0xe22e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-bold.svg)
-  static const file = PhosphorFlatIconData(0xe230, 'Bold');
+  static const file = IconData(0xe230,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-archive-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-archive-bold.svg)
-  static const fileArchive = PhosphorFlatIconData(0xeb2a, 'Bold');
+  static const fileArchive = IconData(0xeb2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-arrow-down-bold.svg)
-  static const fileArrowDown = PhosphorFlatIconData(0xe232, 'Bold');
+  static const fileArrowDown = IconData(0xe232,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-arrow-up-bold.svg)
-  static const fileArrowUp = PhosphorFlatIconData(0xe61e, 'Bold');
+  static const fileArrowUp = IconData(0xe61e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-audio-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-audio-bold.svg)
-  static const fileAudio = PhosphorFlatIconData(0xea20, 'Bold');
+  static const fileAudio = IconData(0xea20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-c-bold.svg)
-  static const fileC = PhosphorFlatIconData(0xeb32, 'Bold');
+  static const fileC = IconData(0xeb32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-sharp-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-c-sharp-bold.svg)
-  static const fileCSharp = PhosphorFlatIconData(0xeb30, 'Bold');
+  static const fileCSharp = IconData(0xeb30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cloud-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-cloud-bold.svg)
-  static const fileCloud = PhosphorFlatIconData(0xe95e, 'Bold');
+  static const fileCloud = IconData(0xe95e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-code-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-code-bold.svg)
-  static const fileCode = PhosphorFlatIconData(0xe914, 'Bold');
+  static const fileCode = IconData(0xe914,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cpp-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-cpp-bold.svg)
-  static const fileCpp = PhosphorFlatIconData(0xeb2e, 'Bold');
+  static const fileCpp = IconData(0xeb2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-css-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-css-bold.svg)
-  static const fileCss = PhosphorFlatIconData(0xeb34, 'Bold');
+  static const fileCss = IconData(0xeb34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-csv-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-csv-bold.svg)
-  static const fileCsv = PhosphorFlatIconData(0xeb1c, 'Bold');
+  static const fileCsv = IconData(0xeb1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-dashed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-dashed-bold.svg)
-  static const fileDashed = PhosphorFlatIconData(0xe704, 'Bold');
+  static const fileDashed = IconData(0xe704,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-doc-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-doc-bold.svg)
-  static const fileDoc = PhosphorFlatIconData(0xeb1e, 'Bold');
+  static const fileDoc = IconData(0xeb1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-html-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-html-bold.svg)
-  static const fileHtml = PhosphorFlatIconData(0xeb38, 'Bold');
+  static const fileHtml = IconData(0xeb38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-image-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-image-bold.svg)
-  static const fileImage = PhosphorFlatIconData(0xea24, 'Bold');
+  static const fileImage = IconData(0xea24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ini-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-ini-bold.svg)
-  static const fileIni = PhosphorFlatIconData(0xeb33, 'Bold');
+  static const fileIni = IconData(0xeb33,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jpg-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-jpg-bold.svg)
-  static const fileJpg = PhosphorFlatIconData(0xeb1a, 'Bold');
+  static const fileJpg = IconData(0xeb1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-js-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-js-bold.svg)
-  static const fileJs = PhosphorFlatIconData(0xeb24, 'Bold');
+  static const fileJs = IconData(0xeb24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jsx-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-jsx-bold.svg)
-  static const fileJsx = PhosphorFlatIconData(0xeb3a, 'Bold');
+  static const fileJsx = IconData(0xeb3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-lock-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-lock-bold.svg)
-  static const fileLock = PhosphorFlatIconData(0xe95c, 'Bold');
+  static const fileLock = IconData(0xe95c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-magnifying-glass-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-magnifying-glass-bold.svg)
-  static const fileMagnifyingGlass = PhosphorFlatIconData(0xe238, 'Bold');
+  static const fileMagnifyingGlass = IconData(0xe238,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-md-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-md-bold.svg)
-  static const fileMd = PhosphorFlatIconData(0xed50, 'Bold');
+  static const fileMd = IconData(0xed50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-minus-bold.svg)
-  static const fileMinus = PhosphorFlatIconData(0xe234, 'Bold');
+  static const fileMinus = IconData(0xe234,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-pdf-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-pdf-bold.svg)
-  static const filePdf = PhosphorFlatIconData(0xe702, 'Bold');
+  static const filePdf = IconData(0xe702,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-plus-bold.svg)
-  static const filePlus = PhosphorFlatIconData(0xe236, 'Bold');
+  static const filePlus = IconData(0xe236,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-png-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-png-bold.svg)
-  static const filePng = PhosphorFlatIconData(0xeb18, 'Bold');
+  static const filePng = IconData(0xeb18,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ppt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-ppt-bold.svg)
-  static const filePpt = PhosphorFlatIconData(0xeb20, 'Bold');
+  static const filePpt = IconData(0xeb20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-py-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-py-bold.svg)
-  static const filePy = PhosphorFlatIconData(0xeb2c, 'Bold');
+  static const filePy = IconData(0xeb2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-rs-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-rs-bold.svg)
-  static const fileRs = PhosphorFlatIconData(0xeb28, 'Bold');
+  static const fileRs = IconData(0xeb28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-sql-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-sql-bold.svg)
-  static const fileSql = PhosphorFlatIconData(0xed4e, 'Bold');
+  static const fileSql = IconData(0xed4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-svg-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-svg-bold.svg)
-  static const fileSvg = PhosphorFlatIconData(0xed08, 'Bold');
+  static const fileSvg = IconData(0xed08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-text-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-text-bold.svg)
-  static const fileText = PhosphorFlatIconData(0xe23a, 'Bold');
+  static const fileText = IconData(0xe23a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ts-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-ts-bold.svg)
-  static const fileTs = PhosphorFlatIconData(0xeb26, 'Bold');
+  static const fileTs = IconData(0xeb26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-tsx-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-tsx-bold.svg)
-  static const fileTsx = PhosphorFlatIconData(0xeb3c, 'Bold');
+  static const fileTsx = IconData(0xeb3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-txt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-txt-bold.svg)
-  static const fileTxt = PhosphorFlatIconData(0xeb35, 'Bold');
+  static const fileTxt = IconData(0xeb35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-video-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-video-bold.svg)
-  static const fileVideo = PhosphorFlatIconData(0xea22, 'Bold');
+  static const fileVideo = IconData(0xea22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-vue-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-vue-bold.svg)
-  static const fileVue = PhosphorFlatIconData(0xeb3e, 'Bold');
+  static const fileVue = IconData(0xeb3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-x-bold.svg)
-  static const fileX = PhosphorFlatIconData(0xe23c, 'Bold');
+  static const fileX = IconData(0xe23c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-xls-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-xls-bold.svg)
-  static const fileXls = PhosphorFlatIconData(0xeb22, 'Bold');
+  static const fileXls = IconData(0xeb22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-zip-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/file-zip-bold.svg)
-  static const fileZip = PhosphorFlatIconData(0xe958, 'Bold');
+  static const fileZip = IconData(0xe958,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![files-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/files-bold.svg)
-  static const files = PhosphorFlatIconData(0xe710, 'Bold');
+  static const files = IconData(0xe710,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-reel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/film-reel-bold.svg)
-  static const filmReel = PhosphorFlatIconData(0xe8c0, 'Bold');
+  static const filmReel = IconData(0xe8c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-script-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/film-script-bold.svg)
-  static const filmScript = PhosphorFlatIconData(0xeb50, 'Bold');
+  static const filmScript = IconData(0xeb50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-slate-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/film-slate-bold.svg)
-  static const filmSlate = PhosphorFlatIconData(0xe8c2, 'Bold');
+  static const filmSlate = IconData(0xe8c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-strip-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/film-strip-bold.svg)
-  static const filmStrip = PhosphorFlatIconData(0xe792, 'Bold');
+  static const filmStrip = IconData(0xe792,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fingerprint-bold.svg)
-  static const fingerprint = PhosphorFlatIconData(0xe23e, 'Bold');
+  static const fingerprint = IconData(0xe23e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fingerprint-simple-bold.svg)
-  static const fingerprintSimple = PhosphorFlatIconData(0xe240, 'Bold');
+  static const fingerprintSimple = IconData(0xe240,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![finn-the-human-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/finn-the-human-bold.svg)
-  static const finnTheHuman = PhosphorFlatIconData(0xe56c, 'Bold');
+  static const finnTheHuman = IconData(0xe56c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fire-bold.svg)
-  static const fire = PhosphorFlatIconData(0xe242, 'Bold');
+  static const fire = IconData(0xe242,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-extinguisher-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fire-extinguisher-bold.svg)
-  static const fireExtinguisher = PhosphorFlatIconData(0xe9e8, 'Bold');
+  static const fireExtinguisher = IconData(0xe9e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fire-simple-bold.svg)
-  static const fireSimple = PhosphorFlatIconData(0xe620, 'Bold');
+  static const fireSimple = IconData(0xe620,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-truck-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fire-truck-bold.svg)
-  static const fireTruck = PhosphorFlatIconData(0xe574, 'Bold');
+  static const fireTruck = IconData(0xe574,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/first-aid-bold.svg)
-  static const firstAid = PhosphorFlatIconData(0xe56e, 'Bold');
+  static const firstAid = IconData(0xe56e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-kit-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/first-aid-kit-bold.svg)
-  static const firstAidKit = PhosphorFlatIconData(0xe570, 'Bold');
+  static const firstAidKit = IconData(0xe570,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fish-bold.svg)
-  static const fish = PhosphorFlatIconData(0xe728, 'Bold');
+  static const fish = IconData(0xe728,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fish-simple-bold.svg)
-  static const fishSimple = PhosphorFlatIconData(0xe72a, 'Bold');
+  static const fishSimple = IconData(0xe72a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flag-bold.svg)
-  static const flag = PhosphorFlatIconData(0xe244, 'Bold');
+  static const flag = IconData(0xe244,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flag-banner-bold.svg)
-  static const flagBanner = PhosphorFlatIconData(0xe622, 'Bold');
+  static const flagBanner = IconData(0xe622,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-fold-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flag-banner-fold-bold.svg)
-  static const flagBannerFold = PhosphorFlatIconData(0xecf2, 'Bold');
+  static const flagBannerFold = IconData(0xecf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-checkered-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flag-checkered-bold.svg)
-  static const flagCheckered = PhosphorFlatIconData(0xea38, 'Bold');
+  static const flagCheckered = IconData(0xea38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-pennant-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flag-pennant-bold.svg)
-  static const flagPennant = PhosphorFlatIconData(0xecf0, 'Bold');
+  static const flagPennant = IconData(0xecf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flame-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flame-bold.svg)
-  static const flame = PhosphorFlatIconData(0xe624, 'Bold');
+  static const flame = IconData(0xe624,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flashlight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flashlight-bold.svg)
-  static const flashlight = PhosphorFlatIconData(0xe246, 'Bold');
+  static const flashlight = IconData(0xe246,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flask-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flask-bold.svg)
-  static const flask = PhosphorFlatIconData(0xe79e, 'Bold');
+  static const flask = IconData(0xe79e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flip-horizontal-bold.svg)
-  static const flipHorizontal = PhosphorFlatIconData(0xed6a, 'Bold');
+  static const flipHorizontal = IconData(0xed6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flip-vertical-bold.svg)
-  static const flipVertical = PhosphorFlatIconData(0xed6c, 'Bold');
+  static const flipVertical = IconData(0xed6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/floppy-disk-bold.svg)
-  static const floppyDisk = PhosphorFlatIconData(0xe248, 'Bold');
+  static const floppyDisk = IconData(0xe248,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-back-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/floppy-disk-back-bold.svg)
-  static const floppyDiskBack = PhosphorFlatIconData(0xeaf4, 'Bold');
+  static const floppyDiskBack = IconData(0xeaf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flow-arrow-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flow-arrow-bold.svg)
-  static const flowArrow = PhosphorFlatIconData(0xe6ec, 'Bold');
+  static const flowArrow = IconData(0xe6ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flower-bold.svg)
-  static const flower = PhosphorFlatIconData(0xe75e, 'Bold');
+  static const flower = IconData(0xe75e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-lotus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flower-lotus-bold.svg)
-  static const flowerLotus = PhosphorFlatIconData(0xe6cc, 'Bold');
+  static const flowerLotus = IconData(0xe6cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-tulip-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flower-tulip-bold.svg)
-  static const flowerTulip = PhosphorFlatIconData(0xeacc, 'Bold');
+  static const flowerTulip = IconData(0xeacc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flying-saucer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/flying-saucer-bold.svg)
-  static const flyingSaucer = PhosphorFlatIconData(0xeb4a, 'Bold');
+  static const flyingSaucer = IconData(0xeb4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-bold.svg)
-  static const folder = PhosphorFlatIconData(0xe24a, 'Bold');
+  static const folder = IconData(0xe24a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-dashed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-dashed-bold.svg)
-  static const folderDashed = PhosphorFlatIconData(0xe8f8, 'Bold');
+  static const folderDashed = IconData(0xe8f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-lock-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-lock-bold.svg)
-  static const folderLock = PhosphorFlatIconData(0xea3c, 'Bold');
+  static const folderLock = IconData(0xea3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-minus-bold.svg)
-  static const folderMinus = PhosphorFlatIconData(0xe254, 'Bold');
+  static const folderMinus = IconData(0xe254,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-open-bold.svg)
-  static const folderOpen = PhosphorFlatIconData(0xe256, 'Bold');
+  static const folderOpen = IconData(0xe256,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-plus-bold.svg)
-  static const folderPlus = PhosphorFlatIconData(0xe258, 'Bold');
+  static const folderPlus = IconData(0xe258,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-simple-bold.svg)
-  static const folderSimple = PhosphorFlatIconData(0xe25a, 'Bold');
+  static const folderSimple = IconData(0xe25a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-dashed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-simple-dashed-bold.svg)
-  static const folderSimpleDashed = PhosphorFlatIconData(0xec2a, 'Bold');
+  static const folderSimpleDashed = IconData(0xec2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-lock-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-simple-lock-bold.svg)
-  static const folderSimpleLock = PhosphorFlatIconData(0xeb5e, 'Bold');
+  static const folderSimpleLock = IconData(0xeb5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-simple-minus-bold.svg)
-  static const folderSimpleMinus = PhosphorFlatIconData(0xe25c, 'Bold');
+  static const folderSimpleMinus = IconData(0xe25c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-simple-plus-bold.svg)
-  static const folderSimplePlus = PhosphorFlatIconData(0xe25e, 'Bold');
+  static const folderSimplePlus = IconData(0xe25e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-star-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-simple-star-bold.svg)
-  static const folderSimpleStar = PhosphorFlatIconData(0xec2e, 'Bold');
+  static const folderSimpleStar = IconData(0xec2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-user-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-simple-user-bold.svg)
-  static const folderSimpleUser = PhosphorFlatIconData(0xeb60, 'Bold');
+  static const folderSimpleUser = IconData(0xeb60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-star-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-star-bold.svg)
-  static const folderStar = PhosphorFlatIconData(0xea86, 'Bold');
+  static const folderStar = IconData(0xea86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-user-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folder-user-bold.svg)
-  static const folderUser = PhosphorFlatIconData(0xeb46, 'Bold');
+  static const folderUser = IconData(0xeb46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folders-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/folders-bold.svg)
-  static const folders = PhosphorFlatIconData(0xe260, 'Bold');
+  static const folders = IconData(0xe260,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/football-bold.svg)
-  static const football = PhosphorFlatIconData(0xe718, 'Bold');
+  static const football = IconData(0xe718,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-helmet-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/football-helmet-bold.svg)
-  static const footballHelmet = PhosphorFlatIconData(0xee4c, 'Bold');
+  static const footballHelmet = IconData(0xee4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![footprints-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/footprints-bold.svg)
-  static const footprints = PhosphorFlatIconData(0xea88, 'Bold');
+  static const footprints = IconData(0xea88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fork-knife-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/fork-knife-bold.svg)
-  static const forkKnife = PhosphorFlatIconData(0xe262, 'Bold');
+  static const forkKnife = IconData(0xe262,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![four-k-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/four-k-bold.svg)
-  static const fourK = PhosphorFlatIconData(0xea5c, 'Bold');
+  static const fourK = IconData(0xea5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![frame-corners-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/frame-corners-bold.svg)
-  static const frameCorners = PhosphorFlatIconData(0xe626, 'Bold');
+  static const frameCorners = IconData(0xe626,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![framer-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/framer-logo-bold.svg)
-  static const framerLogo = PhosphorFlatIconData(0xe264, 'Bold');
+  static const framerLogo = IconData(0xe264,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![function-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/function-bold.svg)
-  static const function = PhosphorFlatIconData(0xebe4, 'Bold');
+  static const function = IconData(0xebe4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/funnel-bold.svg)
-  static const funnel = PhosphorFlatIconData(0xe266, 'Bold');
+  static const funnel = IconData(0xe266,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/funnel-simple-bold.svg)
-  static const funnelSimple = PhosphorFlatIconData(0xe268, 'Bold');
+  static const funnelSimple = IconData(0xe268,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/funnel-simple-x-bold.svg)
-  static const funnelSimpleX = PhosphorFlatIconData(0xe26a, 'Bold');
+  static const funnelSimpleX = IconData(0xe26a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/funnel-x-bold.svg)
-  static const funnelX = PhosphorFlatIconData(0xe26c, 'Bold');
+  static const funnelX = IconData(0xe26c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![game-controller-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/game-controller-bold.svg)
-  static const gameController = PhosphorFlatIconData(0xe26e, 'Bold');
+  static const gameController = IconData(0xe26e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![garage-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/garage-bold.svg)
-  static const garage = PhosphorFlatIconData(0xecd6, 'Bold');
+  static const garage = IconData(0xecd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-can-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gas-can-bold.svg)
-  static const gasCan = PhosphorFlatIconData(0xe8ce, 'Bold');
+  static const gasCan = IconData(0xe8ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-pump-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gas-pump-bold.svg)
-  static const gasPump = PhosphorFlatIconData(0xe768, 'Bold');
+  static const gasPump = IconData(0xe768,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gauge-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gauge-bold.svg)
-  static const gauge = PhosphorFlatIconData(0xe628, 'Bold');
+  static const gauge = IconData(0xe628,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gavel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gavel-bold.svg)
-  static const gavel = PhosphorFlatIconData(0xea32, 'Bold');
+  static const gavel = IconData(0xea32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gear-bold.svg)
-  static const gear = PhosphorFlatIconData(0xe270, 'Bold');
+  static const gear = IconData(0xe270,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-fine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gear-fine-bold.svg)
-  static const gearFine = PhosphorFlatIconData(0xe87c, 'Bold');
+  static const gearFine = IconData(0xe87c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-six-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gear-six-bold.svg)
-  static const gearSix = PhosphorFlatIconData(0xe272, 'Bold');
+  static const gearSix = IconData(0xe272,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-female-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gender-female-bold.svg)
-  static const genderFemale = PhosphorFlatIconData(0xe6e0, 'Bold');
+  static const genderFemale = IconData(0xe6e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-intersex-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gender-intersex-bold.svg)
-  static const genderIntersex = PhosphorFlatIconData(0xe6e6, 'Bold');
+  static const genderIntersex = IconData(0xe6e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-male-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gender-male-bold.svg)
-  static const genderMale = PhosphorFlatIconData(0xe6e2, 'Bold');
+  static const genderMale = IconData(0xe6e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-neuter-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gender-neuter-bold.svg)
-  static const genderNeuter = PhosphorFlatIconData(0xe6ea, 'Bold');
+  static const genderNeuter = IconData(0xe6ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-nonbinary-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gender-nonbinary-bold.svg)
-  static const genderNonbinary = PhosphorFlatIconData(0xe6e4, 'Bold');
+  static const genderNonbinary = IconData(0xe6e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-transgender-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gender-transgender-bold.svg)
-  static const genderTransgender = PhosphorFlatIconData(0xe6e8, 'Bold');
+  static const genderTransgender = IconData(0xe6e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ghost-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ghost-bold.svg)
-  static const ghost = PhosphorFlatIconData(0xe62a, 'Bold');
+  static const ghost = IconData(0xe62a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gif-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gif-bold.svg)
-  static const gif = PhosphorFlatIconData(0xe274, 'Bold');
+  static const gif = IconData(0xe274,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gift-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gift-bold.svg)
-  static const gift = PhosphorFlatIconData(0xe276, 'Bold');
+  static const gift = IconData(0xe276,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-branch-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/git-branch-bold.svg)
-  static const gitBranch = PhosphorFlatIconData(0xe278, 'Bold');
+  static const gitBranch = IconData(0xe278,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-commit-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/git-commit-bold.svg)
-  static const gitCommit = PhosphorFlatIconData(0xe27a, 'Bold');
+  static const gitCommit = IconData(0xe27a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-diff-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/git-diff-bold.svg)
-  static const gitDiff = PhosphorFlatIconData(0xe27c, 'Bold');
+  static const gitDiff = IconData(0xe27c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-fork-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/git-fork-bold.svg)
-  static const gitFork = PhosphorFlatIconData(0xe27e, 'Bold');
+  static const gitFork = IconData(0xe27e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-merge-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/git-merge-bold.svg)
-  static const gitMerge = PhosphorFlatIconData(0xe280, 'Bold');
+  static const gitMerge = IconData(0xe280,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-pull-request-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/git-pull-request-bold.svg)
-  static const gitPullRequest = PhosphorFlatIconData(0xe282, 'Bold');
+  static const gitPullRequest = IconData(0xe282,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![github-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/github-logo-bold.svg)
-  static const githubLogo = PhosphorFlatIconData(0xe576, 'Bold');
+  static const githubLogo = IconData(0xe576,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gitlab-logo-bold.svg)
-  static const gitlabLogo = PhosphorFlatIconData(0xe694, 'Bold');
+  static const gitlabLogo = IconData(0xe694,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gitlab-logo-simple-bold.svg)
-  static const gitlabLogoSimple = PhosphorFlatIconData(0xe696, 'Bold');
+  static const gitlabLogoSimple = IconData(0xe696,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/globe-bold.svg)
-  static const globe = PhosphorFlatIconData(0xe288, 'Bold');
+  static const globe = IconData(0xe288,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-east-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/globe-hemisphere-east-bold.svg)
-  static const globeHemisphereEast = PhosphorFlatIconData(0xe28a, 'Bold');
+  static const globeHemisphereEast = IconData(0xe28a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-west-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/globe-hemisphere-west-bold.svg)
-  static const globeHemisphereWest = PhosphorFlatIconData(0xe28c, 'Bold');
+  static const globeHemisphereWest = IconData(0xe28c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/globe-simple-bold.svg)
-  static const globeSimple = PhosphorFlatIconData(0xe28e, 'Bold');
+  static const globeSimple = IconData(0xe28e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/globe-simple-x-bold.svg)
-  static const globeSimpleX = PhosphorFlatIconData(0xe284, 'Bold');
+  static const globeSimpleX = IconData(0xe284,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-stand-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/globe-stand-bold.svg)
-  static const globeStand = PhosphorFlatIconData(0xe290, 'Bold');
+  static const globeStand = IconData(0xe290,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/globe-x-bold.svg)
-  static const globeX = PhosphorFlatIconData(0xe286, 'Bold');
+  static const globeX = IconData(0xe286,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goggles-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/goggles-bold.svg)
-  static const goggles = PhosphorFlatIconData(0xecb4, 'Bold');
+  static const goggles = IconData(0xecb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![golf-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/golf-bold.svg)
-  static const golf = PhosphorFlatIconData(0xea3e, 'Bold');
+  static const golf = IconData(0xea3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goodreads-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/goodreads-logo-bold.svg)
-  static const goodreadsLogo = PhosphorFlatIconData(0xed10, 'Bold');
+  static const goodreadsLogo = IconData(0xed10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-cardboard-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/google-cardboard-logo-bold.svg)
-  static const googleCardboardLogo = PhosphorFlatIconData(0xe7b6, 'Bold');
+  static const googleCardboardLogo = IconData(0xe7b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-chrome-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/google-chrome-logo-bold.svg)
-  static const googleChromeLogo = PhosphorFlatIconData(0xe976, 'Bold');
+  static const googleChromeLogo = IconData(0xe976,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-drive-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/google-drive-logo-bold.svg)
-  static const googleDriveLogo = PhosphorFlatIconData(0xe8f6, 'Bold');
+  static const googleDriveLogo = IconData(0xe8f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/google-logo-bold.svg)
-  static const googleLogo = PhosphorFlatIconData(0xe292, 'Bold');
+  static const googleLogo = IconData(0xe292,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-photos-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/google-photos-logo-bold.svg)
-  static const googlePhotosLogo = PhosphorFlatIconData(0xeb92, 'Bold');
+  static const googlePhotosLogo = IconData(0xeb92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-play-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/google-play-logo-bold.svg)
-  static const googlePlayLogo = PhosphorFlatIconData(0xe294, 'Bold');
+  static const googlePlayLogo = IconData(0xe294,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-podcasts-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/google-podcasts-logo-bold.svg)
-  static const googlePodcastsLogo = PhosphorFlatIconData(0xeb94, 'Bold');
+  static const googlePodcastsLogo = IconData(0xeb94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gps-bold.svg)
-  static const gps = PhosphorFlatIconData(0xedd8, 'Bold');
+  static const gps = IconData(0xedd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-fix-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gps-fix-bold.svg)
-  static const gpsFix = PhosphorFlatIconData(0xedd6, 'Bold');
+  static const gpsFix = IconData(0xedd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gps-slash-bold.svg)
-  static const gpsSlash = PhosphorFlatIconData(0xedd4, 'Bold');
+  static const gpsSlash = IconData(0xedd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gradient-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/gradient-bold.svg)
-  static const gradient = PhosphorFlatIconData(0xeb42, 'Bold');
+  static const gradient = IconData(0xeb42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graduation-cap-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/graduation-cap-bold.svg)
-  static const graduationCap = PhosphorFlatIconData(0xe62c, 'Bold');
+  static const graduationCap = IconData(0xe62c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/grains-bold.svg)
-  static const grains = PhosphorFlatIconData(0xec68, 'Bold');
+  static const grains = IconData(0xec68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/grains-slash-bold.svg)
-  static const grainsSlash = PhosphorFlatIconData(0xec6a, 'Bold');
+  static const grainsSlash = IconData(0xec6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graph-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/graph-bold.svg)
-  static const graph = PhosphorFlatIconData(0xeb58, 'Bold');
+  static const graph = IconData(0xeb58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graphics-card-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/graphics-card-bold.svg)
-  static const graphicsCard = PhosphorFlatIconData(0xe612, 'Bold');
+  static const graphicsCard = IconData(0xe612,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/greater-than-bold.svg)
-  static const greaterThan = PhosphorFlatIconData(0xedc4, 'Bold');
+  static const greaterThan = IconData(0xedc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-or-equal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/greater-than-or-equal-bold.svg)
-  static const greaterThanOrEqual = PhosphorFlatIconData(0xeda2, 'Bold');
+  static const greaterThanOrEqual = IconData(0xeda2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/grid-four-bold.svg)
-  static const gridFour = PhosphorFlatIconData(0xe296, 'Bold');
+  static const gridFour = IconData(0xe296,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-nine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/grid-nine-bold.svg)
-  static const gridNine = PhosphorFlatIconData(0xec8c, 'Bold');
+  static const gridNine = IconData(0xec8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![guitar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/guitar-bold.svg)
-  static const guitar = PhosphorFlatIconData(0xea8a, 'Bold');
+  static const guitar = IconData(0xea8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hair-dryer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hair-dryer-bold.svg)
-  static const hairDryer = PhosphorFlatIconData(0xea66, 'Bold');
+  static const hairDryer = IconData(0xea66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hamburger-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hamburger-bold.svg)
-  static const hamburger = PhosphorFlatIconData(0xe790, 'Bold');
+  static const hamburger = IconData(0xe790,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hammer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hammer-bold.svg)
-  static const hammer = PhosphorFlatIconData(0xe80e, 'Bold');
+  static const hammer = IconData(0xe80e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-bold.svg)
-  static const hand = PhosphorFlatIconData(0xe298, 'Bold');
+  static const hand = IconData(0xe298,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-arrow-down-bold.svg)
-  static const handArrowDown = PhosphorFlatIconData(0xea4e, 'Bold');
+  static const handArrowDown = IconData(0xea4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-arrow-up-bold.svg)
-  static const handArrowUp = PhosphorFlatIconData(0xee5a, 'Bold');
+  static const handArrowUp = IconData(0xee5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-coins-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-coins-bold.svg)
-  static const handCoins = PhosphorFlatIconData(0xea8c, 'Bold');
+  static const handCoins = IconData(0xea8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-deposit-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-deposit-bold.svg)
-  static const handDeposit = PhosphorFlatIconData(0xee82, 'Bold');
+  static const handDeposit = IconData(0xee82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-eye-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-eye-bold.svg)
-  static const handEye = PhosphorFlatIconData(0xea4c, 'Bold');
+  static const handEye = IconData(0xea4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-fist-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-fist-bold.svg)
-  static const handFist = PhosphorFlatIconData(0xe57a, 'Bold');
+  static const handFist = IconData(0xe57a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-grabbing-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-grabbing-bold.svg)
-  static const handGrabbing = PhosphorFlatIconData(0xe57c, 'Bold');
+  static const handGrabbing = IconData(0xe57c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-heart-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-heart-bold.svg)
-  static const handHeart = PhosphorFlatIconData(0xe810, 'Bold');
+  static const handHeart = IconData(0xe810,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-palm-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-palm-bold.svg)
-  static const handPalm = PhosphorFlatIconData(0xe57e, 'Bold');
+  static const handPalm = IconData(0xe57e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-peace-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-peace-bold.svg)
-  static const handPeace = PhosphorFlatIconData(0xe7cc, 'Bold');
+  static const handPeace = IconData(0xe7cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-pointing-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-pointing-bold.svg)
-  static const handPointing = PhosphorFlatIconData(0xe29a, 'Bold');
+  static const handPointing = IconData(0xe29a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-soap-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-soap-bold.svg)
-  static const handSoap = PhosphorFlatIconData(0xe630, 'Bold');
+  static const handSoap = IconData(0xe630,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-swipe-left-bold.svg)
-  static const handSwipeLeft = PhosphorFlatIconData(0xec94, 'Bold');
+  static const handSwipeLeft = IconData(0xec94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-swipe-right-bold.svg)
-  static const handSwipeRight = PhosphorFlatIconData(0xec92, 'Bold');
+  static const handSwipeRight = IconData(0xec92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-tap-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-tap-bold.svg)
-  static const handTap = PhosphorFlatIconData(0xec90, 'Bold');
+  static const handTap = IconData(0xec90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-waving-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-waving-bold.svg)
-  static const handWaving = PhosphorFlatIconData(0xe580, 'Bold');
+  static const handWaving = IconData(0xe580,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-withdraw-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hand-withdraw-bold.svg)
-  static const handWithdraw = PhosphorFlatIconData(0xee80, 'Bold');
+  static const handWithdraw = IconData(0xee80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/handbag-bold.svg)
-  static const handbag = PhosphorFlatIconData(0xe29c, 'Bold');
+  static const handbag = IconData(0xe29c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/handbag-simple-bold.svg)
-  static const handbagSimple = PhosphorFlatIconData(0xe62e, 'Bold');
+  static const handbagSimple = IconData(0xe62e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-clapping-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hands-clapping-bold.svg)
-  static const handsClapping = PhosphorFlatIconData(0xe6a0, 'Bold');
+  static const handsClapping = IconData(0xe6a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-praying-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hands-praying-bold.svg)
-  static const handsPraying = PhosphorFlatIconData(0xecc8, 'Bold');
+  static const handsPraying = IconData(0xecc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handshake-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/handshake-bold.svg)
-  static const handshake = PhosphorFlatIconData(0xe582, 'Bold');
+  static const handshake = IconData(0xe582,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drive-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hard-drive-bold.svg)
-  static const hardDrive = PhosphorFlatIconData(0xe29e, 'Bold');
+  static const hardDrive = IconData(0xe29e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drives-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hard-drives-bold.svg)
-  static const hardDrives = PhosphorFlatIconData(0xe2a0, 'Bold');
+  static const hardDrives = IconData(0xe2a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-hat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hard-hat-bold.svg)
-  static const hardHat = PhosphorFlatIconData(0xed46, 'Bold');
+  static const hardHat = IconData(0xed46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hash-bold.svg)
-  static const hash = PhosphorFlatIconData(0xe2a2, 'Bold');
+  static const hash = IconData(0xe2a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-straight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hash-straight-bold.svg)
-  static const hashStraight = PhosphorFlatIconData(0xe2a4, 'Bold');
+  static const hashStraight = IconData(0xe2a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![head-circuit-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/head-circuit-bold.svg)
-  static const headCircuit = PhosphorFlatIconData(0xe7d4, 'Bold');
+  static const headCircuit = IconData(0xe7d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headlights-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/headlights-bold.svg)
-  static const headlights = PhosphorFlatIconData(0xe6fe, 'Bold');
+  static const headlights = IconData(0xe6fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headphones-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/headphones-bold.svg)
-  static const headphones = PhosphorFlatIconData(0xe2a6, 'Bold');
+  static const headphones = IconData(0xe2a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headset-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/headset-bold.svg)
-  static const headset = PhosphorFlatIconData(0xe584, 'Bold');
+  static const headset = IconData(0xe584,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/heart-bold.svg)
-  static const heart = PhosphorFlatIconData(0xe2a8, 'Bold');
+  static const heart = IconData(0xe2a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-break-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/heart-break-bold.svg)
-  static const heartBreak = PhosphorFlatIconData(0xebe8, 'Bold');
+  static const heartBreak = IconData(0xebe8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-half-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/heart-half-bold.svg)
-  static const heartHalf = PhosphorFlatIconData(0xec48, 'Bold');
+  static const heartHalf = IconData(0xec48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/heart-straight-bold.svg)
-  static const heartStraight = PhosphorFlatIconData(0xe2aa, 'Bold');
+  static const heartStraight = IconData(0xe2aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-break-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/heart-straight-break-bold.svg)
-  static const heartStraightBreak = PhosphorFlatIconData(0xeb98, 'Bold');
+  static const heartStraightBreak = IconData(0xeb98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heartbeat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/heartbeat-bold.svg)
-  static const heartbeat = PhosphorFlatIconData(0xe2ac, 'Bold');
+  static const heartbeat = IconData(0xe2ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hexagon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hexagon-bold.svg)
-  static const hexagon = PhosphorFlatIconData(0xe2ae, 'Bold');
+  static const hexagon = IconData(0xe2ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-definition-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/high-definition-bold.svg)
-  static const highDefinition = PhosphorFlatIconData(0xea8e, 'Bold');
+  static const highDefinition = IconData(0xea8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-heel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/high-heel-bold.svg)
-  static const highHeel = PhosphorFlatIconData(0xe8e8, 'Bold');
+  static const highHeel = IconData(0xe8e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/highlighter-bold.svg)
-  static const highlighter = PhosphorFlatIconData(0xec76, 'Bold');
+  static const highlighter = IconData(0xec76,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/highlighter-circle-bold.svg)
-  static const highlighterCircle = PhosphorFlatIconData(0xe632, 'Bold');
+  static const highlighterCircle = IconData(0xe632,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hockey-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hockey-bold.svg)
-  static const hockey = PhosphorFlatIconData(0xec86, 'Bold');
+  static const hockey = IconData(0xec86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hoodie-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hoodie-bold.svg)
-  static const hoodie = PhosphorFlatIconData(0xecd0, 'Bold');
+  static const hoodie = IconData(0xecd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![horse-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/horse-bold.svg)
-  static const horse = PhosphorFlatIconData(0xe2b0, 'Bold');
+  static const horse = IconData(0xe2b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hospital-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hospital-bold.svg)
-  static const hospital = PhosphorFlatIconData(0xe844, 'Bold');
+  static const hospital = IconData(0xe844,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hourglass-bold.svg)
-  static const hourglass = PhosphorFlatIconData(0xe2b2, 'Bold');
+  static const hourglass = IconData(0xe2b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-high-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hourglass-high-bold.svg)
-  static const hourglassHigh = PhosphorFlatIconData(0xe2b4, 'Bold');
+  static const hourglassHigh = IconData(0xe2b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-low-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hourglass-low-bold.svg)
-  static const hourglassLow = PhosphorFlatIconData(0xe2b6, 'Bold');
+  static const hourglassLow = IconData(0xe2b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-medium-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hourglass-medium-bold.svg)
-  static const hourglassMedium = PhosphorFlatIconData(0xe2b8, 'Bold');
+  static const hourglassMedium = IconData(0xe2b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hourglass-simple-bold.svg)
-  static const hourglassSimple = PhosphorFlatIconData(0xe2ba, 'Bold');
+  static const hourglassSimple = IconData(0xe2ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-high-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hourglass-simple-high-bold.svg)
-  static const hourglassSimpleHigh = PhosphorFlatIconData(0xe2bc, 'Bold');
+  static const hourglassSimpleHigh = IconData(0xe2bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-low-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hourglass-simple-low-bold.svg)
-  static const hourglassSimpleLow = PhosphorFlatIconData(0xe2be, 'Bold');
+  static const hourglassSimpleLow = IconData(0xe2be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-medium-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hourglass-simple-medium-bold.svg)
-  static const hourglassSimpleMedium = PhosphorFlatIconData(0xe2c0, 'Bold');
+  static const hourglassSimpleMedium = IconData(0xe2c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/house-bold.svg)
-  static const house = PhosphorFlatIconData(0xe2c2, 'Bold');
+  static const house = IconData(0xe2c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-line-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/house-line-bold.svg)
-  static const houseLine = PhosphorFlatIconData(0xe2c4, 'Bold');
+  static const houseLine = IconData(0xe2c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/house-simple-bold.svg)
-  static const houseSimple = PhosphorFlatIconData(0xe2c6, 'Bold');
+  static const houseSimple = IconData(0xe2c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hurricane-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/hurricane-bold.svg)
-  static const hurricane = PhosphorFlatIconData(0xe88e, 'Bold');
+  static const hurricane = IconData(0xe88e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ice-cream-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ice-cream-bold.svg)
-  static const iceCream = PhosphorFlatIconData(0xe804, 'Bold');
+  static const iceCream = IconData(0xe804,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-badge-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/identification-badge-bold.svg)
-  static const identificationBadge = PhosphorFlatIconData(0xe6f6, 'Bold');
+  static const identificationBadge = IconData(0xe6f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-card-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/identification-card-bold.svg)
-  static const identificationCard = PhosphorFlatIconData(0xe2c8, 'Bold');
+  static const identificationCard = IconData(0xe2c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/image-bold.svg)
-  static const image = PhosphorFlatIconData(0xe2ca, 'Bold');
+  static const image = IconData(0xe2ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-broken-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/image-broken-bold.svg)
-  static const imageBroken = PhosphorFlatIconData(0xe7a8, 'Bold');
+  static const imageBroken = IconData(0xe7a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/image-square-bold.svg)
-  static const imageSquare = PhosphorFlatIconData(0xe2cc, 'Bold');
+  static const imageSquare = IconData(0xe2cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/images-bold.svg)
-  static const images = PhosphorFlatIconData(0xe836, 'Bold');
+  static const images = IconData(0xe836,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/images-square-bold.svg)
-  static const imagesSquare = PhosphorFlatIconData(0xe834, 'Bold');
+  static const imagesSquare = IconData(0xe834,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![infinity-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/infinity-bold.svg)
-  static const infinity = PhosphorFlatIconData(0xe634, 'Bold');
+  static const infinity = IconData(0xe634,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![info-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/info-bold.svg)
-  static const info = PhosphorFlatIconData(0xe2ce, 'Bold');
+  static const info = IconData(0xe2ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![instagram-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/instagram-logo-bold.svg)
-  static const instagramLogo = PhosphorFlatIconData(0xe2d0, 'Bold');
+  static const instagramLogo = IconData(0xe2d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/intersect-bold.svg)
-  static const intersect = PhosphorFlatIconData(0xe2d2, 'Bold');
+  static const intersect = IconData(0xe2d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/intersect-square-bold.svg)
-  static const intersectSquare = PhosphorFlatIconData(0xe87a, 'Bold');
+  static const intersectSquare = IconData(0xe87a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/intersect-three-bold.svg)
-  static const intersectThree = PhosphorFlatIconData(0xecc4, 'Bold');
+  static const intersectThree = IconData(0xecc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersection-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/intersection-bold.svg)
-  static const intersection = PhosphorFlatIconData(0xedba, 'Bold');
+  static const intersection = IconData(0xedba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![invoice-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/invoice-bold.svg)
-  static const invoice = PhosphorFlatIconData(0xee42, 'Bold');
+  static const invoice = IconData(0xee42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![island-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/island-bold.svg)
-  static const island = PhosphorFlatIconData(0xee06, 'Bold');
+  static const island = IconData(0xee06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/jar-bold.svg)
-  static const jar = PhosphorFlatIconData(0xe7e0, 'Bold');
+  static const jar = IconData(0xe7e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-label-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/jar-label-bold.svg)
-  static const jarLabel = PhosphorFlatIconData(0xe7e1, 'Bold');
+  static const jarLabel = IconData(0xe7e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jeep-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/jeep-bold.svg)
-  static const jeep = PhosphorFlatIconData(0xe2d4, 'Bold');
+  static const jeep = IconData(0xe2d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![joystick-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/joystick-bold.svg)
-  static const joystick = PhosphorFlatIconData(0xea5e, 'Bold');
+  static const joystick = IconData(0xea5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![kanban-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/kanban-bold.svg)
-  static const kanban = PhosphorFlatIconData(0xeb54, 'Bold');
+  static const kanban = IconData(0xeb54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/key-bold.svg)
-  static const key = PhosphorFlatIconData(0xe2d6, 'Bold');
+  static const key = IconData(0xe2d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-return-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/key-return-bold.svg)
-  static const keyReturn = PhosphorFlatIconData(0xe782, 'Bold');
+  static const keyReturn = IconData(0xe782,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyboard-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/keyboard-bold.svg)
-  static const keyboard = PhosphorFlatIconData(0xe2d8, 'Bold');
+  static const keyboard = IconData(0xe2d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyhole-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/keyhole-bold.svg)
-  static const keyhole = PhosphorFlatIconData(0xea78, 'Bold');
+  static const keyhole = IconData(0xea78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![knife-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/knife-bold.svg)
-  static const knife = PhosphorFlatIconData(0xe636, 'Bold');
+  static const knife = IconData(0xe636,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ladder-bold.svg)
-  static const ladder = PhosphorFlatIconData(0xe9e4, 'Bold');
+  static const ladder = IconData(0xe9e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ladder-simple-bold.svg)
-  static const ladderSimple = PhosphorFlatIconData(0xec26, 'Bold');
+  static const ladderSimple = IconData(0xec26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lamp-bold.svg)
-  static const lamp = PhosphorFlatIconData(0xe638, 'Bold');
+  static const lamp = IconData(0xe638,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-pendant-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lamp-pendant-bold.svg)
-  static const lampPendant = PhosphorFlatIconData(0xee2e, 'Bold');
+  static const lampPendant = IconData(0xee2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![laptop-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/laptop-bold.svg)
-  static const laptop = PhosphorFlatIconData(0xe586, 'Bold');
+  static const laptop = IconData(0xe586,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lasso-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lasso-bold.svg)
-  static const lasso = PhosphorFlatIconData(0xedc6, 'Bold');
+  static const lasso = IconData(0xedc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lastfm-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lastfm-logo-bold.svg)
-  static const lastfmLogo = PhosphorFlatIconData(0xe842, 'Bold');
+  static const lastfmLogo = IconData(0xe842,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![layout-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/layout-bold.svg)
-  static const layout = PhosphorFlatIconData(0xe6d6, 'Bold');
+  static const layout = IconData(0xe6d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![leaf-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/leaf-bold.svg)
-  static const leaf = PhosphorFlatIconData(0xe2da, 'Bold');
+  static const leaf = IconData(0xe2da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lectern-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lectern-bold.svg)
-  static const lectern = PhosphorFlatIconData(0xe95a, 'Bold');
+  static const lectern = IconData(0xe95a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lego-bold.svg)
-  static const lego = PhosphorFlatIconData(0xe8c6, 'Bold');
+  static const lego = IconData(0xe8c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-smiley-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lego-smiley-bold.svg)
-  static const legoSmiley = PhosphorFlatIconData(0xe8c7, 'Bold');
+  static const legoSmiley = IconData(0xe8c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/less-than-bold.svg)
-  static const lessThan = PhosphorFlatIconData(0xedac, 'Bold');
+  static const lessThan = IconData(0xedac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-or-equal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/less-than-or-equal-bold.svg)
-  static const lessThanOrEqual = PhosphorFlatIconData(0xeda4, 'Bold');
+  static const lessThanOrEqual = IconData(0xeda4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-h-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/letter-circle-h-bold.svg)
-  static const letterCircleH = PhosphorFlatIconData(0xebf8, 'Bold');
+  static const letterCircleH = IconData(0xebf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-p-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/letter-circle-p-bold.svg)
-  static const letterCircleP = PhosphorFlatIconData(0xec08, 'Bold');
+  static const letterCircleP = IconData(0xec08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-v-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/letter-circle-v-bold.svg)
-  static const letterCircleV = PhosphorFlatIconData(0xec14, 'Bold');
+  static const letterCircleV = IconData(0xec14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lifebuoy-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lifebuoy-bold.svg)
-  static const lifebuoy = PhosphorFlatIconData(0xe63a, 'Bold');
+  static const lifebuoy = IconData(0xe63a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lightbulb-bold.svg)
-  static const lightbulb = PhosphorFlatIconData(0xe2dc, 'Bold');
+  static const lightbulb = IconData(0xe2dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-filament-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lightbulb-filament-bold.svg)
-  static const lightbulbFilament = PhosphorFlatIconData(0xe63c, 'Bold');
+  static const lightbulbFilament = IconData(0xe63c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lighthouse-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lighthouse-bold.svg)
-  static const lighthouse = PhosphorFlatIconData(0xe9f6, 'Bold');
+  static const lighthouse = IconData(0xe9f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lightning-bold.svg)
-  static const lightning = PhosphorFlatIconData(0xe2de, 'Bold');
+  static const lightning = IconData(0xe2de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-a-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lightning-a-bold.svg)
-  static const lightningA = PhosphorFlatIconData(0xea84, 'Bold');
+  static const lightningA = IconData(0xea84,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lightning-slash-bold.svg)
-  static const lightningSlash = PhosphorFlatIconData(0xe2e0, 'Bold');
+  static const lightningSlash = IconData(0xe2e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segment-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/line-segment-bold.svg)
-  static const lineSegment = PhosphorFlatIconData(0xe6d2, 'Bold');
+  static const lineSegment = IconData(0xe6d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segments-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/line-segments-bold.svg)
-  static const lineSegments = PhosphorFlatIconData(0xe6d4, 'Bold');
+  static const lineSegments = IconData(0xe6d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/line-vertical-bold.svg)
-  static const lineVertical = PhosphorFlatIconData(0xed70, 'Bold');
+  static const lineVertical = IconData(0xed70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/link-bold.svg)
-  static const link = PhosphorFlatIconData(0xe2e2, 'Bold');
+  static const link = IconData(0xe2e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-break-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/link-break-bold.svg)
-  static const linkBreak = PhosphorFlatIconData(0xe2e4, 'Bold');
+  static const linkBreak = IconData(0xe2e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/link-simple-bold.svg)
-  static const linkSimple = PhosphorFlatIconData(0xe2e6, 'Bold');
+  static const linkSimple = IconData(0xe2e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-break-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/link-simple-break-bold.svg)
-  static const linkSimpleBreak = PhosphorFlatIconData(0xe2e8, 'Bold');
+  static const linkSimpleBreak = IconData(0xe2e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/link-simple-horizontal-bold.svg)
-  static const linkSimpleHorizontal = PhosphorFlatIconData(0xe2ea, 'Bold');
+  static const linkSimpleHorizontal = IconData(0xe2ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-break-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/link-simple-horizontal-break-bold.svg)
-  static const linkSimpleHorizontalBreak = PhosphorFlatIconData(0xe2ec, 'Bold');
+  static const linkSimpleHorizontalBreak = IconData(0xe2ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linkedin-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/linkedin-logo-bold.svg)
-  static const linkedinLogo = PhosphorFlatIconData(0xe2ee, 'Bold');
+  static const linkedinLogo = IconData(0xe2ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linktree-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/linktree-logo-bold.svg)
-  static const linktreeLogo = PhosphorFlatIconData(0xedee, 'Bold');
+  static const linktreeLogo = IconData(0xedee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linux-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/linux-logo-bold.svg)
-  static const linuxLogo = PhosphorFlatIconData(0xeb02, 'Bold');
+  static const linuxLogo = IconData(0xeb02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-bold.svg)
-  static const list = PhosphorFlatIconData(0xe2f0, 'Bold');
+  static const list = IconData(0xe2f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-bullets-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-bullets-bold.svg)
-  static const listBullets = PhosphorFlatIconData(0xe2f2, 'Bold');
+  static const listBullets = IconData(0xe2f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-checks-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-checks-bold.svg)
-  static const listChecks = PhosphorFlatIconData(0xeadc, 'Bold');
+  static const listChecks = IconData(0xeadc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-dashes-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-dashes-bold.svg)
-  static const listDashes = PhosphorFlatIconData(0xe2f4, 'Bold');
+  static const listDashes = IconData(0xe2f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-heart-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-heart-bold.svg)
-  static const listHeart = PhosphorFlatIconData(0xebde, 'Bold');
+  static const listHeart = IconData(0xebde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-magnifying-glass-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-magnifying-glass-bold.svg)
-  static const listMagnifyingGlass = PhosphorFlatIconData(0xebe0, 'Bold');
+  static const listMagnifyingGlass = IconData(0xebe0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-numbers-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-numbers-bold.svg)
-  static const listNumbers = PhosphorFlatIconData(0xe2f6, 'Bold');
+  static const listNumbers = IconData(0xe2f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-plus-bold.svg)
-  static const listPlus = PhosphorFlatIconData(0xe2f8, 'Bold');
+  static const listPlus = IconData(0xe2f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-star-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/list-star-bold.svg)
-  static const listStar = PhosphorFlatIconData(0xebdc, 'Bold');
+  static const listStar = IconData(0xebdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lock-bold.svg)
-  static const lock = PhosphorFlatIconData(0xe2fa, 'Bold');
+  static const lock = IconData(0xe2fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lock-key-bold.svg)
-  static const lockKey = PhosphorFlatIconData(0xe2fe, 'Bold');
+  static const lockKey = IconData(0xe2fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lock-key-open-bold.svg)
-  static const lockKeyOpen = PhosphorFlatIconData(0xe300, 'Bold');
+  static const lockKeyOpen = IconData(0xe300,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lock-laminated-bold.svg)
-  static const lockLaminated = PhosphorFlatIconData(0xe302, 'Bold');
+  static const lockLaminated = IconData(0xe302,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lock-laminated-open-bold.svg)
-  static const lockLaminatedOpen = PhosphorFlatIconData(0xe304, 'Bold');
+  static const lockLaminatedOpen = IconData(0xe304,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lock-open-bold.svg)
-  static const lockOpen = PhosphorFlatIconData(0xe306, 'Bold');
+  static const lockOpen = IconData(0xe306,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lock-simple-bold.svg)
-  static const lockSimple = PhosphorFlatIconData(0xe308, 'Bold');
+  static const lockSimple = IconData(0xe308,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lock-simple-open-bold.svg)
-  static const lockSimpleOpen = PhosphorFlatIconData(0xe30a, 'Bold');
+  static const lockSimpleOpen = IconData(0xe30a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lockers-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/lockers-bold.svg)
-  static const lockers = PhosphorFlatIconData(0xecb8, 'Bold');
+  static const lockers = IconData(0xecb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![log-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/log-bold.svg)
-  static const log = PhosphorFlatIconData(0xed82, 'Bold');
+  static const log = IconData(0xed82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magic-wand-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/magic-wand-bold.svg)
-  static const magicWand = PhosphorFlatIconData(0xe6b6, 'Bold');
+  static const magicWand = IconData(0xe6b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/magnet-bold.svg)
-  static const magnet = PhosphorFlatIconData(0xe680, 'Bold');
+  static const magnet = IconData(0xe680,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-straight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/magnet-straight-bold.svg)
-  static const magnetStraight = PhosphorFlatIconData(0xe682, 'Bold');
+  static const magnetStraight = IconData(0xe682,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/magnifying-glass-bold.svg)
-  static const magnifyingGlass = PhosphorFlatIconData(0xe30c, 'Bold');
+  static const magnifyingGlass = IconData(0xe30c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/magnifying-glass-minus-bold.svg)
-  static const magnifyingGlassMinus = PhosphorFlatIconData(0xe30e, 'Bold');
+  static const magnifyingGlassMinus = IconData(0xe30e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/magnifying-glass-plus-bold.svg)
-  static const magnifyingGlassPlus = PhosphorFlatIconData(0xe310, 'Bold');
+  static const magnifyingGlassPlus = IconData(0xe310,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mailbox-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mailbox-bold.svg)
-  static const mailbox = PhosphorFlatIconData(0xec1e, 'Bold');
+  static const mailbox = IconData(0xec1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/map-pin-bold.svg)
-  static const mapPin = PhosphorFlatIconData(0xe316, 'Bold');
+  static const mapPin = IconData(0xe316,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-area-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/map-pin-area-bold.svg)
-  static const mapPinArea = PhosphorFlatIconData(0xee3a, 'Bold');
+  static const mapPinArea = IconData(0xee3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-line-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/map-pin-line-bold.svg)
-  static const mapPinLine = PhosphorFlatIconData(0xe318, 'Bold');
+  static const mapPinLine = IconData(0xe318,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/map-pin-plus-bold.svg)
-  static const mapPinPlus = PhosphorFlatIconData(0xe314, 'Bold');
+  static const mapPinPlus = IconData(0xe314,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/map-pin-simple-bold.svg)
-  static const mapPinSimple = PhosphorFlatIconData(0xee3e, 'Bold');
+  static const mapPinSimple = IconData(0xee3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-area-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/map-pin-simple-area-bold.svg)
-  static const mapPinSimpleArea = PhosphorFlatIconData(0xee3c, 'Bold');
+  static const mapPinSimpleArea = IconData(0xee3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-line-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/map-pin-simple-line-bold.svg)
-  static const mapPinSimpleLine = PhosphorFlatIconData(0xee38, 'Bold');
+  static const mapPinSimpleLine = IconData(0xee38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-trifold-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/map-trifold-bold.svg)
-  static const mapTrifold = PhosphorFlatIconData(0xe31a, 'Bold');
+  static const mapTrifold = IconData(0xe31a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![markdown-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/markdown-logo-bold.svg)
-  static const markdownLogo = PhosphorFlatIconData(0xe508, 'Bold');
+  static const markdownLogo = IconData(0xe508,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![marker-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/marker-circle-bold.svg)
-  static const markerCircle = PhosphorFlatIconData(0xe640, 'Bold');
+  static const markerCircle = IconData(0xe640,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![martini-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/martini-bold.svg)
-  static const martini = PhosphorFlatIconData(0xe31c, 'Bold');
+  static const martini = IconData(0xe31c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-happy-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mask-happy-bold.svg)
-  static const maskHappy = PhosphorFlatIconData(0xe9f4, 'Bold');
+  static const maskHappy = IconData(0xe9f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-sad-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mask-sad-bold.svg)
-  static const maskSad = PhosphorFlatIconData(0xeb9e, 'Bold');
+  static const maskSad = IconData(0xeb9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mastodon-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mastodon-logo-bold.svg)
-  static const mastodonLogo = PhosphorFlatIconData(0xed68, 'Bold');
+  static const mastodonLogo = IconData(0xed68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![math-operations-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/math-operations-bold.svg)
-  static const mathOperations = PhosphorFlatIconData(0xe31e, 'Bold');
+  static const mathOperations = IconData(0xe31e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![matrix-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/matrix-logo-bold.svg)
-  static const matrixLogo = PhosphorFlatIconData(0xed64, 'Bold');
+  static const matrixLogo = IconData(0xed64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/medal-bold.svg)
-  static const medal = PhosphorFlatIconData(0xe320, 'Bold');
+  static const medal = IconData(0xe320,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-military-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/medal-military-bold.svg)
-  static const medalMilitary = PhosphorFlatIconData(0xecfc, 'Bold');
+  static const medalMilitary = IconData(0xecfc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medium-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/medium-logo-bold.svg)
-  static const mediumLogo = PhosphorFlatIconData(0xe322, 'Bold');
+  static const mediumLogo = IconData(0xe322,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/megaphone-bold.svg)
-  static const megaphone = PhosphorFlatIconData(0xe324, 'Bold');
+  static const megaphone = IconData(0xe324,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/megaphone-simple-bold.svg)
-  static const megaphoneSimple = PhosphorFlatIconData(0xe642, 'Bold');
+  static const megaphoneSimple = IconData(0xe642,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![member-of-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/member-of-bold.svg)
-  static const memberOf = PhosphorFlatIconData(0xedc2, 'Bold');
+  static const memberOf = IconData(0xedc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![memory-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/memory-bold.svg)
-  static const memory = PhosphorFlatIconData(0xe9c4, 'Bold');
+  static const memory = IconData(0xe9c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![messenger-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/messenger-logo-bold.svg)
-  static const messengerLogo = PhosphorFlatIconData(0xe6d8, 'Bold');
+  static const messengerLogo = IconData(0xe6d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meta-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/meta-logo-bold.svg)
-  static const metaLogo = PhosphorFlatIconData(0xed02, 'Bold');
+  static const metaLogo = IconData(0xed02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meteor-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/meteor-bold.svg)
-  static const meteor = PhosphorFlatIconData(0xe9ba, 'Bold');
+  static const meteor = IconData(0xe9ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![metronome-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/metronome-bold.svg)
-  static const metronome = PhosphorFlatIconData(0xec8e, 'Bold');
+  static const metronome = IconData(0xec8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microphone-bold.svg)
-  static const microphone = PhosphorFlatIconData(0xe326, 'Bold');
+  static const microphone = IconData(0xe326,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microphone-slash-bold.svg)
-  static const microphoneSlash = PhosphorFlatIconData(0xe328, 'Bold');
+  static const microphoneSlash = IconData(0xe328,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-stage-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microphone-stage-bold.svg)
-  static const microphoneStage = PhosphorFlatIconData(0xe75c, 'Bold');
+  static const microphoneStage = IconData(0xe75c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microscope-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microscope-bold.svg)
-  static const microscope = PhosphorFlatIconData(0xec7a, 'Bold');
+  static const microscope = IconData(0xec7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-excel-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microsoft-excel-logo-bold.svg)
-  static const microsoftExcelLogo = PhosphorFlatIconData(0xeb6c, 'Bold');
+  static const microsoftExcelLogo = IconData(0xeb6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-outlook-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microsoft-outlook-logo-bold.svg)
-  static const microsoftOutlookLogo = PhosphorFlatIconData(0xeb70, 'Bold');
+  static const microsoftOutlookLogo = IconData(0xeb70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-powerpoint-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microsoft-powerpoint-logo-bold.svg)
-  static const microsoftPowerpointLogo = PhosphorFlatIconData(0xeace, 'Bold');
+  static const microsoftPowerpointLogo = IconData(0xeace,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-teams-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microsoft-teams-logo-bold.svg)
-  static const microsoftTeamsLogo = PhosphorFlatIconData(0xeb66, 'Bold');
+  static const microsoftTeamsLogo = IconData(0xeb66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-word-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/microsoft-word-logo-bold.svg)
-  static const microsoftWordLogo = PhosphorFlatIconData(0xeb6a, 'Bold');
+  static const microsoftWordLogo = IconData(0xeb6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/minus-bold.svg)
-  static const minus = PhosphorFlatIconData(0xe32a, 'Bold');
+  static const minus = IconData(0xe32a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/minus-circle-bold.svg)
-  static const minusCircle = PhosphorFlatIconData(0xe32c, 'Bold');
+  static const minusCircle = IconData(0xe32c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/minus-square-bold.svg)
-  static const minusSquare = PhosphorFlatIconData(0xed4c, 'Bold');
+  static const minusSquare = IconData(0xed4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/money-bold.svg)
-  static const money = PhosphorFlatIconData(0xe588, 'Bold');
+  static const money = IconData(0xe588,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-wavy-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/money-wavy-bold.svg)
-  static const moneyWavy = PhosphorFlatIconData(0xee68, 'Bold');
+  static const moneyWavy = IconData(0xee68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/monitor-bold.svg)
-  static const monitor = PhosphorFlatIconData(0xe32e, 'Bold');
+  static const monitor = IconData(0xe32e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-arrow-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/monitor-arrow-up-bold.svg)
-  static const monitorArrowUp = PhosphorFlatIconData(0xe58a, 'Bold');
+  static const monitorArrowUp = IconData(0xe58a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-play-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/monitor-play-bold.svg)
-  static const monitorPlay = PhosphorFlatIconData(0xe58c, 'Bold');
+  static const monitorPlay = IconData(0xe58c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/moon-bold.svg)
-  static const moon = PhosphorFlatIconData(0xe330, 'Bold');
+  static const moon = IconData(0xe330,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-stars-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/moon-stars-bold.svg)
-  static const moonStars = PhosphorFlatIconData(0xe58e, 'Bold');
+  static const moonStars = IconData(0xe58e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/moped-bold.svg)
-  static const moped = PhosphorFlatIconData(0xe824, 'Bold');
+  static const moped = IconData(0xe824,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-front-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/moped-front-bold.svg)
-  static const mopedFront = PhosphorFlatIconData(0xe822, 'Bold');
+  static const mopedFront = IconData(0xe822,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mosque-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mosque-bold.svg)
-  static const mosque = PhosphorFlatIconData(0xecee, 'Bold');
+  static const mosque = IconData(0xecee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![motorcycle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/motorcycle-bold.svg)
-  static const motorcycle = PhosphorFlatIconData(0xe80a, 'Bold');
+  static const motorcycle = IconData(0xe80a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mountains-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mountains-bold.svg)
-  static const mountains = PhosphorFlatIconData(0xe7ae, 'Bold');
+  static const mountains = IconData(0xe7ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mouse-bold.svg)
-  static const mouse = PhosphorFlatIconData(0xe33a, 'Bold');
+  static const mouse = IconData(0xe33a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-left-click-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mouse-left-click-bold.svg)
-  static const mouseLeftClick = PhosphorFlatIconData(0xe334, 'Bold');
+  static const mouseLeftClick = IconData(0xe334,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-middle-click-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mouse-middle-click-bold.svg)
-  static const mouseMiddleClick = PhosphorFlatIconData(0xe338, 'Bold');
+  static const mouseMiddleClick = IconData(0xe338,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-right-click-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mouse-right-click-bold.svg)
-  static const mouseRightClick = PhosphorFlatIconData(0xe336, 'Bold');
+  static const mouseRightClick = IconData(0xe336,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-scroll-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mouse-scroll-bold.svg)
-  static const mouseScroll = PhosphorFlatIconData(0xe332, 'Bold');
+  static const mouseScroll = IconData(0xe332,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/mouse-simple-bold.svg)
-  static const mouseSimple = PhosphorFlatIconData(0xe644, 'Bold');
+  static const mouseSimple = IconData(0xe644,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/music-note-bold.svg)
-  static const musicNote = PhosphorFlatIconData(0xe33c, 'Bold');
+  static const musicNote = IconData(0xe33c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/music-note-simple-bold.svg)
-  static const musicNoteSimple = PhosphorFlatIconData(0xe33e, 'Bold');
+  static const musicNoteSimple = IconData(0xe33e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/music-notes-bold.svg)
-  static const musicNotes = PhosphorFlatIconData(0xe340, 'Bold');
+  static const musicNotes = IconData(0xe340,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/music-notes-minus-bold.svg)
-  static const musicNotesMinus = PhosphorFlatIconData(0xee0c, 'Bold');
+  static const musicNotesMinus = IconData(0xee0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/music-notes-plus-bold.svg)
-  static const musicNotesPlus = PhosphorFlatIconData(0xeb7c, 'Bold');
+  static const musicNotesPlus = IconData(0xeb7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/music-notes-simple-bold.svg)
-  static const musicNotesSimple = PhosphorFlatIconData(0xe342, 'Bold');
+  static const musicNotesSimple = IconData(0xe342,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![navigation-arrow-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/navigation-arrow-bold.svg)
-  static const navigationArrow = PhosphorFlatIconData(0xeade, 'Bold');
+  static const navigationArrow = IconData(0xeade,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![needle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/needle-bold.svg)
-  static const needle = PhosphorFlatIconData(0xe82e, 'Bold');
+  static const needle = IconData(0xe82e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/network-bold.svg)
-  static const network = PhosphorFlatIconData(0xedde, 'Bold');
+  static const network = IconData(0xedde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/network-slash-bold.svg)
-  static const networkSlash = PhosphorFlatIconData(0xeddc, 'Bold');
+  static const networkSlash = IconData(0xeddc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/network-x-bold.svg)
-  static const networkX = PhosphorFlatIconData(0xedda, 'Bold');
+  static const networkX = IconData(0xedda,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/newspaper-bold.svg)
-  static const newspaper = PhosphorFlatIconData(0xe344, 'Bold');
+  static const newspaper = IconData(0xe344,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-clipping-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/newspaper-clipping-bold.svg)
-  static const newspaperClipping = PhosphorFlatIconData(0xe346, 'Bold');
+  static const newspaperClipping = IconData(0xe346,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-equals-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/not-equals-bold.svg)
-  static const notEquals = PhosphorFlatIconData(0xeda6, 'Bold');
+  static const notEquals = IconData(0xeda6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-member-of-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/not-member-of-bold.svg)
-  static const notMemberOf = PhosphorFlatIconData(0xedae, 'Bold');
+  static const notMemberOf = IconData(0xedae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-subset-of-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/not-subset-of-bold.svg)
-  static const notSubsetOf = PhosphorFlatIconData(0xedb0, 'Bold');
+  static const notSubsetOf = IconData(0xedb0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-superset-of-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/not-superset-of-bold.svg)
-  static const notSupersetOf = PhosphorFlatIconData(0xedb2, 'Bold');
+  static const notSupersetOf = IconData(0xedb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notches-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/notches-bold.svg)
-  static const notches = PhosphorFlatIconData(0xed3a, 'Bold');
+  static const notches = IconData(0xed3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/note-bold.svg)
-  static const note = PhosphorFlatIconData(0xe348, 'Bold');
+  static const note = IconData(0xe348,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-blank-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/note-blank-bold.svg)
-  static const noteBlank = PhosphorFlatIconData(0xe34a, 'Bold');
+  static const noteBlank = IconData(0xe34a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-pencil-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/note-pencil-bold.svg)
-  static const notePencil = PhosphorFlatIconData(0xe34c, 'Bold');
+  static const notePencil = IconData(0xe34c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notebook-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/notebook-bold.svg)
-  static const notebook = PhosphorFlatIconData(0xe34e, 'Bold');
+  static const notebook = IconData(0xe34e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notepad-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/notepad-bold.svg)
-  static const notepad = PhosphorFlatIconData(0xe63e, 'Bold');
+  static const notepad = IconData(0xe63e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notification-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/notification-bold.svg)
-  static const notification = PhosphorFlatIconData(0xe6fa, 'Bold');
+  static const notification = IconData(0xe6fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notion-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/notion-logo-bold.svg)
-  static const notionLogo = PhosphorFlatIconData(0xe9a0, 'Bold');
+  static const notionLogo = IconData(0xe9a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nuclear-plant-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/nuclear-plant-bold.svg)
-  static const nuclearPlant = PhosphorFlatIconData(0xed7c, 'Bold');
+  static const nuclearPlant = IconData(0xed7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-eight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-eight-bold.svg)
-  static const numberCircleEight = PhosphorFlatIconData(0xe352, 'Bold');
+  static const numberCircleEight = IconData(0xe352,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-five-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-five-bold.svg)
-  static const numberCircleFive = PhosphorFlatIconData(0xe358, 'Bold');
+  static const numberCircleFive = IconData(0xe358,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-four-bold.svg)
-  static const numberCircleFour = PhosphorFlatIconData(0xe35e, 'Bold');
+  static const numberCircleFour = IconData(0xe35e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-nine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-nine-bold.svg)
-  static const numberCircleNine = PhosphorFlatIconData(0xe364, 'Bold');
+  static const numberCircleNine = IconData(0xe364,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-one-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-one-bold.svg)
-  static const numberCircleOne = PhosphorFlatIconData(0xe36a, 'Bold');
+  static const numberCircleOne = IconData(0xe36a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-seven-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-seven-bold.svg)
-  static const numberCircleSeven = PhosphorFlatIconData(0xe370, 'Bold');
+  static const numberCircleSeven = IconData(0xe370,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-six-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-six-bold.svg)
-  static const numberCircleSix = PhosphorFlatIconData(0xe376, 'Bold');
+  static const numberCircleSix = IconData(0xe376,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-three-bold.svg)
-  static const numberCircleThree = PhosphorFlatIconData(0xe37c, 'Bold');
+  static const numberCircleThree = IconData(0xe37c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-two-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-two-bold.svg)
-  static const numberCircleTwo = PhosphorFlatIconData(0xe382, 'Bold');
+  static const numberCircleTwo = IconData(0xe382,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-zero-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-circle-zero-bold.svg)
-  static const numberCircleZero = PhosphorFlatIconData(0xe388, 'Bold');
+  static const numberCircleZero = IconData(0xe388,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-eight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-eight-bold.svg)
-  static const numberEight = PhosphorFlatIconData(0xe350, 'Bold');
+  static const numberEight = IconData(0xe350,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-five-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-five-bold.svg)
-  static const numberFive = PhosphorFlatIconData(0xe356, 'Bold');
+  static const numberFive = IconData(0xe356,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-four-bold.svg)
-  static const numberFour = PhosphorFlatIconData(0xe35c, 'Bold');
+  static const numberFour = IconData(0xe35c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-nine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-nine-bold.svg)
-  static const numberNine = PhosphorFlatIconData(0xe362, 'Bold');
+  static const numberNine = IconData(0xe362,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-one-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-one-bold.svg)
-  static const numberOne = PhosphorFlatIconData(0xe368, 'Bold');
+  static const numberOne = IconData(0xe368,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-seven-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-seven-bold.svg)
-  static const numberSeven = PhosphorFlatIconData(0xe36e, 'Bold');
+  static const numberSeven = IconData(0xe36e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-six-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-six-bold.svg)
-  static const numberSix = PhosphorFlatIconData(0xe374, 'Bold');
+  static const numberSix = IconData(0xe374,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-eight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-eight-bold.svg)
-  static const numberSquareEight = PhosphorFlatIconData(0xe354, 'Bold');
+  static const numberSquareEight = IconData(0xe354,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-five-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-five-bold.svg)
-  static const numberSquareFive = PhosphorFlatIconData(0xe35a, 'Bold');
+  static const numberSquareFive = IconData(0xe35a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-four-bold.svg)
-  static const numberSquareFour = PhosphorFlatIconData(0xe360, 'Bold');
+  static const numberSquareFour = IconData(0xe360,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-nine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-nine-bold.svg)
-  static const numberSquareNine = PhosphorFlatIconData(0xe366, 'Bold');
+  static const numberSquareNine = IconData(0xe366,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-one-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-one-bold.svg)
-  static const numberSquareOne = PhosphorFlatIconData(0xe36c, 'Bold');
+  static const numberSquareOne = IconData(0xe36c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-seven-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-seven-bold.svg)
-  static const numberSquareSeven = PhosphorFlatIconData(0xe372, 'Bold');
+  static const numberSquareSeven = IconData(0xe372,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-six-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-six-bold.svg)
-  static const numberSquareSix = PhosphorFlatIconData(0xe378, 'Bold');
+  static const numberSquareSix = IconData(0xe378,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-three-bold.svg)
-  static const numberSquareThree = PhosphorFlatIconData(0xe37e, 'Bold');
+  static const numberSquareThree = IconData(0xe37e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-two-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-two-bold.svg)
-  static const numberSquareTwo = PhosphorFlatIconData(0xe384, 'Bold');
+  static const numberSquareTwo = IconData(0xe384,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-zero-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-square-zero-bold.svg)
-  static const numberSquareZero = PhosphorFlatIconData(0xe38a, 'Bold');
+  static const numberSquareZero = IconData(0xe38a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-three-bold.svg)
-  static const numberThree = PhosphorFlatIconData(0xe37a, 'Bold');
+  static const numberThree = IconData(0xe37a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-two-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-two-bold.svg)
-  static const numberTwo = PhosphorFlatIconData(0xe380, 'Bold');
+  static const numberTwo = IconData(0xe380,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-zero-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/number-zero-bold.svg)
-  static const numberZero = PhosphorFlatIconData(0xe386, 'Bold');
+  static const numberZero = IconData(0xe386,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![numpad-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/numpad-bold.svg)
-  static const numpad = PhosphorFlatIconData(0xe3c8, 'Bold');
+  static const numpad = IconData(0xe3c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nut-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/nut-bold.svg)
-  static const nut = PhosphorFlatIconData(0xe38c, 'Bold');
+  static const nut = IconData(0xe38c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ny-times-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ny-times-logo-bold.svg)
-  static const nyTimesLogo = PhosphorFlatIconData(0xe646, 'Bold');
+  static const nyTimesLogo = IconData(0xe646,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![octagon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/octagon-bold.svg)
-  static const octagon = PhosphorFlatIconData(0xe38e, 'Bold');
+  static const octagon = IconData(0xe38e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![office-chair-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/office-chair-bold.svg)
-  static const officeChair = PhosphorFlatIconData(0xea46, 'Bold');
+  static const officeChair = IconData(0xea46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![onigiri-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/onigiri-bold.svg)
-  static const onigiri = PhosphorFlatIconData(0xee2c, 'Bold');
+  static const onigiri = IconData(0xee2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![open-ai-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/open-ai-logo-bold.svg)
-  static const openAiLogo = PhosphorFlatIconData(0xe7d2, 'Bold');
+  static const openAiLogo = IconData(0xe7d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![option-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/option-bold.svg)
-  static const option = PhosphorFlatIconData(0xe8a8, 'Bold');
+  static const option = IconData(0xe8a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/orange-bold.svg)
-  static const orange = PhosphorFlatIconData(0xee40, 'Bold');
+  static const orange = IconData(0xee40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-slice-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/orange-slice-bold.svg)
-  static const orangeSlice = PhosphorFlatIconData(0xed36, 'Bold');
+  static const orangeSlice = IconData(0xed36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![oven-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/oven-bold.svg)
-  static const oven = PhosphorFlatIconData(0xed8c, 'Bold');
+  static const oven = IconData(0xed8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![package-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/package-bold.svg)
-  static const package = PhosphorFlatIconData(0xe390, 'Bold');
+  static const package = IconData(0xe390,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paint-brush-bold.svg)
-  static const paintBrush = PhosphorFlatIconData(0xe6f0, 'Bold');
+  static const paintBrush = IconData(0xe6f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-broad-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paint-brush-broad-bold.svg)
-  static const paintBrushBroad = PhosphorFlatIconData(0xe590, 'Bold');
+  static const paintBrushBroad = IconData(0xe590,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-household-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paint-brush-household-bold.svg)
-  static const paintBrushHousehold = PhosphorFlatIconData(0xe6f2, 'Bold');
+  static const paintBrushHousehold = IconData(0xe6f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-bucket-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paint-bucket-bold.svg)
-  static const paintBucket = PhosphorFlatIconData(0xe392, 'Bold');
+  static const paintBucket = IconData(0xe392,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-roller-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paint-roller-bold.svg)
-  static const paintRoller = PhosphorFlatIconData(0xe6f4, 'Bold');
+  static const paintRoller = IconData(0xe6f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![palette-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/palette-bold.svg)
-  static const palette = PhosphorFlatIconData(0xe6c8, 'Bold');
+  static const palette = IconData(0xe6c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![panorama-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/panorama-bold.svg)
-  static const panorama = PhosphorFlatIconData(0xeaa2, 'Bold');
+  static const panorama = IconData(0xeaa2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pants-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pants-bold.svg)
-  static const pants = PhosphorFlatIconData(0xec88, 'Bold');
+  static const pants = IconData(0xec88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paper-plane-bold.svg)
-  static const paperPlane = PhosphorFlatIconData(0xe394, 'Bold');
+  static const paperPlane = IconData(0xe394,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paper-plane-right-bold.svg)
-  static const paperPlaneRight = PhosphorFlatIconData(0xe396, 'Bold');
+  static const paperPlaneRight = IconData(0xe396,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-tilt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paper-plane-tilt-bold.svg)
-  static const paperPlaneTilt = PhosphorFlatIconData(0xe398, 'Bold');
+  static const paperPlaneTilt = IconData(0xe398,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paperclip-bold.svg)
-  static const paperclip = PhosphorFlatIconData(0xe39a, 'Bold');
+  static const paperclip = IconData(0xe39a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paperclip-horizontal-bold.svg)
-  static const paperclipHorizontal = PhosphorFlatIconData(0xe592, 'Bold');
+  static const paperclipHorizontal = IconData(0xe592,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parachute-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/parachute-bold.svg)
-  static const parachute = PhosphorFlatIconData(0xea7c, 'Bold');
+  static const parachute = IconData(0xea7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paragraph-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paragraph-bold.svg)
-  static const paragraph = PhosphorFlatIconData(0xe960, 'Bold');
+  static const paragraph = IconData(0xe960,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parallelogram-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/parallelogram-bold.svg)
-  static const parallelogram = PhosphorFlatIconData(0xecc6, 'Bold');
+  static const parallelogram = IconData(0xecc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![park-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/park-bold.svg)
-  static const park = PhosphorFlatIconData(0xecb2, 'Bold');
+  static const park = IconData(0xecb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![password-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/password-bold.svg)
-  static const password = PhosphorFlatIconData(0xe752, 'Bold');
+  static const password = IconData(0xe752,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![path-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/path-bold.svg)
-  static const path = PhosphorFlatIconData(0xe39c, 'Bold');
+  static const path = IconData(0xe39c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![patreon-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/patreon-logo-bold.svg)
-  static const patreonLogo = PhosphorFlatIconData(0xe98a, 'Bold');
+  static const patreonLogo = IconData(0xe98a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pause-bold.svg)
-  static const pause = PhosphorFlatIconData(0xe39e, 'Bold');
+  static const pause = IconData(0xe39e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pause-circle-bold.svg)
-  static const pauseCircle = PhosphorFlatIconData(0xe3a0, 'Bold');
+  static const pauseCircle = IconData(0xe3a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paw-print-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paw-print-bold.svg)
-  static const pawPrint = PhosphorFlatIconData(0xe648, 'Bold');
+  static const pawPrint = IconData(0xe648,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paypal-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/paypal-logo-bold.svg)
-  static const paypalLogo = PhosphorFlatIconData(0xe98c, 'Bold');
+  static const paypalLogo = IconData(0xe98c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![peace-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/peace-bold.svg)
-  static const peace = PhosphorFlatIconData(0xe3a2, 'Bold');
+  static const peace = IconData(0xe3a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pen-bold.svg)
-  static const pen = PhosphorFlatIconData(0xe3aa, 'Bold');
+  static const pen = IconData(0xe3aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pen-nib-bold.svg)
-  static const penNib = PhosphorFlatIconData(0xe3ac, 'Bold');
+  static const penNib = IconData(0xe3ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-straight-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pen-nib-straight-bold.svg)
-  static const penNibStraight = PhosphorFlatIconData(0xe64a, 'Bold');
+  static const penNibStraight = IconData(0xe64a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pencil-bold.svg)
-  static const pencil = PhosphorFlatIconData(0xe3ae, 'Bold');
+  static const pencil = IconData(0xe3ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pencil-circle-bold.svg)
-  static const pencilCircle = PhosphorFlatIconData(0xe3b0, 'Bold');
+  static const pencilCircle = IconData(0xe3b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-line-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pencil-line-bold.svg)
-  static const pencilLine = PhosphorFlatIconData(0xe3b2, 'Bold');
+  static const pencilLine = IconData(0xe3b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-ruler-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pencil-ruler-bold.svg)
-  static const pencilRuler = PhosphorFlatIconData(0xe906, 'Bold');
+  static const pencilRuler = IconData(0xe906,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pencil-simple-bold.svg)
-  static const pencilSimple = PhosphorFlatIconData(0xe3b4, 'Bold');
+  static const pencilSimple = IconData(0xe3b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-line-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pencil-simple-line-bold.svg)
-  static const pencilSimpleLine = PhosphorFlatIconData(0xebc6, 'Bold');
+  static const pencilSimpleLine = IconData(0xebc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pencil-simple-slash-bold.svg)
-  static const pencilSimpleSlash = PhosphorFlatIconData(0xecf6, 'Bold');
+  static const pencilSimpleSlash = IconData(0xecf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pencil-slash-bold.svg)
-  static const pencilSlash = PhosphorFlatIconData(0xecf8, 'Bold');
+  static const pencilSlash = IconData(0xecf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pentagon-bold.svg)
-  static const pentagon = PhosphorFlatIconData(0xec7e, 'Bold');
+  static const pentagon = IconData(0xec7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagram-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pentagram-bold.svg)
-  static const pentagram = PhosphorFlatIconData(0xec5c, 'Bold');
+  static const pentagram = IconData(0xec5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pepper-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pepper-bold.svg)
-  static const pepper = PhosphorFlatIconData(0xe94a, 'Bold');
+  static const pepper = IconData(0xe94a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![percent-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/percent-bold.svg)
-  static const percent = PhosphorFlatIconData(0xe3b6, 'Bold');
+  static const percent = IconData(0xe3b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-bold.svg)
-  static const person = PhosphorFlatIconData(0xe3a8, 'Bold');
+  static const person = IconData(0xe3a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-arms-spread-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-arms-spread-bold.svg)
-  static const personArmsSpread = PhosphorFlatIconData(0xecfe, 'Bold');
+  static const personArmsSpread = IconData(0xecfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-bold.svg)
-  static const personSimple = PhosphorFlatIconData(0xe72e, 'Bold');
+  static const personSimple = IconData(0xe72e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-bike-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-bike-bold.svg)
-  static const personSimpleBike = PhosphorFlatIconData(0xe734, 'Bold');
+  static const personSimpleBike = IconData(0xe734,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-circle-bold.svg)
-  static const personSimpleCircle = PhosphorFlatIconData(0xee58, 'Bold');
+  static const personSimpleCircle = IconData(0xee58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-hike-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-hike-bold.svg)
-  static const personSimpleHike = PhosphorFlatIconData(0xed54, 'Bold');
+  static const personSimpleHike = IconData(0xed54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-run-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-run-bold.svg)
-  static const personSimpleRun = PhosphorFlatIconData(0xe730, 'Bold');
+  static const personSimpleRun = IconData(0xe730,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-ski-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-ski-bold.svg)
-  static const personSimpleSki = PhosphorFlatIconData(0xe71c, 'Bold');
+  static const personSimpleSki = IconData(0xe71c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-snowboard-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-snowboard-bold.svg)
-  static const personSimpleSnowboard = PhosphorFlatIconData(0xe71e, 'Bold');
+  static const personSimpleSnowboard = IconData(0xe71e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-swim-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-swim-bold.svg)
-  static const personSimpleSwim = PhosphorFlatIconData(0xe736, 'Bold');
+  static const personSimpleSwim = IconData(0xe736,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-tai-chi-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-tai-chi-bold.svg)
-  static const personSimpleTaiChi = PhosphorFlatIconData(0xed5c, 'Bold');
+  static const personSimpleTaiChi = IconData(0xed5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-throw-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-throw-bold.svg)
-  static const personSimpleThrow = PhosphorFlatIconData(0xe732, 'Bold');
+  static const personSimpleThrow = IconData(0xe732,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-walk-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/person-simple-walk-bold.svg)
-  static const personSimpleWalk = PhosphorFlatIconData(0xe73a, 'Bold');
+  static const personSimpleWalk = IconData(0xe73a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![perspective-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/perspective-bold.svg)
-  static const perspective = PhosphorFlatIconData(0xebe6, 'Bold');
+  static const perspective = IconData(0xebe6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-bold.svg)
-  static const phone = PhosphorFlatIconData(0xe3b8, 'Bold');
+  static const phone = IconData(0xe3b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-call-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-call-bold.svg)
-  static const phoneCall = PhosphorFlatIconData(0xe3ba, 'Bold');
+  static const phoneCall = IconData(0xe3ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-disconnect-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-disconnect-bold.svg)
-  static const phoneDisconnect = PhosphorFlatIconData(0xe3bc, 'Bold');
+  static const phoneDisconnect = IconData(0xe3bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-incoming-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-incoming-bold.svg)
-  static const phoneIncoming = PhosphorFlatIconData(0xe3be, 'Bold');
+  static const phoneIncoming = IconData(0xe3be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-list-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-list-bold.svg)
-  static const phoneList = PhosphorFlatIconData(0xe3cc, 'Bold');
+  static const phoneList = IconData(0xe3cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-outgoing-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-outgoing-bold.svg)
-  static const phoneOutgoing = PhosphorFlatIconData(0xe3c0, 'Bold');
+  static const phoneOutgoing = IconData(0xe3c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-pause-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-pause-bold.svg)
-  static const phonePause = PhosphorFlatIconData(0xe3ca, 'Bold');
+  static const phonePause = IconData(0xe3ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-plus-bold.svg)
-  static const phonePlus = PhosphorFlatIconData(0xec56, 'Bold');
+  static const phonePlus = IconData(0xec56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-slash-bold.svg)
-  static const phoneSlash = PhosphorFlatIconData(0xe3c2, 'Bold');
+  static const phoneSlash = IconData(0xe3c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-transfer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-transfer-bold.svg)
-  static const phoneTransfer = PhosphorFlatIconData(0xe3c6, 'Bold');
+  static const phoneTransfer = IconData(0xe3c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phone-x-bold.svg)
-  static const phoneX = PhosphorFlatIconData(0xe3c4, 'Bold');
+  static const phoneX = IconData(0xe3c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phosphor-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/phosphor-logo-bold.svg)
-  static const phosphorLogo = PhosphorFlatIconData(0xe3ce, 'Bold');
+  static const phosphorLogo = IconData(0xe3ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pi-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pi-bold.svg)
-  static const pi = PhosphorFlatIconData(0xec80, 'Bold');
+  static const pi = IconData(0xec80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piano-keys-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/piano-keys-bold.svg)
-  static const pianoKeys = PhosphorFlatIconData(0xe9c8, 'Bold');
+  static const pianoKeys = IconData(0xe9c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picnic-table-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/picnic-table-bold.svg)
-  static const picnicTable = PhosphorFlatIconData(0xee26, 'Bold');
+  static const picnicTable = IconData(0xee26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picture-in-picture-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/picture-in-picture-bold.svg)
-  static const pictureInpicture = PhosphorFlatIconData(0xe64c, 'Bold');
+  static const pictureInpicture = IconData(0xe64c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piggy-bank-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/piggy-bank-bold.svg)
-  static const piggyBank = PhosphorFlatIconData(0xea04, 'Bold');
+  static const piggyBank = IconData(0xea04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pill-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pill-bold.svg)
-  static const pill = PhosphorFlatIconData(0xe700, 'Bold');
+  static const pill = IconData(0xe700,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ping-pong-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ping-pong-bold.svg)
-  static const pingPong = PhosphorFlatIconData(0xea42, 'Bold');
+  static const pingPong = IconData(0xea42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pint-glass-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pint-glass-bold.svg)
-  static const pintGlass = PhosphorFlatIconData(0xedd0, 'Bold');
+  static const pintGlass = IconData(0xedd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinterest-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pinterest-logo-bold.svg)
-  static const pinterestLogo = PhosphorFlatIconData(0xe64e, 'Bold');
+  static const pinterestLogo = IconData(0xe64e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinwheel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pinwheel-bold.svg)
-  static const pinwheel = PhosphorFlatIconData(0xeb9c, 'Bold');
+  static const pinwheel = IconData(0xeb9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pipe-bold.svg)
-  static const pipe = PhosphorFlatIconData(0xed86, 'Bold');
+  static const pipe = IconData(0xed86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-wrench-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pipe-wrench-bold.svg)
-  static const pipeWrench = PhosphorFlatIconData(0xed88, 'Bold');
+  static const pipeWrench = IconData(0xed88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pix-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pix-logo-bold.svg)
-  static const pixLogo = PhosphorFlatIconData(0xecc2, 'Bold');
+  static const pixLogo = IconData(0xecc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pizza-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pizza-bold.svg)
-  static const pizza = PhosphorFlatIconData(0xe796, 'Bold');
+  static const pizza = IconData(0xe796,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![placeholder-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/placeholder-bold.svg)
-  static const placeholder = PhosphorFlatIconData(0xe650, 'Bold');
+  static const placeholder = IconData(0xe650,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![planet-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/planet-bold.svg)
-  static const planet = PhosphorFlatIconData(0xe652, 'Bold');
+  static const planet = IconData(0xe652,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plant-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plant-bold.svg)
-  static const plant = PhosphorFlatIconData(0xebae, 'Bold');
+  static const plant = IconData(0xebae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/play-bold.svg)
-  static const play = PhosphorFlatIconData(0xe3d0, 'Bold');
+  static const play = IconData(0xe3d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/play-circle-bold.svg)
-  static const playCircle = PhosphorFlatIconData(0xe3d2, 'Bold');
+  static const playCircle = IconData(0xe3d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-pause-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/play-pause-bold.svg)
-  static const playPause = PhosphorFlatIconData(0xe8be, 'Bold');
+  static const playPause = IconData(0xe8be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![playlist-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/playlist-bold.svg)
-  static const playlist = PhosphorFlatIconData(0xe6aa, 'Bold');
+  static const playlist = IconData(0xe6aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plug-bold.svg)
-  static const plug = PhosphorFlatIconData(0xe946, 'Bold');
+  static const plug = IconData(0xe946,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-charging-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plug-charging-bold.svg)
-  static const plugCharging = PhosphorFlatIconData(0xeb5c, 'Bold');
+  static const plugCharging = IconData(0xeb5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plugs-bold.svg)
-  static const plugs = PhosphorFlatIconData(0xeb56, 'Bold');
+  static const plugs = IconData(0xeb56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-connected-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plugs-connected-bold.svg)
-  static const plugsConnected = PhosphorFlatIconData(0xeb5a, 'Bold');
+  static const plugsConnected = IconData(0xeb5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plus-bold.svg)
-  static const plus = PhosphorFlatIconData(0xe3d4, 'Bold');
+  static const plus = IconData(0xe3d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plus-circle-bold.svg)
-  static const plusCircle = PhosphorFlatIconData(0xe3d6, 'Bold');
+  static const plusCircle = IconData(0xe3d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plus-minus-bold.svg)
-  static const plusMinus = PhosphorFlatIconData(0xe3d8, 'Bold');
+  static const plusMinus = IconData(0xe3d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/plus-square-bold.svg)
-  static const plusSquare = PhosphorFlatIconData(0xed4a, 'Bold');
+  static const plusSquare = IconData(0xed4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![poker-chip-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/poker-chip-bold.svg)
-  static const pokerChip = PhosphorFlatIconData(0xe594, 'Bold');
+  static const pokerChip = IconData(0xe594,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![police-car-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/police-car-bold.svg)
-  static const policeCar = PhosphorFlatIconData(0xec4a, 'Bold');
+  static const policeCar = IconData(0xec4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![polygon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/polygon-bold.svg)
-  static const polygon = PhosphorFlatIconData(0xe6d0, 'Bold');
+  static const polygon = IconData(0xe6d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popcorn-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/popcorn-bold.svg)
-  static const popcorn = PhosphorFlatIconData(0xeb4e, 'Bold');
+  static const popcorn = IconData(0xeb4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popsicle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/popsicle-bold.svg)
-  static const popsicle = PhosphorFlatIconData(0xebbe, 'Bold');
+  static const popsicle = IconData(0xebbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![potted-plant-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/potted-plant-bold.svg)
-  static const pottedPlant = PhosphorFlatIconData(0xec22, 'Bold');
+  static const pottedPlant = IconData(0xec22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![power-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/power-bold.svg)
-  static const power = PhosphorFlatIconData(0xe3da, 'Bold');
+  static const power = IconData(0xe3da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prescription-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/prescription-bold.svg)
-  static const prescription = PhosphorFlatIconData(0xe7a2, 'Bold');
+  static const prescription = IconData(0xe7a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/presentation-bold.svg)
-  static const presentation = PhosphorFlatIconData(0xe654, 'Bold');
+  static const presentation = IconData(0xe654,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-chart-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/presentation-chart-bold.svg)
-  static const presentationChart = PhosphorFlatIconData(0xe656, 'Bold');
+  static const presentationChart = IconData(0xe656,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![printer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/printer-bold.svg)
-  static const printer = PhosphorFlatIconData(0xe3dc, 'Bold');
+  static const printer = IconData(0xe3dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/prohibit-bold.svg)
-  static const prohibit = PhosphorFlatIconData(0xe3de, 'Bold');
+  static const prohibit = IconData(0xe3de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-inset-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/prohibit-inset-bold.svg)
-  static const prohibitInset = PhosphorFlatIconData(0xe3e0, 'Bold');
+  static const prohibitInset = IconData(0xe3e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/projector-screen-bold.svg)
-  static const projectorScreen = PhosphorFlatIconData(0xe658, 'Bold');
+  static const projectorScreen = IconData(0xe658,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-chart-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/projector-screen-chart-bold.svg)
-  static const projectorScreenChart = PhosphorFlatIconData(0xe65a, 'Bold');
+  static const projectorScreenChart = IconData(0xe65a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pulse-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/pulse-bold.svg)
-  static const pulse = PhosphorFlatIconData(0xe000, 'Bold');
+  static const pulse = IconData(0xe000,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/push-pin-bold.svg)
-  static const pushPin = PhosphorFlatIconData(0xe3e2, 'Bold');
+  static const pushPin = IconData(0xe3e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/push-pin-simple-bold.svg)
-  static const pushPinSimple = PhosphorFlatIconData(0xe65c, 'Bold');
+  static const pushPinSimple = IconData(0xe65c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/push-pin-simple-slash-bold.svg)
-  static const pushPinSimpleSlash = PhosphorFlatIconData(0xe65e, 'Bold');
+  static const pushPinSimpleSlash = IconData(0xe65e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/push-pin-slash-bold.svg)
-  static const pushPinSlash = PhosphorFlatIconData(0xe3e4, 'Bold');
+  static const pushPinSlash = IconData(0xe3e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![puzzle-piece-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/puzzle-piece-bold.svg)
-  static const puzzlePiece = PhosphorFlatIconData(0xe596, 'Bold');
+  static const puzzlePiece = IconData(0xe596,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![qr-code-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/qr-code-bold.svg)
-  static const qrCode = PhosphorFlatIconData(0xe3e6, 'Bold');
+  static const qrCode = IconData(0xe3e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/question-bold.svg)
-  static const question = PhosphorFlatIconData(0xe3e8, 'Bold');
+  static const question = IconData(0xe3e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-mark-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/question-mark-bold.svg)
-  static const questionMark = PhosphorFlatIconData(0xe3e9, 'Bold');
+  static const questionMark = IconData(0xe3e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![queue-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/queue-bold.svg)
-  static const queue = PhosphorFlatIconData(0xe6ac, 'Bold');
+  static const queue = IconData(0xe6ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![quotes-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/quotes-bold.svg)
-  static const quotes = PhosphorFlatIconData(0xe660, 'Bold');
+  static const quotes = IconData(0xe660,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rabbit-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rabbit-bold.svg)
-  static const rabbit = PhosphorFlatIconData(0xeac2, 'Bold');
+  static const rabbit = IconData(0xeac2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![racquet-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/racquet-bold.svg)
-  static const racquet = PhosphorFlatIconData(0xee02, 'Bold');
+  static const racquet = IconData(0xee02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/radical-bold.svg)
-  static const radical = PhosphorFlatIconData(0xe3ea, 'Bold');
+  static const radical = IconData(0xe3ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/radio-bold.svg)
-  static const radio = PhosphorFlatIconData(0xe77e, 'Bold');
+  static const radio = IconData(0xe77e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-button-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/radio-button-bold.svg)
-  static const radioButton = PhosphorFlatIconData(0xeb08, 'Bold');
+  static const radioButton = IconData(0xeb08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radioactive-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/radioactive-bold.svg)
-  static const radioactive = PhosphorFlatIconData(0xe9dc, 'Bold');
+  static const radioactive = IconData(0xe9dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rainbow-bold.svg)
-  static const rainbow = PhosphorFlatIconData(0xe598, 'Bold');
+  static const rainbow = IconData(0xe598,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-cloud-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rainbow-cloud-bold.svg)
-  static const rainbowCloud = PhosphorFlatIconData(0xe59a, 'Bold');
+  static const rainbowCloud = IconData(0xe59a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ranking-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ranking-bold.svg)
-  static const ranking = PhosphorFlatIconData(0xed62, 'Bold');
+  static const ranking = IconData(0xed62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![read-cv-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/read-cv-logo-bold.svg)
-  static const readCvLogo = PhosphorFlatIconData(0xed0c, 'Bold');
+  static const readCvLogo = IconData(0xed0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/receipt-bold.svg)
-  static const receipt = PhosphorFlatIconData(0xe3ec, 'Bold');
+  static const receipt = IconData(0xe3ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/receipt-x-bold.svg)
-  static const receiptX = PhosphorFlatIconData(0xed40, 'Bold');
+  static const receiptX = IconData(0xed40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![record-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/record-bold.svg)
-  static const record = PhosphorFlatIconData(0xe3ee, 'Bold');
+  static const record = IconData(0xe3ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rectangle-bold.svg)
-  static const rectangle = PhosphorFlatIconData(0xe3f0, 'Bold');
+  static const rectangle = IconData(0xe3f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-dashed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rectangle-dashed-bold.svg)
-  static const rectangleDashed = PhosphorFlatIconData(0xe3f2, 'Bold');
+  static const rectangleDashed = IconData(0xe3f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![recycle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/recycle-bold.svg)
-  static const recycle = PhosphorFlatIconData(0xe75a, 'Bold');
+  static const recycle = IconData(0xe75a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![reddit-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/reddit-logo-bold.svg)
-  static const redditLogo = PhosphorFlatIconData(0xe59c, 'Bold');
+  static const redditLogo = IconData(0xe59c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/repeat-bold.svg)
-  static const repeat = PhosphorFlatIconData(0xe3f6, 'Bold');
+  static const repeat = IconData(0xe3f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-once-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/repeat-once-bold.svg)
-  static const repeatOnce = PhosphorFlatIconData(0xe3f8, 'Bold');
+  static const repeatOnce = IconData(0xe3f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![replit-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/replit-logo-bold.svg)
-  static const replitLogo = PhosphorFlatIconData(0xeb8a, 'Bold');
+  static const replitLogo = IconData(0xeb8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![resize-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/resize-bold.svg)
-  static const resize = PhosphorFlatIconData(0xed6e, 'Bold');
+  static const resize = IconData(0xed6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rewind-bold.svg)
-  static const rewind = PhosphorFlatIconData(0xe6a8, 'Bold');
+  static const rewind = IconData(0xe6a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rewind-circle-bold.svg)
-  static const rewindCircle = PhosphorFlatIconData(0xe3fa, 'Bold');
+  static const rewindCircle = IconData(0xe3fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![road-horizon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/road-horizon-bold.svg)
-  static const roadHorizon = PhosphorFlatIconData(0xe838, 'Bold');
+  static const roadHorizon = IconData(0xe838,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![robot-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/robot-bold.svg)
-  static const robot = PhosphorFlatIconData(0xe762, 'Bold');
+  static const robot = IconData(0xe762,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rocket-bold.svg)
-  static const rocket = PhosphorFlatIconData(0xe3fc, 'Bold');
+  static const rocket = IconData(0xe3fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-launch-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rocket-launch-bold.svg)
-  static const rocketLaunch = PhosphorFlatIconData(0xe3fe, 'Bold');
+  static const rocketLaunch = IconData(0xe3fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rows-bold.svg)
-  static const rows = PhosphorFlatIconData(0xe5a2, 'Bold');
+  static const rows = IconData(0xe5a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-bottom-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rows-plus-bottom-bold.svg)
-  static const rowsPlusBottom = PhosphorFlatIconData(0xe59e, 'Bold');
+  static const rowsPlusBottom = IconData(0xe59e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-top-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rows-plus-top-bold.svg)
-  static const rowsPlusTop = PhosphorFlatIconData(0xe5a0, 'Bold');
+  static const rowsPlusTop = IconData(0xe5a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rss-bold.svg)
-  static const rss = PhosphorFlatIconData(0xe400, 'Bold');
+  static const rss = IconData(0xe400,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rss-simple-bold.svg)
-  static const rssSimple = PhosphorFlatIconData(0xe402, 'Bold');
+  static const rssSimple = IconData(0xe402,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rug-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/rug-bold.svg)
-  static const rug = PhosphorFlatIconData(0xea1a, 'Bold');
+  static const rug = IconData(0xea1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ruler-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ruler-bold.svg)
-  static const ruler = PhosphorFlatIconData(0xe6b8, 'Bold');
+  static const ruler = IconData(0xe6b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sailboat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sailboat-bold.svg)
-  static const sailboat = PhosphorFlatIconData(0xe78a, 'Bold');
+  static const sailboat = IconData(0xe78a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scales-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/scales-bold.svg)
-  static const scales = PhosphorFlatIconData(0xe750, 'Bold');
+  static const scales = IconData(0xe750,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/scan-bold.svg)
-  static const scan = PhosphorFlatIconData(0xebb6, 'Bold');
+  static const scan = IconData(0xebb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-smiley-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/scan-smiley-bold.svg)
-  static const scanSmiley = PhosphorFlatIconData(0xebb4, 'Bold');
+  static const scanSmiley = IconData(0xebb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scissors-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/scissors-bold.svg)
-  static const scissors = PhosphorFlatIconData(0xeae0, 'Bold');
+  static const scissors = IconData(0xeae0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scooter-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/scooter-bold.svg)
-  static const scooter = PhosphorFlatIconData(0xe820, 'Bold');
+  static const scooter = IconData(0xe820,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screencast-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/screencast-bold.svg)
-  static const screencast = PhosphorFlatIconData(0xe404, 'Bold');
+  static const screencast = IconData(0xe404,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screwdriver-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/screwdriver-bold.svg)
-  static const screwdriver = PhosphorFlatIconData(0xe86e, 'Bold');
+  static const screwdriver = IconData(0xe86e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/scribble-bold.svg)
-  static const scribble = PhosphorFlatIconData(0xe806, 'Bold');
+  static const scribble = IconData(0xe806,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-loop-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/scribble-loop-bold.svg)
-  static const scribbleLoop = PhosphorFlatIconData(0xe662, 'Bold');
+  static const scribbleLoop = IconData(0xe662,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scroll-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/scroll-bold.svg)
-  static const scroll = PhosphorFlatIconData(0xeb7a, 'Bold');
+  static const scroll = IconData(0xeb7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/seal-bold.svg)
-  static const seal = PhosphorFlatIconData(0xe604, 'Bold');
+  static const seal = IconData(0xe604,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-check-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/seal-check-bold.svg)
-  static const sealCheck = PhosphorFlatIconData(0xe606, 'Bold');
+  static const sealCheck = IconData(0xe606,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-percent-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/seal-percent-bold.svg)
-  static const sealPercent = PhosphorFlatIconData(0xe60a, 'Bold');
+  static const sealPercent = IconData(0xe60a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-question-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/seal-question-bold.svg)
-  static const sealQuestion = PhosphorFlatIconData(0xe608, 'Bold');
+  static const sealQuestion = IconData(0xe608,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-warning-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/seal-warning-bold.svg)
-  static const sealWarning = PhosphorFlatIconData(0xe60c, 'Bold');
+  static const sealWarning = IconData(0xe60c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/seat-bold.svg)
-  static const seat = PhosphorFlatIconData(0xeb8e, 'Bold');
+  static const seat = IconData(0xeb8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seatbelt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/seatbelt-bold.svg)
-  static const seatbelt = PhosphorFlatIconData(0xedfe, 'Bold');
+  static const seatbelt = IconData(0xedfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![security-camera-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/security-camera-bold.svg)
-  static const securityCamera = PhosphorFlatIconData(0xeca4, 'Bold');
+  static const securityCamera = IconData(0xeca4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/selection-bold.svg)
-  static const selection = PhosphorFlatIconData(0xe69a, 'Bold');
+  static const selection = IconData(0xe69a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-all-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/selection-all-bold.svg)
-  static const selectionAll = PhosphorFlatIconData(0xe746, 'Bold');
+  static const selectionAll = IconData(0xe746,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-background-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/selection-background-bold.svg)
-  static const selectionBackground = PhosphorFlatIconData(0xeaf8, 'Bold');
+  static const selectionBackground = IconData(0xeaf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-foreground-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/selection-foreground-bold.svg)
-  static const selectionForeground = PhosphorFlatIconData(0xeaf6, 'Bold');
+  static const selectionForeground = IconData(0xeaf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-inverse-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/selection-inverse-bold.svg)
-  static const selectionInverse = PhosphorFlatIconData(0xe744, 'Bold');
+  static const selectionInverse = IconData(0xe744,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/selection-plus-bold.svg)
-  static const selectionPlus = PhosphorFlatIconData(0xe69c, 'Bold');
+  static const selectionPlus = IconData(0xe69c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/selection-slash-bold.svg)
-  static const selectionSlash = PhosphorFlatIconData(0xe69e, 'Bold');
+  static const selectionSlash = IconData(0xe69e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shapes-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shapes-bold.svg)
-  static const shapes = PhosphorFlatIconData(0xec5e, 'Bold');
+  static const shapes = IconData(0xec5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/share-bold.svg)
-  static const share = PhosphorFlatIconData(0xe406, 'Bold');
+  static const share = IconData(0xe406,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-fat-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/share-fat-bold.svg)
-  static const shareFat = PhosphorFlatIconData(0xed52, 'Bold');
+  static const shareFat = IconData(0xed52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-network-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/share-network-bold.svg)
-  static const shareNetwork = PhosphorFlatIconData(0xe408, 'Bold');
+  static const shareNetwork = IconData(0xe408,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shield-bold.svg)
-  static const shield = PhosphorFlatIconData(0xe40a, 'Bold');
+  static const shield = IconData(0xe40a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-check-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shield-check-bold.svg)
-  static const shieldCheck = PhosphorFlatIconData(0xe40c, 'Bold');
+  static const shieldCheck = IconData(0xe40c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-checkered-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shield-checkered-bold.svg)
-  static const shieldCheckered = PhosphorFlatIconData(0xe708, 'Bold');
+  static const shieldCheckered = IconData(0xe708,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-chevron-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shield-chevron-bold.svg)
-  static const shieldChevron = PhosphorFlatIconData(0xe40e, 'Bold');
+  static const shieldChevron = IconData(0xe40e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shield-plus-bold.svg)
-  static const shieldPlus = PhosphorFlatIconData(0xe706, 'Bold');
+  static const shieldPlus = IconData(0xe706,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shield-slash-bold.svg)
-  static const shieldSlash = PhosphorFlatIconData(0xe410, 'Bold');
+  static const shieldSlash = IconData(0xe410,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-star-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shield-star-bold.svg)
-  static const shieldStar = PhosphorFlatIconData(0xec34, 'Bold');
+  static const shieldStar = IconData(0xec34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-warning-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shield-warning-bold.svg)
-  static const shieldWarning = PhosphorFlatIconData(0xe412, 'Bold');
+  static const shieldWarning = IconData(0xe412,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shipping-container-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shipping-container-bold.svg)
-  static const shippingContainer = PhosphorFlatIconData(0xe78c, 'Bold');
+  static const shippingContainer = IconData(0xe78c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shirt-folded-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shirt-folded-bold.svg)
-  static const shirtFolded = PhosphorFlatIconData(0xea92, 'Bold');
+  static const shirtFolded = IconData(0xea92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shooting-star-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shooting-star-bold.svg)
-  static const shootingStar = PhosphorFlatIconData(0xecfa, 'Bold');
+  static const shootingStar = IconData(0xecfa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shopping-bag-bold.svg)
-  static const shoppingBag = PhosphorFlatIconData(0xe416, 'Bold');
+  static const shoppingBag = IconData(0xe416,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-open-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shopping-bag-open-bold.svg)
-  static const shoppingBagOpen = PhosphorFlatIconData(0xe418, 'Bold');
+  static const shoppingBagOpen = IconData(0xe418,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shopping-cart-bold.svg)
-  static const shoppingCart = PhosphorFlatIconData(0xe41e, 'Bold');
+  static const shoppingCart = IconData(0xe41e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shopping-cart-simple-bold.svg)
-  static const shoppingCartSimple = PhosphorFlatIconData(0xe420, 'Bold');
+  static const shoppingCartSimple = IconData(0xe420,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shovel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shovel-bold.svg)
-  static const shovel = PhosphorFlatIconData(0xe9e6, 'Bold');
+  static const shovel = IconData(0xe9e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shower-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shower-bold.svg)
-  static const shower = PhosphorFlatIconData(0xe776, 'Bold');
+  static const shower = IconData(0xe776,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shrimp-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shrimp-bold.svg)
-  static const shrimp = PhosphorFlatIconData(0xeab4, 'Bold');
+  static const shrimp = IconData(0xeab4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shuffle-bold.svg)
-  static const shuffle = PhosphorFlatIconData(0xe422, 'Bold');
+  static const shuffle = IconData(0xe422,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-angular-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shuffle-angular-bold.svg)
-  static const shuffleAngular = PhosphorFlatIconData(0xe424, 'Bold');
+  static const shuffleAngular = IconData(0xe424,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/shuffle-simple-bold.svg)
-  static const shuffleSimple = PhosphorFlatIconData(0xe426, 'Bold');
+  static const shuffleSimple = IconData(0xe426,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sidebar-bold.svg)
-  static const sidebar = PhosphorFlatIconData(0xeab6, 'Bold');
+  static const sidebar = IconData(0xeab6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sidebar-simple-bold.svg)
-  static const sidebarSimple = PhosphorFlatIconData(0xec24, 'Bold');
+  static const sidebarSimple = IconData(0xec24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sigma-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sigma-bold.svg)
-  static const sigma = PhosphorFlatIconData(0xeab8, 'Bold');
+  static const sigma = IconData(0xeab8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-in-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sign-in-bold.svg)
-  static const signIn = PhosphorFlatIconData(0xe428, 'Bold');
+  static const signIn = IconData(0xe428,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-out-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sign-out-bold.svg)
-  static const signOut = PhosphorFlatIconData(0xe42a, 'Bold');
+  static const signOut = IconData(0xe42a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signature-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/signature-bold.svg)
-  static const signature = PhosphorFlatIconData(0xebac, 'Bold');
+  static const signature = IconData(0xebac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signpost-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/signpost-bold.svg)
-  static const signpost = PhosphorFlatIconData(0xe89c, 'Bold');
+  static const signpost = IconData(0xe89c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sim-card-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sim-card-bold.svg)
-  static const simCard = PhosphorFlatIconData(0xe664, 'Bold');
+  static const simCard = IconData(0xe664,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![siren-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/siren-bold.svg)
-  static const siren = PhosphorFlatIconData(0xe9b8, 'Bold');
+  static const siren = IconData(0xe9b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sketch-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sketch-logo-bold.svg)
-  static const sketchLogo = PhosphorFlatIconData(0xe42c, 'Bold');
+  static const sketchLogo = IconData(0xe42c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/skip-back-bold.svg)
-  static const skipBack = PhosphorFlatIconData(0xe5a4, 'Bold');
+  static const skipBack = IconData(0xe5a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/skip-back-circle-bold.svg)
-  static const skipBackCircle = PhosphorFlatIconData(0xe42e, 'Bold');
+  static const skipBackCircle = IconData(0xe42e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/skip-forward-bold.svg)
-  static const skipForward = PhosphorFlatIconData(0xe5a6, 'Bold');
+  static const skipForward = IconData(0xe5a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/skip-forward-circle-bold.svg)
-  static const skipForwardCircle = PhosphorFlatIconData(0xe430, 'Bold');
+  static const skipForwardCircle = IconData(0xe430,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skull-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/skull-bold.svg)
-  static const skull = PhosphorFlatIconData(0xe916, 'Bold');
+  static const skull = IconData(0xe916,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skype-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/skype-logo-bold.svg)
-  static const skypeLogo = PhosphorFlatIconData(0xe8dc, 'Bold');
+  static const skypeLogo = IconData(0xe8dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slack-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/slack-logo-bold.svg)
-  static const slackLogo = PhosphorFlatIconData(0xe5a8, 'Bold');
+  static const slackLogo = IconData(0xe5a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sliders-bold.svg)
-  static const sliders = PhosphorFlatIconData(0xe432, 'Bold');
+  static const sliders = IconData(0xe432,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sliders-horizontal-bold.svg)
-  static const slidersHorizontal = PhosphorFlatIconData(0xe434, 'Bold');
+  static const slidersHorizontal = IconData(0xe434,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slideshow-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/slideshow-bold.svg)
-  static const slideshow = PhosphorFlatIconData(0xed32, 'Bold');
+  static const slideshow = IconData(0xed32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-bold.svg)
-  static const smiley = PhosphorFlatIconData(0xe436, 'Bold');
+  static const smiley = IconData(0xe436,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-angry-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-angry-bold.svg)
-  static const smileyAngry = PhosphorFlatIconData(0xec62, 'Bold');
+  static const smileyAngry = IconData(0xec62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-blank-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-blank-bold.svg)
-  static const smileyBlank = PhosphorFlatIconData(0xe438, 'Bold');
+  static const smileyBlank = IconData(0xe438,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-meh-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-meh-bold.svg)
-  static const smileyMeh = PhosphorFlatIconData(0xe43a, 'Bold');
+  static const smileyMeh = IconData(0xe43a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-melting-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-melting-bold.svg)
-  static const smileyMelting = PhosphorFlatIconData(0xee56, 'Bold');
+  static const smileyMelting = IconData(0xee56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-nervous-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-nervous-bold.svg)
-  static const smileyNervous = PhosphorFlatIconData(0xe43c, 'Bold');
+  static const smileyNervous = IconData(0xe43c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sad-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-sad-bold.svg)
-  static const smileySad = PhosphorFlatIconData(0xe43e, 'Bold');
+  static const smileySad = IconData(0xe43e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sticker-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-sticker-bold.svg)
-  static const smileySticker = PhosphorFlatIconData(0xe440, 'Bold');
+  static const smileySticker = IconData(0xe440,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-wink-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-wink-bold.svg)
-  static const smileyWink = PhosphorFlatIconData(0xe666, 'Bold');
+  static const smileyWink = IconData(0xe666,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-x-eyes-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/smiley-x-eyes-bold.svg)
-  static const smileyXEyes = PhosphorFlatIconData(0xe442, 'Bold');
+  static const smileyXEyes = IconData(0xe442,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snapchat-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/snapchat-logo-bold.svg)
-  static const snapchatLogo = PhosphorFlatIconData(0xe668, 'Bold');
+  static const snapchatLogo = IconData(0xe668,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sneaker-bold.svg)
-  static const sneaker = PhosphorFlatIconData(0xe80c, 'Bold');
+  static const sneaker = IconData(0xe80c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-move-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sneaker-move-bold.svg)
-  static const sneakerMove = PhosphorFlatIconData(0xed60, 'Bold');
+  static const sneakerMove = IconData(0xed60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snowflake-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/snowflake-bold.svg)
-  static const snowflake = PhosphorFlatIconData(0xe5aa, 'Bold');
+  static const snowflake = IconData(0xe5aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soccer-ball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/soccer-ball-bold.svg)
-  static const soccerBall = PhosphorFlatIconData(0xe716, 'Bold');
+  static const soccerBall = IconData(0xe716,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sock-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sock-bold.svg)
-  static const sock = PhosphorFlatIconData(0xecce, 'Bold');
+  static const sock = IconData(0xecce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-panel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/solar-panel-bold.svg)
-  static const solarPanel = PhosphorFlatIconData(0xed7a, 'Bold');
+  static const solarPanel = IconData(0xed7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-roof-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/solar-roof-bold.svg)
-  static const solarRoof = PhosphorFlatIconData(0xed7b, 'Bold');
+  static const solarRoof = IconData(0xed7b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-ascending-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sort-ascending-bold.svg)
-  static const sortAscending = PhosphorFlatIconData(0xe444, 'Bold');
+  static const sortAscending = IconData(0xe444,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-descending-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sort-descending-bold.svg)
-  static const sortDescending = PhosphorFlatIconData(0xe446, 'Bold');
+  static const sortDescending = IconData(0xe446,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soundcloud-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/soundcloud-logo-bold.svg)
-  static const soundcloudLogo = PhosphorFlatIconData(0xe8de, 'Bold');
+  static const soundcloudLogo = IconData(0xe8de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spade-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/spade-bold.svg)
-  static const spade = PhosphorFlatIconData(0xe448, 'Bold');
+  static const spade = IconData(0xe448,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sparkle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sparkle-bold.svg)
-  static const sparkle = PhosphorFlatIconData(0xe6a2, 'Bold');
+  static const sparkle = IconData(0xe6a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-hifi-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-hifi-bold.svg)
-  static const speakerHifi = PhosphorFlatIconData(0xea08, 'Bold');
+  static const speakerHifi = IconData(0xea08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-high-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-high-bold.svg)
-  static const speakerHigh = PhosphorFlatIconData(0xe44a, 'Bold');
+  static const speakerHigh = IconData(0xe44a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-low-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-low-bold.svg)
-  static const speakerLow = PhosphorFlatIconData(0xe44c, 'Bold');
+  static const speakerLow = IconData(0xe44c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-none-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-none-bold.svg)
-  static const speakerNone = PhosphorFlatIconData(0xe44e, 'Bold');
+  static const speakerNone = IconData(0xe44e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-high-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-simple-high-bold.svg)
-  static const speakerSimpleHigh = PhosphorFlatIconData(0xe450, 'Bold');
+  static const speakerSimpleHigh = IconData(0xe450,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-low-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-simple-low-bold.svg)
-  static const speakerSimpleLow = PhosphorFlatIconData(0xe452, 'Bold');
+  static const speakerSimpleLow = IconData(0xe452,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-none-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-simple-none-bold.svg)
-  static const speakerSimpleNone = PhosphorFlatIconData(0xe454, 'Bold');
+  static const speakerSimpleNone = IconData(0xe454,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-simple-slash-bold.svg)
-  static const speakerSimpleSlash = PhosphorFlatIconData(0xe456, 'Bold');
+  static const speakerSimpleSlash = IconData(0xe456,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-simple-x-bold.svg)
-  static const speakerSimpleX = PhosphorFlatIconData(0xe458, 'Bold');
+  static const speakerSimpleX = IconData(0xe458,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-slash-bold.svg)
-  static const speakerSlash = PhosphorFlatIconData(0xe45a, 'Bold');
+  static const speakerSlash = IconData(0xe45a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speaker-x-bold.svg)
-  static const speakerX = PhosphorFlatIconData(0xe45c, 'Bold');
+  static const speakerX = IconData(0xe45c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speedometer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/speedometer-bold.svg)
-  static const speedometer = PhosphorFlatIconData(0xee74, 'Bold');
+  static const speedometer = IconData(0xee74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sphere-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sphere-bold.svg)
-  static const sphere = PhosphorFlatIconData(0xee66, 'Bold');
+  static const sphere = IconData(0xee66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/spinner-bold.svg)
-  static const spinner = PhosphorFlatIconData(0xe66a, 'Bold');
+  static const spinner = IconData(0xe66a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-ball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/spinner-ball-bold.svg)
-  static const spinnerBall = PhosphorFlatIconData(0xee28, 'Bold');
+  static const spinnerBall = IconData(0xee28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-gap-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/spinner-gap-bold.svg)
-  static const spinnerGap = PhosphorFlatIconData(0xe66c, 'Bold');
+  static const spinnerGap = IconData(0xe66c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spiral-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/spiral-bold.svg)
-  static const spiral = PhosphorFlatIconData(0xe9fa, 'Bold');
+  static const spiral = IconData(0xe9fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/split-horizontal-bold.svg)
-  static const splitHorizontal = PhosphorFlatIconData(0xe872, 'Bold');
+  static const splitHorizontal = IconData(0xe872,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/split-vertical-bold.svg)
-  static const splitVertical = PhosphorFlatIconData(0xe876, 'Bold');
+  static const splitVertical = IconData(0xe876,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spotify-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/spotify-logo-bold.svg)
-  static const spotifyLogo = PhosphorFlatIconData(0xe66e, 'Bold');
+  static const spotifyLogo = IconData(0xe66e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spray-bottle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/spray-bottle-bold.svg)
-  static const sprayBottle = PhosphorFlatIconData(0xe7e4, 'Bold');
+  static const sprayBottle = IconData(0xe7e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/square-bold.svg)
-  static const square = PhosphorFlatIconData(0xe45e, 'Bold');
+  static const square = IconData(0xe45e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/square-half-bold.svg)
-  static const squareHalf = PhosphorFlatIconData(0xe462, 'Bold');
+  static const squareHalf = IconData(0xe462,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-bottom-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/square-half-bottom-bold.svg)
-  static const squareHalfBottom = PhosphorFlatIconData(0xeb16, 'Bold');
+  static const squareHalfBottom = IconData(0xeb16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/square-logo-bold.svg)
-  static const squareLogo = PhosphorFlatIconData(0xe690, 'Bold');
+  static const squareLogo = IconData(0xe690,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-horizontal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/square-split-horizontal-bold.svg)
-  static const squareSplitHorizontal = PhosphorFlatIconData(0xe870, 'Bold');
+  static const squareSplitHorizontal = IconData(0xe870,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-vertical-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/square-split-vertical-bold.svg)
-  static const squareSplitVertical = PhosphorFlatIconData(0xe874, 'Bold');
+  static const squareSplitVertical = IconData(0xe874,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![squares-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/squares-four-bold.svg)
-  static const squaresFour = PhosphorFlatIconData(0xe464, 'Bold');
+  static const squaresFour = IconData(0xe464,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stack-bold.svg)
-  static const stack = PhosphorFlatIconData(0xe466, 'Bold');
+  static const stack = IconData(0xe466,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stack-minus-bold.svg)
-  static const stackMinus = PhosphorFlatIconData(0xedf4, 'Bold');
+  static const stackMinus = IconData(0xedf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-overflow-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stack-overflow-logo-bold.svg)
-  static const stackOverflowLogo = PhosphorFlatIconData(0xeb78, 'Bold');
+  static const stackOverflowLogo = IconData(0xeb78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stack-plus-bold.svg)
-  static const stackPlus = PhosphorFlatIconData(0xedf6, 'Bold');
+  static const stackPlus = IconData(0xedf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stack-simple-bold.svg)
-  static const stackSimple = PhosphorFlatIconData(0xe468, 'Bold');
+  static const stackSimple = IconData(0xe468,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stairs-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stairs-bold.svg)
-  static const stairs = PhosphorFlatIconData(0xe8ec, 'Bold');
+  static const stairs = IconData(0xe8ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stamp-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stamp-bold.svg)
-  static const stamp = PhosphorFlatIconData(0xea48, 'Bold');
+  static const stamp = IconData(0xea48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![standard-definition-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/standard-definition-bold.svg)
-  static const standardDefinition = PhosphorFlatIconData(0xea90, 'Bold');
+  static const standardDefinition = IconData(0xea90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/star-bold.svg)
-  static const star = PhosphorFlatIconData(0xe46a, 'Bold');
+  static const star = IconData(0xe46a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-and-crescent-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/star-and-crescent-bold.svg)
-  static const starAndCrescent = PhosphorFlatIconData(0xecf4, 'Bold');
+  static const starAndCrescent = IconData(0xecf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/star-four-bold.svg)
-  static const starFour = PhosphorFlatIconData(0xe6a4, 'Bold');
+  static const starFour = IconData(0xe6a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-half-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/star-half-bold.svg)
-  static const starHalf = PhosphorFlatIconData(0xe70a, 'Bold');
+  static const starHalf = IconData(0xe70a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-of-david-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/star-of-david-bold.svg)
-  static const starOfDavid = PhosphorFlatIconData(0xe89e, 'Bold');
+  static const starOfDavid = IconData(0xe89e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steam-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/steam-logo-bold.svg)
-  static const steamLogo = PhosphorFlatIconData(0xead4, 'Bold');
+  static const steamLogo = IconData(0xead4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steering-wheel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/steering-wheel-bold.svg)
-  static const steeringWheel = PhosphorFlatIconData(0xe9ac, 'Bold');
+  static const steeringWheel = IconData(0xe9ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steps-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/steps-bold.svg)
-  static const steps = PhosphorFlatIconData(0xecbe, 'Bold');
+  static const steps = IconData(0xecbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stethoscope-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stethoscope-bold.svg)
-  static const stethoscope = PhosphorFlatIconData(0xe7ea, 'Bold');
+  static const stethoscope = IconData(0xe7ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sticker-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sticker-bold.svg)
-  static const sticker = PhosphorFlatIconData(0xe5ac, 'Bold');
+  static const sticker = IconData(0xe5ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stool-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stool-bold.svg)
-  static const stool = PhosphorFlatIconData(0xea44, 'Bold');
+  static const stool = IconData(0xea44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stop-bold.svg)
-  static const stop = PhosphorFlatIconData(0xe46c, 'Bold');
+  static const stop = IconData(0xe46c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stop-circle-bold.svg)
-  static const stopCircle = PhosphorFlatIconData(0xe46e, 'Bold');
+  static const stopCircle = IconData(0xe46e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![storefront-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/storefront-bold.svg)
-  static const storefront = PhosphorFlatIconData(0xe470, 'Bold');
+  static const storefront = IconData(0xe470,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![strategy-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/strategy-bold.svg)
-  static const strategy = PhosphorFlatIconData(0xea3a, 'Bold');
+  static const strategy = IconData(0xea3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stripe-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/stripe-logo-bold.svg)
-  static const stripeLogo = PhosphorFlatIconData(0xe698, 'Bold');
+  static const stripeLogo = IconData(0xe698,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![student-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/student-bold.svg)
-  static const student = PhosphorFlatIconData(0xe73e, 'Bold');
+  static const student = IconData(0xe73e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-of-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/subset-of-bold.svg)
-  static const subsetOf = PhosphorFlatIconData(0xedc0, 'Bold');
+  static const subsetOf = IconData(0xedc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-proper-of-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/subset-proper-of-bold.svg)
-  static const subsetProperOf = PhosphorFlatIconData(0xedb6, 'Bold');
+  static const subsetProperOf = IconData(0xedb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/subtitles-bold.svg)
-  static const subtitles = PhosphorFlatIconData(0xe1a8, 'Bold');
+  static const subtitles = IconData(0xe1a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/subtitles-slash-bold.svg)
-  static const subtitlesSlash = PhosphorFlatIconData(0xe1a6, 'Bold');
+  static const subtitlesSlash = IconData(0xe1a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/subtract-bold.svg)
-  static const subtract = PhosphorFlatIconData(0xebd6, 'Bold');
+  static const subtract = IconData(0xebd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/subtract-square-bold.svg)
-  static const subtractSquare = PhosphorFlatIconData(0xebd4, 'Bold');
+  static const subtractSquare = IconData(0xebd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subway-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/subway-bold.svg)
-  static const subway = PhosphorFlatIconData(0xe498, 'Bold');
+  static const subway = IconData(0xe498,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/suitcase-bold.svg)
-  static const suitcase = PhosphorFlatIconData(0xe5ae, 'Bold');
+  static const suitcase = IconData(0xe5ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-rolling-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/suitcase-rolling-bold.svg)
-  static const suitcaseRolling = PhosphorFlatIconData(0xe9b0, 'Bold');
+  static const suitcaseRolling = IconData(0xe9b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/suitcase-simple-bold.svg)
-  static const suitcaseSimple = PhosphorFlatIconData(0xe5b0, 'Bold');
+  static const suitcaseSimple = IconData(0xe5b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sun-bold.svg)
-  static const sun = PhosphorFlatIconData(0xe472, 'Bold');
+  static const sun = IconData(0xe472,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-dim-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sun-dim-bold.svg)
-  static const sunDim = PhosphorFlatIconData(0xe474, 'Bold');
+  static const sunDim = IconData(0xe474,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-horizon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sun-horizon-bold.svg)
-  static const sunHorizon = PhosphorFlatIconData(0xe5b6, 'Bold');
+  static const sunHorizon = IconData(0xe5b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sunglasses-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sunglasses-bold.svg)
-  static const sunglasses = PhosphorFlatIconData(0xe816, 'Bold');
+  static const sunglasses = IconData(0xe816,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-of-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/superset-of-bold.svg)
-  static const supersetOf = PhosphorFlatIconData(0xedb8, 'Bold');
+  static const supersetOf = IconData(0xedb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-proper-of-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/superset-proper-of-bold.svg)
-  static const supersetProperOf = PhosphorFlatIconData(0xedb4, 'Bold');
+  static const supersetProperOf = IconData(0xedb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swap-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/swap-bold.svg)
-  static const swap = PhosphorFlatIconData(0xe83c, 'Bold');
+  static const swap = IconData(0xe83c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swatches-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/swatches-bold.svg)
-  static const swatches = PhosphorFlatIconData(0xe5b8, 'Bold');
+  static const swatches = IconData(0xe5b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swimming-pool-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/swimming-pool-bold.svg)
-  static const swimmingPool = PhosphorFlatIconData(0xecb6, 'Bold');
+  static const swimmingPool = IconData(0xecb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sword-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/sword-bold.svg)
-  static const sword = PhosphorFlatIconData(0xe5ba, 'Bold');
+  static const sword = IconData(0xe5ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![synagogue-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/synagogue-bold.svg)
-  static const synagogue = PhosphorFlatIconData(0xecec, 'Bold');
+  static const synagogue = IconData(0xecec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![syringe-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/syringe-bold.svg)
-  static const syringe = PhosphorFlatIconData(0xe968, 'Bold');
+  static const syringe = IconData(0xe968,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![t-shirt-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/t-shirt-bold.svg)
-  static const tShirt = PhosphorFlatIconData(0xe670, 'Bold');
+  static const tShirt = IconData(0xe670,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![table-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/table-bold.svg)
-  static const table = PhosphorFlatIconData(0xe476, 'Bold');
+  static const table = IconData(0xe476,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tabs-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tabs-bold.svg)
-  static const tabs = PhosphorFlatIconData(0xe778, 'Bold');
+  static const tabs = IconData(0xe778,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tag-bold.svg)
-  static const tag = PhosphorFlatIconData(0xe478, 'Bold');
+  static const tag = IconData(0xe478,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-chevron-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tag-chevron-bold.svg)
-  static const tagChevron = PhosphorFlatIconData(0xe672, 'Bold');
+  static const tagChevron = IconData(0xe672,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tag-simple-bold.svg)
-  static const tagSimple = PhosphorFlatIconData(0xe47a, 'Bold');
+  static const tagSimple = IconData(0xe47a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![target-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/target-bold.svg)
-  static const target = PhosphorFlatIconData(0xe47c, 'Bold');
+  static const target = IconData(0xe47c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![taxi-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/taxi-bold.svg)
-  static const taxi = PhosphorFlatIconData(0xe902, 'Bold');
+  static const taxi = IconData(0xe902,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tea-bag-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tea-bag-bold.svg)
-  static const teaBag = PhosphorFlatIconData(0xe8e6, 'Bold');
+  static const teaBag = IconData(0xe8e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![telegram-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/telegram-logo-bold.svg)
-  static const telegramLogo = PhosphorFlatIconData(0xe5bc, 'Bold');
+  static const telegramLogo = IconData(0xe5bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/television-bold.svg)
-  static const television = PhosphorFlatIconData(0xe754, 'Bold');
+  static const television = IconData(0xe754,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/television-simple-bold.svg)
-  static const televisionSimple = PhosphorFlatIconData(0xeae6, 'Bold');
+  static const televisionSimple = IconData(0xeae6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tennis-ball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tennis-ball-bold.svg)
-  static const tennisBall = PhosphorFlatIconData(0xe720, 'Bold');
+  static const tennisBall = IconData(0xe720,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tent-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tent-bold.svg)
-  static const tent = PhosphorFlatIconData(0xe8ba, 'Bold');
+  static const tent = IconData(0xe8ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/terminal-bold.svg)
-  static const terminal = PhosphorFlatIconData(0xe47e, 'Bold');
+  static const terminal = IconData(0xe47e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-window-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/terminal-window-bold.svg)
-  static const terminalWindow = PhosphorFlatIconData(0xeae8, 'Bold');
+  static const terminalWindow = IconData(0xeae8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![test-tube-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/test-tube-bold.svg)
-  static const testTube = PhosphorFlatIconData(0xe7a0, 'Bold');
+  static const testTube = IconData(0xe7a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-a-underline-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-a-underline-bold.svg)
-  static const textAUnderline = PhosphorFlatIconData(0xed34, 'Bold');
+  static const textAUnderline = IconData(0xed34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-aa-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-aa-bold.svg)
-  static const textAa = PhosphorFlatIconData(0xe6ee, 'Bold');
+  static const textAa = IconData(0xe6ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-center-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-align-center-bold.svg)
-  static const textAlignCenter = PhosphorFlatIconData(0xe480, 'Bold');
+  static const textAlignCenter = IconData(0xe480,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-justify-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-align-justify-bold.svg)
-  static const textAlignJustify = PhosphorFlatIconData(0xe482, 'Bold');
+  static const textAlignJustify = IconData(0xe482,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-align-left-bold.svg)
-  static const textAlignLeft = PhosphorFlatIconData(0xe484, 'Bold');
+  static const textAlignLeft = IconData(0xe484,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-align-right-bold.svg)
-  static const textAlignRight = PhosphorFlatIconData(0xe486, 'Bold');
+  static const textAlignRight = IconData(0xe486,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-b-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-b-bold.svg)
-  static const textB = PhosphorFlatIconData(0xe5be, 'Bold');
+  static const textB = IconData(0xe5be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-columns-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-columns-bold.svg)
-  static const textColumns = PhosphorFlatIconData(0xec96, 'Bold');
+  static const textColumns = IconData(0xec96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-h-bold.svg)
-  static const textH = PhosphorFlatIconData(0xe6ba, 'Bold');
+  static const textH = IconData(0xe6ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-five-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-h-five-bold.svg)
-  static const textHFive = PhosphorFlatIconData(0xe6c4, 'Bold');
+  static const textHFive = IconData(0xe6c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-h-four-bold.svg)
-  static const textHFour = PhosphorFlatIconData(0xe6c2, 'Bold');
+  static const textHFour = IconData(0xe6c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-one-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-h-one-bold.svg)
-  static const textHOne = PhosphorFlatIconData(0xe6bc, 'Bold');
+  static const textHOne = IconData(0xe6bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-six-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-h-six-bold.svg)
-  static const textHSix = PhosphorFlatIconData(0xe6c6, 'Bold');
+  static const textHSix = IconData(0xe6c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-h-three-bold.svg)
-  static const textHThree = PhosphorFlatIconData(0xe6c0, 'Bold');
+  static const textHThree = IconData(0xe6c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-two-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-h-two-bold.svg)
-  static const textHTwo = PhosphorFlatIconData(0xe6be, 'Bold');
+  static const textHTwo = IconData(0xe6be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-indent-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-indent-bold.svg)
-  static const textIndent = PhosphorFlatIconData(0xea1e, 'Bold');
+  static const textIndent = IconData(0xea1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-italic-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-italic-bold.svg)
-  static const textItalic = PhosphorFlatIconData(0xe5c0, 'Bold');
+  static const textItalic = IconData(0xe5c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-outdent-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-outdent-bold.svg)
-  static const textOutdent = PhosphorFlatIconData(0xea1c, 'Bold');
+  static const textOutdent = IconData(0xea1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-strikethrough-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-strikethrough-bold.svg)
-  static const textStrikethrough = PhosphorFlatIconData(0xe5c2, 'Bold');
+  static const textStrikethrough = IconData(0xe5c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-subscript-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-subscript-bold.svg)
-  static const textSubscript = PhosphorFlatIconData(0xec98, 'Bold');
+  static const textSubscript = IconData(0xec98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-superscript-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-superscript-bold.svg)
-  static const textSuperscript = PhosphorFlatIconData(0xec9a, 'Bold');
+  static const textSuperscript = IconData(0xec9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-t-bold.svg)
-  static const textT = PhosphorFlatIconData(0xe48a, 'Bold');
+  static const textT = IconData(0xe48a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-t-slash-bold.svg)
-  static const textTSlash = PhosphorFlatIconData(0xe488, 'Bold');
+  static const textTSlash = IconData(0xe488,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-underline-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/text-underline-bold.svg)
-  static const textUnderline = PhosphorFlatIconData(0xe5c4, 'Bold');
+  static const textUnderline = IconData(0xe5c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![textbox-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/textbox-bold.svg)
-  static const textbox = PhosphorFlatIconData(0xeb0a, 'Bold');
+  static const textbox = IconData(0xeb0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/thermometer-bold.svg)
-  static const thermometer = PhosphorFlatIconData(0xe5c6, 'Bold');
+  static const thermometer = IconData(0xe5c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-cold-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/thermometer-cold-bold.svg)
-  static const thermometerCold = PhosphorFlatIconData(0xe5c8, 'Bold');
+  static const thermometerCold = IconData(0xe5c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-hot-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/thermometer-hot-bold.svg)
-  static const thermometerHot = PhosphorFlatIconData(0xe5ca, 'Bold');
+  static const thermometerHot = IconData(0xe5ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/thermometer-simple-bold.svg)
-  static const thermometerSimple = PhosphorFlatIconData(0xe5cc, 'Bold');
+  static const thermometerSimple = IconData(0xe5cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![threads-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/threads-logo-bold.svg)
-  static const threadsLogo = PhosphorFlatIconData(0xed9e, 'Bold');
+  static const threadsLogo = IconData(0xed9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![three-d-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/three-d-bold.svg)
-  static const threeD = PhosphorFlatIconData(0xea5a, 'Bold');
+  static const threeD = IconData(0xea5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/thumbs-down-bold.svg)
-  static const thumbsDown = PhosphorFlatIconData(0xe48c, 'Bold');
+  static const thumbsDown = IconData(0xe48c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/thumbs-up-bold.svg)
-  static const thumbsUp = PhosphorFlatIconData(0xe48e, 'Bold');
+  static const thumbsUp = IconData(0xe48e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ticket-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/ticket-bold.svg)
-  static const ticket = PhosphorFlatIconData(0xe490, 'Bold');
+  static const ticket = IconData(0xe490,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tidal-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tidal-logo-bold.svg)
-  static const tidalLogo = PhosphorFlatIconData(0xed1c, 'Bold');
+  static const tidalLogo = IconData(0xed1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tiktok-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tiktok-logo-bold.svg)
-  static const tiktokLogo = PhosphorFlatIconData(0xeaf2, 'Bold');
+  static const tiktokLogo = IconData(0xeaf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tilde-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tilde-bold.svg)
-  static const tilde = PhosphorFlatIconData(0xeda8, 'Bold');
+  static const tilde = IconData(0xeda8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![timer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/timer-bold.svg)
-  static const timer = PhosphorFlatIconData(0xe492, 'Bold');
+  static const timer = IconData(0xe492,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tip-jar-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tip-jar-bold.svg)
-  static const tipJar = PhosphorFlatIconData(0xe7e2, 'Bold');
+  static const tipJar = IconData(0xe7e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tipi-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tipi-bold.svg)
-  static const tipi = PhosphorFlatIconData(0xed30, 'Bold');
+  static const tipi = IconData(0xed30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tire-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tire-bold.svg)
-  static const tire = PhosphorFlatIconData(0xedd2, 'Bold');
+  static const tire = IconData(0xedd2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-left-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/toggle-left-bold.svg)
-  static const toggleLeft = PhosphorFlatIconData(0xe674, 'Bold');
+  static const toggleLeft = IconData(0xe674,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-right-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/toggle-right-bold.svg)
-  static const toggleRight = PhosphorFlatIconData(0xe676, 'Bold');
+  static const toggleRight = IconData(0xe676,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/toilet-bold.svg)
-  static const toilet = PhosphorFlatIconData(0xe79a, 'Bold');
+  static const toilet = IconData(0xe79a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-paper-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/toilet-paper-bold.svg)
-  static const toiletPaper = PhosphorFlatIconData(0xe79c, 'Bold');
+  static const toiletPaper = IconData(0xe79c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toolbox-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/toolbox-bold.svg)
-  static const toolbox = PhosphorFlatIconData(0xeca0, 'Bold');
+  static const toolbox = IconData(0xeca0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tooth-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tooth-bold.svg)
-  static const tooth = PhosphorFlatIconData(0xe9cc, 'Bold');
+  static const tooth = IconData(0xe9cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tornado-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tornado-bold.svg)
-  static const tornado = PhosphorFlatIconData(0xe88c, 'Bold');
+  static const tornado = IconData(0xe88c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tote-bold.svg)
-  static const tote = PhosphorFlatIconData(0xe494, 'Bold');
+  static const tote = IconData(0xe494,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tote-simple-bold.svg)
-  static const toteSimple = PhosphorFlatIconData(0xe678, 'Bold');
+  static const toteSimple = IconData(0xe678,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![towel-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/towel-bold.svg)
-  static const towel = PhosphorFlatIconData(0xede6, 'Bold');
+  static const towel = IconData(0xede6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tractor-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tractor-bold.svg)
-  static const tractor = PhosphorFlatIconData(0xec6e, 'Bold');
+  static const tractor = IconData(0xec6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trademark-bold.svg)
-  static const trademark = PhosphorFlatIconData(0xe9f0, 'Bold');
+  static const trademark = IconData(0xe9f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-registered-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trademark-registered-bold.svg)
-  static const trademarkRegistered = PhosphorFlatIconData(0xe3f4, 'Bold');
+  static const trademarkRegistered = IconData(0xe3f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-cone-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/traffic-cone-bold.svg)
-  static const trafficCone = PhosphorFlatIconData(0xe9a8, 'Bold');
+  static const trafficCone = IconData(0xe9a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-sign-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/traffic-sign-bold.svg)
-  static const trafficSign = PhosphorFlatIconData(0xe67a, 'Bold');
+  static const trafficSign = IconData(0xe67a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-signal-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/traffic-signal-bold.svg)
-  static const trafficSignal = PhosphorFlatIconData(0xe9aa, 'Bold');
+  static const trafficSignal = IconData(0xe9aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/train-bold.svg)
-  static const train = PhosphorFlatIconData(0xe496, 'Bold');
+  static const train = IconData(0xe496,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-regional-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/train-regional-bold.svg)
-  static const trainRegional = PhosphorFlatIconData(0xe49e, 'Bold');
+  static const trainRegional = IconData(0xe49e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/train-simple-bold.svg)
-  static const trainSimple = PhosphorFlatIconData(0xe4a0, 'Bold');
+  static const trainSimple = IconData(0xe4a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tram-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tram-bold.svg)
-  static const tram = PhosphorFlatIconData(0xe9ec, 'Bold');
+  static const tram = IconData(0xe9ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![translate-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/translate-bold.svg)
-  static const translate = PhosphorFlatIconData(0xe4a2, 'Bold');
+  static const translate = IconData(0xe4a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trash-bold.svg)
-  static const trash = PhosphorFlatIconData(0xe4a6, 'Bold');
+  static const trash = IconData(0xe4a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trash-simple-bold.svg)
-  static const trashSimple = PhosphorFlatIconData(0xe4a8, 'Bold');
+  static const trashSimple = IconData(0xe4a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tray-bold.svg)
-  static const tray = PhosphorFlatIconData(0xe4aa, 'Bold');
+  static const tray = IconData(0xe4aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tray-arrow-down-bold.svg)
-  static const trayArrowDown = PhosphorFlatIconData(0xe010, 'Bold');
+  static const trayArrowDown = IconData(0xe010,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tray-arrow-up-bold.svg)
-  static const trayArrowUp = PhosphorFlatIconData(0xee52, 'Bold');
+  static const trayArrowUp = IconData(0xee52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![treasure-chest-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/treasure-chest-bold.svg)
-  static const treasureChest = PhosphorFlatIconData(0xede2, 'Bold');
+  static const treasureChest = IconData(0xede2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tree-bold.svg)
-  static const tree = PhosphorFlatIconData(0xe6da, 'Bold');
+  static const tree = IconData(0xe6da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-evergreen-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tree-evergreen-bold.svg)
-  static const treeEvergreen = PhosphorFlatIconData(0xe6dc, 'Bold');
+  static const treeEvergreen = IconData(0xe6dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-palm-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tree-palm-bold.svg)
-  static const treePalm = PhosphorFlatIconData(0xe91a, 'Bold');
+  static const treePalm = IconData(0xe91a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-structure-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tree-structure-bold.svg)
-  static const treeStructure = PhosphorFlatIconData(0xe67c, 'Bold');
+  static const treeStructure = IconData(0xe67c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-view-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tree-view-bold.svg)
-  static const treeView = PhosphorFlatIconData(0xee48, 'Bold');
+  static const treeView = IconData(0xee48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-down-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trend-down-bold.svg)
-  static const trendDown = PhosphorFlatIconData(0xe4ac, 'Bold');
+  static const trendDown = IconData(0xe4ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-up-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trend-up-bold.svg)
-  static const trendUp = PhosphorFlatIconData(0xe4ae, 'Bold');
+  static const trendUp = IconData(0xe4ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/triangle-bold.svg)
-  static const triangle = PhosphorFlatIconData(0xe4b0, 'Bold');
+  static const triangle = IconData(0xe4b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-dashed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/triangle-dashed-bold.svg)
-  static const triangleDashed = PhosphorFlatIconData(0xe4b2, 'Bold');
+  static const triangleDashed = IconData(0xe4b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trolley-bold.svg)
-  static const trolley = PhosphorFlatIconData(0xe5b2, 'Bold');
+  static const trolley = IconData(0xe5b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-suitcase-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trolley-suitcase-bold.svg)
-  static const trolleySuitcase = PhosphorFlatIconData(0xe5b4, 'Bold');
+  static const trolleySuitcase = IconData(0xe5b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trophy-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/trophy-bold.svg)
-  static const trophy = PhosphorFlatIconData(0xe67e, 'Bold');
+  static const trophy = IconData(0xe67e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/truck-bold.svg)
-  static const truck = PhosphorFlatIconData(0xe4b4, 'Bold');
+  static const truck = IconData(0xe4b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-trailer-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/truck-trailer-bold.svg)
-  static const truckTrailer = PhosphorFlatIconData(0xe4b6, 'Bold');
+  static const truckTrailer = IconData(0xe4b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tumblr-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/tumblr-logo-bold.svg)
-  static const tumblrLogo = PhosphorFlatIconData(0xe8d4, 'Bold');
+  static const tumblrLogo = IconData(0xe8d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitch-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/twitch-logo-bold.svg)
-  static const twitchLogo = PhosphorFlatIconData(0xe5ce, 'Bold');
+  static const twitchLogo = IconData(0xe5ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitter-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/twitter-logo-bold.svg)
-  static const twitterLogo = PhosphorFlatIconData(0xe4ba, 'Bold');
+  static const twitterLogo = IconData(0xe4ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/umbrella-bold.svg)
-  static const umbrella = PhosphorFlatIconData(0xe684, 'Bold');
+  static const umbrella = IconData(0xe684,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/umbrella-simple-bold.svg)
-  static const umbrellaSimple = PhosphorFlatIconData(0xe686, 'Bold');
+  static const umbrellaSimple = IconData(0xe686,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![union-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/union-bold.svg)
-  static const union = PhosphorFlatIconData(0xedbe, 'Bold');
+  static const union = IconData(0xedbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/unite-bold.svg)
-  static const unite = PhosphorFlatIconData(0xe87e, 'Bold');
+  static const unite = IconData(0xe87e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/unite-square-bold.svg)
-  static const uniteSquare = PhosphorFlatIconData(0xe878, 'Bold');
+  static const uniteSquare = IconData(0xe878,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/upload-bold.svg)
-  static const upload = PhosphorFlatIconData(0xe4be, 'Bold');
+  static const upload = IconData(0xe4be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-simple-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/upload-simple-bold.svg)
-  static const uploadSimple = PhosphorFlatIconData(0xe4c0, 'Bold');
+  static const uploadSimple = IconData(0xe4c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![usb-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/usb-bold.svg)
-  static const usb = PhosphorFlatIconData(0xe956, 'Bold');
+  static const usb = IconData(0xe956,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-bold.svg)
-  static const user = PhosphorFlatIconData(0xe4c2, 'Bold');
+  static const user = IconData(0xe4c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-check-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-check-bold.svg)
-  static const userCheck = PhosphorFlatIconData(0xeafa, 'Bold');
+  static const userCheck = IconData(0xeafa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-circle-bold.svg)
-  static const userCircle = PhosphorFlatIconData(0xe4c4, 'Bold');
+  static const userCircle = IconData(0xe4c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-check-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-circle-check-bold.svg)
-  static const userCircleCheck = PhosphorFlatIconData(0xec38, 'Bold');
+  static const userCircleCheck = IconData(0xec38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-dashed-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-circle-dashed-bold.svg)
-  static const userCircleDashed = PhosphorFlatIconData(0xec36, 'Bold');
+  static const userCircleDashed = IconData(0xec36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-gear-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-circle-gear-bold.svg)
-  static const userCircleGear = PhosphorFlatIconData(0xe4c6, 'Bold');
+  static const userCircleGear = IconData(0xe4c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-circle-minus-bold.svg)
-  static const userCircleMinus = PhosphorFlatIconData(0xe4c8, 'Bold');
+  static const userCircleMinus = IconData(0xe4c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-circle-plus-bold.svg)
-  static const userCirclePlus = PhosphorFlatIconData(0xe4ca, 'Bold');
+  static const userCirclePlus = IconData(0xe4ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-focus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-focus-bold.svg)
-  static const userFocus = PhosphorFlatIconData(0xe6fc, 'Bold');
+  static const userFocus = IconData(0xe6fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-gear-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-gear-bold.svg)
-  static const userGear = PhosphorFlatIconData(0xe4cc, 'Bold');
+  static const userGear = IconData(0xe4cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-list-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-list-bold.svg)
-  static const userList = PhosphorFlatIconData(0xe73c, 'Bold');
+  static const userList = IconData(0xe73c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-minus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-minus-bold.svg)
-  static const userMinus = PhosphorFlatIconData(0xe4ce, 'Bold');
+  static const userMinus = IconData(0xe4ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-plus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-plus-bold.svg)
-  static const userPlus = PhosphorFlatIconData(0xe4d0, 'Bold');
+  static const userPlus = IconData(0xe4d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-rectangle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-rectangle-bold.svg)
-  static const userRectangle = PhosphorFlatIconData(0xe4d2, 'Bold');
+  static const userRectangle = IconData(0xe4d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-sound-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-sound-bold.svg)
-  static const userSound = PhosphorFlatIconData(0xeca8, 'Bold');
+  static const userSound = IconData(0xeca8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-square-bold.svg)
-  static const userSquare = PhosphorFlatIconData(0xe4d4, 'Bold');
+  static const userSquare = IconData(0xe4d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-switch-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/user-switch-bold.svg)
-  static const userSwitch = PhosphorFlatIconData(0xe756, 'Bold');
+  static const userSwitch = IconData(0xe756,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/users-bold.svg)
-  static const users = PhosphorFlatIconData(0xe4d6, 'Bold');
+  static const users = IconData(0xe4d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-four-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/users-four-bold.svg)
-  static const usersFour = PhosphorFlatIconData(0xe68c, 'Bold');
+  static const usersFour = IconData(0xe68c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/users-three-bold.svg)
-  static const usersThree = PhosphorFlatIconData(0xe68e, 'Bold');
+  static const usersThree = IconData(0xe68e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![van-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/van-bold.svg)
-  static const van = PhosphorFlatIconData(0xe826, 'Bold');
+  static const van = IconData(0xe826,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vault-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/vault-bold.svg)
-  static const vault = PhosphorFlatIconData(0xe76e, 'Bold');
+  static const vault = IconData(0xe76e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-three-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/vector-three-bold.svg)
-  static const vectorThree = PhosphorFlatIconData(0xee62, 'Bold');
+  static const vectorThree = IconData(0xee62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-two-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/vector-two-bold.svg)
-  static const vectorTwo = PhosphorFlatIconData(0xee64, 'Bold');
+  static const vectorTwo = IconData(0xee64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vibrate-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/vibrate-bold.svg)
-  static const vibrate = PhosphorFlatIconData(0xe4d8, 'Bold');
+  static const vibrate = IconData(0xe4d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/video-bold.svg)
-  static const video = PhosphorFlatIconData(0xe740, 'Bold');
+  static const video = IconData(0xe740,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/video-camera-bold.svg)
-  static const videoCamera = PhosphorFlatIconData(0xe4da, 'Bold');
+  static const videoCamera = IconData(0xe4da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/video-camera-slash-bold.svg)
-  static const videoCameraSlash = PhosphorFlatIconData(0xe4dc, 'Bold');
+  static const videoCameraSlash = IconData(0xe4dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-conference-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/video-conference-bold.svg)
-  static const videoConference = PhosphorFlatIconData(0xedce, 'Bold');
+  static const videoConference = IconData(0xedce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vignette-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/vignette-bold.svg)
-  static const vignette = PhosphorFlatIconData(0xeba2, 'Bold');
+  static const vignette = IconData(0xeba2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vinyl-record-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/vinyl-record-bold.svg)
-  static const vinylRecord = PhosphorFlatIconData(0xecac, 'Bold');
+  static const vinylRecord = IconData(0xecac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virtual-reality-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/virtual-reality-bold.svg)
-  static const virtualReality = PhosphorFlatIconData(0xe7b8, 'Bold');
+  static const virtualReality = IconData(0xe7b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virus-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/virus-bold.svg)
-  static const virus = PhosphorFlatIconData(0xe7d6, 'Bold');
+  static const virus = IconData(0xe7d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![visor-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/visor-bold.svg)
-  static const visor = PhosphorFlatIconData(0xee2a, 'Bold');
+  static const visor = IconData(0xee2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![voicemail-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/voicemail-bold.svg)
-  static const voicemail = PhosphorFlatIconData(0xe4de, 'Bold');
+  static const voicemail = IconData(0xe4de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![volleyball-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/volleyball-bold.svg)
-  static const volleyball = PhosphorFlatIconData(0xe726, 'Bold');
+  static const volleyball = IconData(0xe726,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wall-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wall-bold.svg)
-  static const wall = PhosphorFlatIconData(0xe688, 'Bold');
+  static const wall = IconData(0xe688,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wallet-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wallet-bold.svg)
-  static const wallet = PhosphorFlatIconData(0xe68a, 'Bold');
+  static const wallet = IconData(0xe68a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warehouse-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/warehouse-bold.svg)
-  static const warehouse = PhosphorFlatIconData(0xecd4, 'Bold');
+  static const warehouse = IconData(0xecd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/warning-bold.svg)
-  static const warning = PhosphorFlatIconData(0xe4e0, 'Bold');
+  static const warning = IconData(0xe4e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/warning-circle-bold.svg)
-  static const warningCircle = PhosphorFlatIconData(0xe4e2, 'Bold');
+  static const warningCircle = IconData(0xe4e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-diamond-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/warning-diamond-bold.svg)
-  static const warningDiamond = PhosphorFlatIconData(0xe7fc, 'Bold');
+  static const warningDiamond = IconData(0xe7fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-octagon-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/warning-octagon-bold.svg)
-  static const warningOctagon = PhosphorFlatIconData(0xe4e4, 'Bold');
+  static const warningOctagon = IconData(0xe4e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![washing-machine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/washing-machine-bold.svg)
-  static const washingMachine = PhosphorFlatIconData(0xede8, 'Bold');
+  static const washingMachine = IconData(0xede8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![watch-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/watch-bold.svg)
-  static const watch = PhosphorFlatIconData(0xe4e6, 'Bold');
+  static const watch = IconData(0xe4e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sawtooth-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wave-sawtooth-bold.svg)
-  static const waveSawtooth = PhosphorFlatIconData(0xea9c, 'Bold');
+  static const waveSawtooth = IconData(0xea9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wave-sine-bold.svg)
-  static const waveSine = PhosphorFlatIconData(0xea9a, 'Bold');
+  static const waveSine = IconData(0xea9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wave-square-bold.svg)
-  static const waveSquare = PhosphorFlatIconData(0xea9e, 'Bold');
+  static const waveSquare = IconData(0xea9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-triangle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wave-triangle-bold.svg)
-  static const waveTriangle = PhosphorFlatIconData(0xeaa0, 'Bold');
+  static const waveTriangle = IconData(0xeaa0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/waveform-bold.svg)
-  static const waveform = PhosphorFlatIconData(0xe802, 'Bold');
+  static const waveform = IconData(0xe802,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/waveform-slash-bold.svg)
-  static const waveformSlash = PhosphorFlatIconData(0xe800, 'Bold');
+  static const waveformSlash = IconData(0xe800,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waves-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/waves-bold.svg)
-  static const waves = PhosphorFlatIconData(0xe6de, 'Bold');
+  static const waves = IconData(0xe6de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/webcam-bold.svg)
-  static const webcam = PhosphorFlatIconData(0xe9b2, 'Bold');
+  static const webcam = IconData(0xe9b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/webcam-slash-bold.svg)
-  static const webcamSlash = PhosphorFlatIconData(0xecdc, 'Bold');
+  static const webcamSlash = IconData(0xecdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webhooks-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/webhooks-logo-bold.svg)
-  static const webhooksLogo = PhosphorFlatIconData(0xecae, 'Bold');
+  static const webhooksLogo = IconData(0xecae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wechat-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wechat-logo-bold.svg)
-  static const wechatLogo = PhosphorFlatIconData(0xe8d2, 'Bold');
+  static const wechatLogo = IconData(0xe8d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![whatsapp-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/whatsapp-logo-bold.svg)
-  static const whatsappLogo = PhosphorFlatIconData(0xe5d0, 'Bold');
+  static const whatsappLogo = IconData(0xe5d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wheelchair-bold.svg)
-  static const wheelchair = PhosphorFlatIconData(0xe4e8, 'Bold');
+  static const wheelchair = IconData(0xe4e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-motion-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wheelchair-motion-bold.svg)
-  static const wheelchairMotion = PhosphorFlatIconData(0xe89a, 'Bold');
+  static const wheelchairMotion = IconData(0xe89a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-high-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wifi-high-bold.svg)
-  static const wifiHigh = PhosphorFlatIconData(0xe4ea, 'Bold');
+  static const wifiHigh = IconData(0xe4ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-low-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wifi-low-bold.svg)
-  static const wifiLow = PhosphorFlatIconData(0xe4ec, 'Bold');
+  static const wifiLow = IconData(0xe4ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-medium-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wifi-medium-bold.svg)
-  static const wifiMedium = PhosphorFlatIconData(0xe4ee, 'Bold');
+  static const wifiMedium = IconData(0xe4ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-none-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wifi-none-bold.svg)
-  static const wifiNone = PhosphorFlatIconData(0xe4f0, 'Bold');
+  static const wifiNone = IconData(0xe4f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-slash-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wifi-slash-bold.svg)
-  static const wifiSlash = PhosphorFlatIconData(0xe4f2, 'Bold');
+  static const wifiSlash = IconData(0xe4f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wifi-x-bold.svg)
-  static const wifiX = PhosphorFlatIconData(0xe4f4, 'Bold');
+  static const wifiX = IconData(0xe4f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wind-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wind-bold.svg)
-  static const wind = PhosphorFlatIconData(0xe5d2, 'Bold');
+  static const wind = IconData(0xe5d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windmill-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/windmill-bold.svg)
-  static const windmill = PhosphorFlatIconData(0xe9f8, 'Bold');
+  static const windmill = IconData(0xe9f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windows-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/windows-logo-bold.svg)
-  static const windowsLogo = PhosphorFlatIconData(0xe692, 'Bold');
+  static const windowsLogo = IconData(0xe692,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wine-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wine-bold.svg)
-  static const wine = PhosphorFlatIconData(0xe6b2, 'Bold');
+  static const wine = IconData(0xe6b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wrench-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/wrench-bold.svg)
-  static const wrench = PhosphorFlatIconData(0xe5d4, 'Bold');
+  static const wrench = IconData(0xe5d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/x-bold.svg)
-  static const x = PhosphorFlatIconData(0xe4f6, 'Bold');
+  static const x = IconData(0xe4f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-circle-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/x-circle-bold.svg)
-  static const xCircle = PhosphorFlatIconData(0xe4f8, 'Bold');
+  static const xCircle = IconData(0xe4f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/x-logo-bold.svg)
-  static const xLogo = PhosphorFlatIconData(0xe4bc, 'Bold');
+  static const xLogo = IconData(0xe4bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-square-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/x-square-bold.svg)
-  static const xSquare = PhosphorFlatIconData(0xe4fa, 'Bold');
+  static const xSquare = IconData(0xe4fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yarn-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/yarn-bold.svg)
-  static const yarn = PhosphorFlatIconData(0xed9a, 'Bold');
+  static const yarn = IconData(0xed9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yin-yang-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/yin-yang-bold.svg)
-  static const yinYang = PhosphorFlatIconData(0xe92a, 'Bold');
+  static const yinYang = IconData(0xe92a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![youtube-logo-bold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/bold/youtube-logo-bold.svg)
-  static const youtubeLogo = PhosphorFlatIconData(0xe4fc, 'Bold');
+  static const youtubeLogo = IconData(0xe4fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 }

--- a/lib/src/phosphor_icons_duotone.dart
+++ b/lib/src/phosphor_icons_duotone.dart
@@ -1,9076 +1,9086 @@
 // Auto generated File
 // DON'T EDIT BY HAND
 
-import 'package:phosphor_flutter/src/phosphor_icon_data.dart';
 import 'package:flutter/widgets.dart';
+
+const String _f = 'PhosphorDuotone';
+const String _p = 'phosphor_flutter';
 
 @staticIconProvider
 class PhosphorIconsDuotone {
   const PhosphorIconsDuotone();
 
   /// ![acorn-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/acorn-duotone.svg)
-  static const acorn = PhosphorDuotoneIconData(
-    0xeb9b,
-    PhosphorIconData(0xeb9a, 'Duotone'),
-  );
+  static const acorn = IconData(0xeb9b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/address-book-duotone.svg)
-  static const addressBook = PhosphorDuotoneIconData(
-    0xe6f9,
-    PhosphorIconData(0xe6f8, 'Duotone'),
-  );
+  static const addressBook = IconData(0xe6f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-tabs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/address-book-tabs-duotone.svg)
-  static const addressBookTabs = PhosphorDuotoneIconData(
-    0xee4f,
-    PhosphorIconData(0xee4e, 'Duotone'),
-  );
+  static const addressBookTabs = IconData(0xee4f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![air-traffic-control-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/air-traffic-control-duotone.svg)
-  static const airTrafficControl = PhosphorDuotoneIconData(
-    0xecd9,
-    PhosphorIconData(0xecd8, 'Duotone'),
-  );
+  static const airTrafficControl = IconData(0xecd9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-duotone.svg)
-  static const airplane = PhosphorDuotoneIconData(
-    0xe003,
-    PhosphorIconData(0xe002, 'Duotone'),
-  );
+  static const airplane = IconData(0xe003,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-in-flight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-in-flight-duotone.svg)
-  static const airplaneInFlight = PhosphorDuotoneIconData(
-    0xe4ff,
-    PhosphorIconData(0xe4fe, 'Duotone'),
-  );
+  static const airplaneInFlight = IconData(0xe4ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-landing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-landing-duotone.svg)
-  static const airplaneLanding = PhosphorDuotoneIconData(
-    0xe503,
-    PhosphorIconData(0xe502, 'Duotone'),
-  );
+  static const airplaneLanding = IconData(0xe503,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-takeoff-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-takeoff-duotone.svg)
-  static const airplaneTakeoff = PhosphorDuotoneIconData(
-    0xe505,
-    PhosphorIconData(0xe504, 'Duotone'),
-  );
+  static const airplaneTakeoff = IconData(0xe505,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-taxiing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-taxiing-duotone.svg)
-  static const airplaneTaxiing = PhosphorDuotoneIconData(
-    0xe501,
-    PhosphorIconData(0xe500, 'Duotone'),
-  );
+  static const airplaneTaxiing = IconData(0xe501,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-tilt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplane-tilt-duotone.svg)
-  static const airplaneTilt = PhosphorDuotoneIconData(
-    0xe5d7,
-    PhosphorIconData(0xe5d6, 'Duotone'),
-  );
+  static const airplaneTilt = IconData(0xe5d7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplay-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/airplay-duotone.svg)
-  static const airplay = PhosphorDuotoneIconData(
-    0xe005,
-    PhosphorIconData(0xe004, 'Duotone'),
-  );
+  static const airplay = IconData(0xe005,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alarm-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/alarm-duotone.svg)
-  static const alarm = PhosphorDuotoneIconData(
-    0xe007,
-    PhosphorIconData(0xe006, 'Duotone'),
-  );
+  static const alarm = IconData(0xe007,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alien-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/alien-duotone.svg)
-  static const alien = PhosphorDuotoneIconData(
-    0xe8a7,
-    PhosphorIconData(0xe8a6, 'Duotone'),
-  );
+  static const alien = IconData(0xe8a7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-bottom-duotone.svg)
-  static const alignBottom = PhosphorDuotoneIconData(
-    0xe507,
-    PhosphorIconData(0xe506, 'Duotone'),
-  );
+  static const alignBottom = IconData(0xe507,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-bottom-simple-duotone.svg)
-  static const alignBottomSimple = PhosphorDuotoneIconData(
-    0xeb0d,
-    PhosphorIconData(0xeb0c, 'Duotone'),
-  );
+  static const alignBottomSimple = IconData(0xeb0d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-center-horizontal-duotone.svg)
-  static const alignCenterHorizontal = PhosphorDuotoneIconData(
-    0xe50b,
-    PhosphorIconData(0xe50a, 'Duotone'),
-  );
+  static const alignCenterHorizontal = IconData(0xe50b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-center-horizontal-simple-duotone.svg)
-  static const alignCenterHorizontalSimple = PhosphorDuotoneIconData(
-    0xeb0f,
-    PhosphorIconData(0xeb0e, 'Duotone'),
-  );
+  static const alignCenterHorizontalSimple = IconData(0xeb0f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-center-vertical-duotone.svg)
-  static const alignCenterVertical = PhosphorDuotoneIconData(
-    0xe50d,
-    PhosphorIconData(0xe50c, 'Duotone'),
-  );
+  static const alignCenterVertical = IconData(0xe50d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-center-vertical-simple-duotone.svg)
-  static const alignCenterVerticalSimple = PhosphorDuotoneIconData(
-    0xeb11,
-    PhosphorIconData(0xeb10, 'Duotone'),
-  );
+  static const alignCenterVerticalSimple = IconData(0xeb11,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-left-duotone.svg)
-  static const alignLeft = PhosphorDuotoneIconData(
-    0xe50f,
-    PhosphorIconData(0xe50e, 'Duotone'),
-  );
+  static const alignLeft = IconData(0xe50f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-left-simple-duotone.svg)
-  static const alignLeftSimple = PhosphorDuotoneIconData(
-    0xeaef,
-    PhosphorIconData(0xeaee, 'Duotone'),
-  );
+  static const alignLeftSimple = IconData(0xeaef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-right-duotone.svg)
-  static const alignRight = PhosphorDuotoneIconData(
-    0xe511,
-    PhosphorIconData(0xe510, 'Duotone'),
-  );
+  static const alignRight = IconData(0xe511,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-right-simple-duotone.svg)
-  static const alignRightSimple = PhosphorDuotoneIconData(
-    0xeb13,
-    PhosphorIconData(0xeb12, 'Duotone'),
-  );
+  static const alignRightSimple = IconData(0xeb13,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-top-duotone.svg)
-  static const alignTop = PhosphorDuotoneIconData(
-    0xe513,
-    PhosphorIconData(0xe512, 'Duotone'),
-  );
+  static const alignTop = IconData(0xe513,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/align-top-simple-duotone.svg)
-  static const alignTopSimple = PhosphorDuotoneIconData(
-    0xeb15,
-    PhosphorIconData(0xeb14, 'Duotone'),
-  );
+  static const alignTopSimple = IconData(0xeb15,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![amazon-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/amazon-logo-duotone.svg)
-  static const amazonLogo = PhosphorDuotoneIconData(
-    0xe96d,
-    PhosphorIconData(0xe96c, 'Duotone'),
-  );
+  static const amazonLogo = IconData(0xe96d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ambulance-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ambulance-duotone.svg)
-  static const ambulance = PhosphorDuotoneIconData(
-    0xe573,
-    PhosphorIconData(0xe572, 'Duotone'),
-  );
+  static const ambulance = IconData(0xe573,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/anchor-duotone.svg)
-  static const anchor = PhosphorDuotoneIconData(
-    0xe515,
-    PhosphorIconData(0xe514, 'Duotone'),
-  );
+  static const anchor = IconData(0xe515,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/anchor-simple-duotone.svg)
-  static const anchorSimple = PhosphorDuotoneIconData(
-    0xe5d9,
-    PhosphorIconData(0xe5d8, 'Duotone'),
-  );
+  static const anchorSimple = IconData(0xe5d9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![android-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/android-logo-duotone.svg)
-  static const androidLogo = PhosphorDuotoneIconData(
-    0xe009,
-    PhosphorIconData(0xe008, 'Duotone'),
-  );
+  static const androidLogo = IconData(0xe009,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/angle-duotone.svg)
-  static const angle = PhosphorDuotoneIconData(
-    0xe7bd,
-    PhosphorIconData(0xe7bc, 'Duotone'),
-  );
+  static const angle = IconData(0xe7bd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angular-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/angular-logo-duotone.svg)
-  static const angularLogo = PhosphorDuotoneIconData(
-    0xeb81,
-    PhosphorIconData(0xeb80, 'Duotone'),
-  );
+  static const angularLogo = IconData(0xeb81,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![aperture-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/aperture-duotone.svg)
-  static const aperture = PhosphorDuotoneIconData(
-    0xe00b,
-    PhosphorIconData(0xe00a, 'Duotone'),
-  );
+  static const aperture = IconData(0xe00b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-store-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/app-store-logo-duotone.svg)
-  static const appStoreLogo = PhosphorDuotoneIconData(
-    0xe975,
-    PhosphorIconData(0xe974, 'Duotone'),
-  );
+  static const appStoreLogo = IconData(0xe975,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-window-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/app-window-duotone.svg)
-  static const appWindow = PhosphorDuotoneIconData(
-    0xe5db,
-    PhosphorIconData(0xe5da, 'Duotone'),
-  );
+  static const appWindow = IconData(0xe5db,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/apple-logo-duotone.svg)
-  static const appleLogo = PhosphorDuotoneIconData(
-    0xe517,
-    PhosphorIconData(0xe516, 'Duotone'),
-  );
+  static const appleLogo = IconData(0xe517,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-podcasts-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/apple-podcasts-logo-duotone.svg)
-  static const applePodcastsLogo = PhosphorDuotoneIconData(
-    0xeb97,
-    PhosphorIconData(0xeb96, 'Duotone'),
-  );
+  static const applePodcastsLogo = IconData(0xeb97,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![approximate-equals-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/approximate-equals-duotone.svg)
-  static const approximateEquals = PhosphorDuotoneIconData(
-    0xedab,
-    PhosphorIconData(0xedaa, 'Duotone'),
-  );
+  static const approximateEquals = IconData(0xedab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![archive-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/archive-duotone.svg)
-  static const archive = PhosphorDuotoneIconData(
-    0xe00d,
-    PhosphorIconData(0xe00c, 'Duotone'),
-  );
+  static const archive = IconData(0xe00d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![armchair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/armchair-duotone.svg)
-  static const armchair = PhosphorDuotoneIconData(
-    0xe013,
-    PhosphorIconData(0xe012, 'Duotone'),
-  );
+  static const armchair = IconData(0xe013,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-arc-left-duotone.svg)
-  static const arrowArcLeft = PhosphorDuotoneIconData(
-    0xe015,
-    PhosphorIconData(0xe014, 'Duotone'),
-  );
+  static const arrowArcLeft = IconData(0xe015,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-arc-right-duotone.svg)
-  static const arrowArcRight = PhosphorDuotoneIconData(
-    0xe017,
-    PhosphorIconData(0xe016, 'Duotone'),
-  );
+  static const arrowArcRight = IconData(0xe017,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-double-up-left-duotone.svg)
-  static const arrowBendDoubleUpLeft = PhosphorDuotoneIconData(
-    0xe03b,
-    PhosphorIconData(0xe03a, 'Duotone'),
-  );
+  static const arrowBendDoubleUpLeft = IconData(0xe03b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-double-up-right-duotone.svg)
-  static const arrowBendDoubleUpRight = PhosphorDuotoneIconData(
-    0xe03d,
-    PhosphorIconData(0xe03c, 'Duotone'),
-  );
+  static const arrowBendDoubleUpRight = IconData(0xe03d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-down-left-duotone.svg)
-  static const arrowBendDownLeft = PhosphorDuotoneIconData(
-    0xe019,
-    PhosphorIconData(0xe018, 'Duotone'),
-  );
+  static const arrowBendDownLeft = IconData(0xe019,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-down-right-duotone.svg)
-  static const arrowBendDownRight = PhosphorDuotoneIconData(
-    0xe01b,
-    PhosphorIconData(0xe01a, 'Duotone'),
-  );
+  static const arrowBendDownRight = IconData(0xe01b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-left-down-duotone.svg)
-  static const arrowBendLeftDown = PhosphorDuotoneIconData(
-    0xe01d,
-    PhosphorIconData(0xe01c, 'Duotone'),
-  );
+  static const arrowBendLeftDown = IconData(0xe01d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-left-up-duotone.svg)
-  static const arrowBendLeftUp = PhosphorDuotoneIconData(
-    0xe01f,
-    PhosphorIconData(0xe01e, 'Duotone'),
-  );
+  static const arrowBendLeftUp = IconData(0xe01f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-right-down-duotone.svg)
-  static const arrowBendRightDown = PhosphorDuotoneIconData(
-    0xe021,
-    PhosphorIconData(0xe020, 'Duotone'),
-  );
+  static const arrowBendRightDown = IconData(0xe021,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-right-up-duotone.svg)
-  static const arrowBendRightUp = PhosphorDuotoneIconData(
-    0xe023,
-    PhosphorIconData(0xe022, 'Duotone'),
-  );
+  static const arrowBendRightUp = IconData(0xe023,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-up-left-duotone.svg)
-  static const arrowBendUpLeft = PhosphorDuotoneIconData(
-    0xe025,
-    PhosphorIconData(0xe024, 'Duotone'),
-  );
+  static const arrowBendUpLeft = IconData(0xe025,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-bend-up-right-duotone.svg)
-  static const arrowBendUpRight = PhosphorDuotoneIconData(
-    0xe027,
-    PhosphorIconData(0xe026, 'Duotone'),
-  );
+  static const arrowBendUpRight = IconData(0xe027,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-down-duotone.svg)
-  static const arrowCircleDown = PhosphorDuotoneIconData(
-    0xe029,
-    PhosphorIconData(0xe028, 'Duotone'),
-  );
+  static const arrowCircleDown = IconData(0xe029,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-down-left-duotone.svg)
-  static const arrowCircleDownLeft = PhosphorDuotoneIconData(
-    0xe02b,
-    PhosphorIconData(0xe02a, 'Duotone'),
-  );
+  static const arrowCircleDownLeft = IconData(0xe02b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-down-right-duotone.svg)
-  static const arrowCircleDownRight = PhosphorDuotoneIconData(
-    0xe02d,
-    PhosphorIconData(0xe02c, 'Duotone'),
-  );
+  static const arrowCircleDownRight = IconData(0xe02d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-left-duotone.svg)
-  static const arrowCircleLeft = PhosphorDuotoneIconData(
-    0xe05b,
-    PhosphorIconData(0xe05a, 'Duotone'),
-  );
+  static const arrowCircleLeft = IconData(0xe05b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-right-duotone.svg)
-  static const arrowCircleRight = PhosphorDuotoneIconData(
-    0xe02f,
-    PhosphorIconData(0xe02e, 'Duotone'),
-  );
+  static const arrowCircleRight = IconData(0xe02f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-up-duotone.svg)
-  static const arrowCircleUp = PhosphorDuotoneIconData(
-    0xe031,
-    PhosphorIconData(0xe030, 'Duotone'),
-  );
+  static const arrowCircleUp = IconData(0xe031,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-up-left-duotone.svg)
-  static const arrowCircleUpLeft = PhosphorDuotoneIconData(
-    0xe033,
-    PhosphorIconData(0xe032, 'Duotone'),
-  );
+  static const arrowCircleUpLeft = IconData(0xe033,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-circle-up-right-duotone.svg)
-  static const arrowCircleUpRight = PhosphorDuotoneIconData(
-    0xe035,
-    PhosphorIconData(0xe034, 'Duotone'),
-  );
+  static const arrowCircleUpRight = IconData(0xe035,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-clockwise-duotone.svg)
-  static const arrowClockwise = PhosphorDuotoneIconData(
-    0xe037,
-    PhosphorIconData(0xe036, 'Duotone'),
-  );
+  static const arrowClockwise = IconData(0xe037,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-counter-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-counter-clockwise-duotone.svg)
-  static const arrowCounterClockwise = PhosphorDuotoneIconData(
-    0xe039,
-    PhosphorIconData(0xe038, 'Duotone'),
-  );
+  static const arrowCounterClockwise = IconData(0xe039,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-down-duotone.svg)
-  static const arrowDown = PhosphorDuotoneIconData(
-    0xe03f,
-    PhosphorIconData(0xe03e, 'Duotone'),
-  );
+  static const arrowDown = IconData(0xe03f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-down-left-duotone.svg)
-  static const arrowDownLeft = PhosphorDuotoneIconData(
-    0xe041,
-    PhosphorIconData(0xe040, 'Duotone'),
-  );
+  static const arrowDownLeft = IconData(0xe041,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-down-right-duotone.svg)
-  static const arrowDownRight = PhosphorDuotoneIconData(
-    0xe043,
-    PhosphorIconData(0xe042, 'Duotone'),
-  );
+  static const arrowDownRight = IconData(0xe043,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-down-left-duotone.svg)
-  static const arrowElbowDownLeft = PhosphorDuotoneIconData(
-    0xe045,
-    PhosphorIconData(0xe044, 'Duotone'),
-  );
+  static const arrowElbowDownLeft = IconData(0xe045,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-down-right-duotone.svg)
-  static const arrowElbowDownRight = PhosphorDuotoneIconData(
-    0xe047,
-    PhosphorIconData(0xe046, 'Duotone'),
-  );
+  static const arrowElbowDownRight = IconData(0xe047,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-left-duotone.svg)
-  static const arrowElbowLeft = PhosphorDuotoneIconData(
-    0xe049,
-    PhosphorIconData(0xe048, 'Duotone'),
-  );
+  static const arrowElbowLeft = IconData(0xe049,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-left-down-duotone.svg)
-  static const arrowElbowLeftDown = PhosphorDuotoneIconData(
-    0xe04b,
-    PhosphorIconData(0xe04a, 'Duotone'),
-  );
+  static const arrowElbowLeftDown = IconData(0xe04b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-left-up-duotone.svg)
-  static const arrowElbowLeftUp = PhosphorDuotoneIconData(
-    0xe04d,
-    PhosphorIconData(0xe04c, 'Duotone'),
-  );
+  static const arrowElbowLeftUp = IconData(0xe04d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-right-duotone.svg)
-  static const arrowElbowRight = PhosphorDuotoneIconData(
-    0xe04f,
-    PhosphorIconData(0xe04e, 'Duotone'),
-  );
+  static const arrowElbowRight = IconData(0xe04f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-right-down-duotone.svg)
-  static const arrowElbowRightDown = PhosphorDuotoneIconData(
-    0xe051,
-    PhosphorIconData(0xe050, 'Duotone'),
-  );
+  static const arrowElbowRightDown = IconData(0xe051,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-right-up-duotone.svg)
-  static const arrowElbowRightUp = PhosphorDuotoneIconData(
-    0xe053,
-    PhosphorIconData(0xe052, 'Duotone'),
-  );
+  static const arrowElbowRightUp = IconData(0xe053,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-up-left-duotone.svg)
-  static const arrowElbowUpLeft = PhosphorDuotoneIconData(
-    0xe055,
-    PhosphorIconData(0xe054, 'Duotone'),
-  );
+  static const arrowElbowUpLeft = IconData(0xe055,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-elbow-up-right-duotone.svg)
-  static const arrowElbowUpRight = PhosphorDuotoneIconData(
-    0xe057,
-    PhosphorIconData(0xe056, 'Duotone'),
-  );
+  static const arrowElbowUpRight = IconData(0xe057,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-down-duotone.svg)
-  static const arrowFatDown = PhosphorDuotoneIconData(
-    0xe519,
-    PhosphorIconData(0xe518, 'Duotone'),
-  );
+  static const arrowFatDown = IconData(0xe519,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-left-duotone.svg)
-  static const arrowFatLeft = PhosphorDuotoneIconData(
-    0xe51b,
-    PhosphorIconData(0xe51a, 'Duotone'),
-  );
+  static const arrowFatLeft = IconData(0xe51b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-line-down-duotone.svg)
-  static const arrowFatLineDown = PhosphorDuotoneIconData(
-    0xe51d,
-    PhosphorIconData(0xe51c, 'Duotone'),
-  );
+  static const arrowFatLineDown = IconData(0xe51d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-line-left-duotone.svg)
-  static const arrowFatLineLeft = PhosphorDuotoneIconData(
-    0xe51f,
-    PhosphorIconData(0xe51e, 'Duotone'),
-  );
+  static const arrowFatLineLeft = IconData(0xe51f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-line-right-duotone.svg)
-  static const arrowFatLineRight = PhosphorDuotoneIconData(
-    0xe521,
-    PhosphorIconData(0xe520, 'Duotone'),
-  );
+  static const arrowFatLineRight = IconData(0xe521,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-line-up-duotone.svg)
-  static const arrowFatLineUp = PhosphorDuotoneIconData(
-    0xe523,
-    PhosphorIconData(0xe522, 'Duotone'),
-  );
+  static const arrowFatLineUp = IconData(0xe523,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-lines-down-duotone.svg)
-  static const arrowFatLinesDown = PhosphorDuotoneIconData(
-    0xe525,
-    PhosphorIconData(0xe524, 'Duotone'),
-  );
+  static const arrowFatLinesDown = IconData(0xe525,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-lines-left-duotone.svg)
-  static const arrowFatLinesLeft = PhosphorDuotoneIconData(
-    0xe527,
-    PhosphorIconData(0xe526, 'Duotone'),
-  );
+  static const arrowFatLinesLeft = IconData(0xe527,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-lines-right-duotone.svg)
-  static const arrowFatLinesRight = PhosphorDuotoneIconData(
-    0xe529,
-    PhosphorIconData(0xe528, 'Duotone'),
-  );
+  static const arrowFatLinesRight = IconData(0xe529,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-lines-up-duotone.svg)
-  static const arrowFatLinesUp = PhosphorDuotoneIconData(
-    0xe52b,
-    PhosphorIconData(0xe52a, 'Duotone'),
-  );
+  static const arrowFatLinesUp = IconData(0xe52b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-right-duotone.svg)
-  static const arrowFatRight = PhosphorDuotoneIconData(
-    0xe52d,
-    PhosphorIconData(0xe52c, 'Duotone'),
-  );
+  static const arrowFatRight = IconData(0xe52d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-fat-up-duotone.svg)
-  static const arrowFatUp = PhosphorDuotoneIconData(
-    0xe52f,
-    PhosphorIconData(0xe52e, 'Duotone'),
-  );
+  static const arrowFatUp = IconData(0xe52f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-left-duotone.svg)
-  static const arrowLeft = PhosphorDuotoneIconData(
-    0xe059,
-    PhosphorIconData(0xe058, 'Duotone'),
-  );
+  static const arrowLeft = IconData(0xe059,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-down-duotone.svg)
-  static const arrowLineDown = PhosphorDuotoneIconData(
-    0xe05d,
-    PhosphorIconData(0xe05c, 'Duotone'),
-  );
+  static const arrowLineDown = IconData(0xe05d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-down-left-duotone.svg)
-  static const arrowLineDownLeft = PhosphorDuotoneIconData(
-    0xe05f,
-    PhosphorIconData(0xe05e, 'Duotone'),
-  );
+  static const arrowLineDownLeft = IconData(0xe05f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-down-right-duotone.svg)
-  static const arrowLineDownRight = PhosphorDuotoneIconData(
-    0xe061,
-    PhosphorIconData(0xe060, 'Duotone'),
-  );
+  static const arrowLineDownRight = IconData(0xe061,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-left-duotone.svg)
-  static const arrowLineLeft = PhosphorDuotoneIconData(
-    0xe063,
-    PhosphorIconData(0xe062, 'Duotone'),
-  );
+  static const arrowLineLeft = IconData(0xe063,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-right-duotone.svg)
-  static const arrowLineRight = PhosphorDuotoneIconData(
-    0xe065,
-    PhosphorIconData(0xe064, 'Duotone'),
-  );
+  static const arrowLineRight = IconData(0xe065,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-up-duotone.svg)
-  static const arrowLineUp = PhosphorDuotoneIconData(
-    0xe067,
-    PhosphorIconData(0xe066, 'Duotone'),
-  );
+  static const arrowLineUp = IconData(0xe067,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-up-left-duotone.svg)
-  static const arrowLineUpLeft = PhosphorDuotoneIconData(
-    0xe069,
-    PhosphorIconData(0xe068, 'Duotone'),
-  );
+  static const arrowLineUpLeft = IconData(0xe069,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-line-up-right-duotone.svg)
-  static const arrowLineUpRight = PhosphorDuotoneIconData(
-    0xe06b,
-    PhosphorIconData(0xe06a, 'Duotone'),
-  );
+  static const arrowLineUpRight = IconData(0xe06b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-right-duotone.svg)
-  static const arrowRight = PhosphorDuotoneIconData(
-    0xe06d,
-    PhosphorIconData(0xe06c, 'Duotone'),
-  );
+  static const arrowRight = IconData(0xe06d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-down-duotone.svg)
-  static const arrowSquareDown = PhosphorDuotoneIconData(
-    0xe06f,
-    PhosphorIconData(0xe06e, 'Duotone'),
-  );
+  static const arrowSquareDown = IconData(0xe06f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-down-left-duotone.svg)
-  static const arrowSquareDownLeft = PhosphorDuotoneIconData(
-    0xe071,
-    PhosphorIconData(0xe070, 'Duotone'),
-  );
+  static const arrowSquareDownLeft = IconData(0xe071,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-down-right-duotone.svg)
-  static const arrowSquareDownRight = PhosphorDuotoneIconData(
-    0xe073,
-    PhosphorIconData(0xe072, 'Duotone'),
-  );
+  static const arrowSquareDownRight = IconData(0xe073,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-in-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-in-duotone.svg)
-  static const arrowSquareIn = PhosphorDuotoneIconData(
-    0xe5dd,
-    PhosphorIconData(0xe5dc, 'Duotone'),
-  );
+  static const arrowSquareIn = IconData(0xe5dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-left-duotone.svg)
-  static const arrowSquareLeft = PhosphorDuotoneIconData(
-    0xe075,
-    PhosphorIconData(0xe074, 'Duotone'),
-  );
+  static const arrowSquareLeft = IconData(0xe075,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-out-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-out-duotone.svg)
-  static const arrowSquareOut = PhosphorDuotoneIconData(
-    0xe5df,
-    PhosphorIconData(0xe5de, 'Duotone'),
-  );
+  static const arrowSquareOut = IconData(0xe5df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-right-duotone.svg)
-  static const arrowSquareRight = PhosphorDuotoneIconData(
-    0xe077,
-    PhosphorIconData(0xe076, 'Duotone'),
-  );
+  static const arrowSquareRight = IconData(0xe077,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-up-duotone.svg)
-  static const arrowSquareUp = PhosphorDuotoneIconData(
-    0xe079,
-    PhosphorIconData(0xe078, 'Duotone'),
-  );
+  static const arrowSquareUp = IconData(0xe079,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-up-left-duotone.svg)
-  static const arrowSquareUpLeft = PhosphorDuotoneIconData(
-    0xe07b,
-    PhosphorIconData(0xe07a, 'Duotone'),
-  );
+  static const arrowSquareUpLeft = IconData(0xe07b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-square-up-right-duotone.svg)
-  static const arrowSquareUpRight = PhosphorDuotoneIconData(
-    0xe07d,
-    PhosphorIconData(0xe07c, 'Duotone'),
-  );
+  static const arrowSquareUpRight = IconData(0xe07d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-down-left-duotone.svg)
-  static const arrowUDownLeft = PhosphorDuotoneIconData(
-    0xe07f,
-    PhosphorIconData(0xe07e, 'Duotone'),
-  );
+  static const arrowUDownLeft = IconData(0xe07f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-down-right-duotone.svg)
-  static const arrowUDownRight = PhosphorDuotoneIconData(
-    0xe081,
-    PhosphorIconData(0xe080, 'Duotone'),
-  );
+  static const arrowUDownRight = IconData(0xe081,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-left-down-duotone.svg)
-  static const arrowULeftDown = PhosphorDuotoneIconData(
-    0xe083,
-    PhosphorIconData(0xe082, 'Duotone'),
-  );
+  static const arrowULeftDown = IconData(0xe083,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-left-up-duotone.svg)
-  static const arrowULeftUp = PhosphorDuotoneIconData(
-    0xe085,
-    PhosphorIconData(0xe084, 'Duotone'),
-  );
+  static const arrowULeftUp = IconData(0xe085,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-right-down-duotone.svg)
-  static const arrowURightDown = PhosphorDuotoneIconData(
-    0xe087,
-    PhosphorIconData(0xe086, 'Duotone'),
-  );
+  static const arrowURightDown = IconData(0xe087,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-right-up-duotone.svg)
-  static const arrowURightUp = PhosphorDuotoneIconData(
-    0xe089,
-    PhosphorIconData(0xe088, 'Duotone'),
-  );
+  static const arrowURightUp = IconData(0xe089,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-up-left-duotone.svg)
-  static const arrowUUpLeft = PhosphorDuotoneIconData(
-    0xe08b,
-    PhosphorIconData(0xe08a, 'Duotone'),
-  );
+  static const arrowUUpLeft = IconData(0xe08b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-u-up-right-duotone.svg)
-  static const arrowUUpRight = PhosphorDuotoneIconData(
-    0xe08d,
-    PhosphorIconData(0xe08c, 'Duotone'),
-  );
+  static const arrowUUpRight = IconData(0xe08d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-up-duotone.svg)
-  static const arrowUp = PhosphorDuotoneIconData(
-    0xe08f,
-    PhosphorIconData(0xe08e, 'Duotone'),
-  );
+  static const arrowUp = IconData(0xe08f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-up-left-duotone.svg)
-  static const arrowUpLeft = PhosphorDuotoneIconData(
-    0xe091,
-    PhosphorIconData(0xe090, 'Duotone'),
-  );
+  static const arrowUpLeft = IconData(0xe091,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrow-up-right-duotone.svg)
-  static const arrowUpRight = PhosphorDuotoneIconData(
-    0xe093,
-    PhosphorIconData(0xe092, 'Duotone'),
-  );
+  static const arrowUpRight = IconData(0xe093,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-clockwise-duotone.svg)
-  static const arrowsClockwise = PhosphorDuotoneIconData(
-    0xe095,
-    PhosphorIconData(0xe094, 'Duotone'),
-  );
+  static const arrowsClockwise = IconData(0xe095,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-counter-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-counter-clockwise-duotone.svg)
-  static const arrowsCounterClockwise = PhosphorDuotoneIconData(
-    0xe097,
-    PhosphorIconData(0xe096, 'Duotone'),
-  );
+  static const arrowsCounterClockwise = IconData(0xe097,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-down-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-down-up-duotone.svg)
-  static const arrowsDownUp = PhosphorDuotoneIconData(
-    0xe099,
-    PhosphorIconData(0xe098, 'Duotone'),
-  );
+  static const arrowsDownUp = IconData(0xe099,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-horizontal-duotone.svg)
-  static const arrowsHorizontal = PhosphorDuotoneIconData(
-    0xeb07,
-    PhosphorIconData(0xeb06, 'Duotone'),
-  );
+  static const arrowsHorizontal = IconData(0xeb07,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-duotone.svg)
-  static const arrowsIn = PhosphorDuotoneIconData(
-    0xe09b,
-    PhosphorIconData(0xe09a, 'Duotone'),
-  );
+  static const arrowsIn = IconData(0xe09b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-cardinal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-cardinal-duotone.svg)
-  static const arrowsInCardinal = PhosphorDuotoneIconData(
-    0xe09d,
-    PhosphorIconData(0xe09c, 'Duotone'),
-  );
+  static const arrowsInCardinal = IconData(0xe09d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-line-horizontal-duotone.svg)
-  static const arrowsInLineHorizontal = PhosphorDuotoneIconData(
-    0xe531,
-    PhosphorIconData(0xe530, 'Duotone'),
-  );
+  static const arrowsInLineHorizontal = IconData(0xe531,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-line-vertical-duotone.svg)
-  static const arrowsInLineVertical = PhosphorDuotoneIconData(
-    0xe533,
-    PhosphorIconData(0xe532, 'Duotone'),
-  );
+  static const arrowsInLineVertical = IconData(0xe533,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-in-simple-duotone.svg)
-  static const arrowsInSimple = PhosphorDuotoneIconData(
-    0xe09f,
-    PhosphorIconData(0xe09e, 'Duotone'),
-  );
+  static const arrowsInSimple = IconData(0xe09f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-left-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-left-right-duotone.svg)
-  static const arrowsLeftRight = PhosphorDuotoneIconData(
-    0xe0a1,
-    PhosphorIconData(0xe0a0, 'Duotone'),
-  );
+  static const arrowsLeftRight = IconData(0xe0a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-merge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-merge-duotone.svg)
-  static const arrowsMerge = PhosphorDuotoneIconData(
-    0xed3f,
-    PhosphorIconData(0xed3e, 'Duotone'),
-  );
+  static const arrowsMerge = IconData(0xed3f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-duotone.svg)
-  static const arrowsOut = PhosphorDuotoneIconData(
-    0xe0a3,
-    PhosphorIconData(0xe0a2, 'Duotone'),
-  );
+  static const arrowsOut = IconData(0xe0a3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-cardinal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-cardinal-duotone.svg)
-  static const arrowsOutCardinal = PhosphorDuotoneIconData(
-    0xe0a5,
-    PhosphorIconData(0xe0a4, 'Duotone'),
-  );
+  static const arrowsOutCardinal = IconData(0xe0a5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-line-horizontal-duotone.svg)
-  static const arrowsOutLineHorizontal = PhosphorDuotoneIconData(
-    0xe535,
-    PhosphorIconData(0xe534, 'Duotone'),
-  );
+  static const arrowsOutLineHorizontal = IconData(0xe535,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-line-vertical-duotone.svg)
-  static const arrowsOutLineVertical = PhosphorDuotoneIconData(
-    0xe537,
-    PhosphorIconData(0xe536, 'Duotone'),
-  );
+  static const arrowsOutLineVertical = IconData(0xe537,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-out-simple-duotone.svg)
-  static const arrowsOutSimple = PhosphorDuotoneIconData(
-    0xe0a7,
-    PhosphorIconData(0xe0a6, 'Duotone'),
-  );
+  static const arrowsOutSimple = IconData(0xe0a7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-split-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-split-duotone.svg)
-  static const arrowsSplit = PhosphorDuotoneIconData(
-    0xed3d,
-    PhosphorIconData(0xed3c, 'Duotone'),
-  );
+  static const arrowsSplit = IconData(0xed3d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/arrows-vertical-duotone.svg)
-  static const arrowsVertical = PhosphorDuotoneIconData(
-    0xeb05,
-    PhosphorIconData(0xeb04, 'Duotone'),
-  );
+  static const arrowsVertical = IconData(0xeb05,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/article-duotone.svg)
-  static const article = PhosphorDuotoneIconData(
-    0xe0a9,
-    PhosphorIconData(0xe0a8, 'Duotone'),
-  );
+  static const article = IconData(0xe0a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/article-medium-duotone.svg)
-  static const articleMedium = PhosphorDuotoneIconData(
-    0xe5e1,
-    PhosphorIconData(0xe5e0, 'Duotone'),
-  );
+  static const articleMedium = IconData(0xe5e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-ny-times-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/article-ny-times-duotone.svg)
-  static const articleNyTimes = PhosphorDuotoneIconData(
-    0xe5e3,
-    PhosphorIconData(0xe5e2, 'Duotone'),
-  );
+  static const articleNyTimes = IconData(0xe5e3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asclepius-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/asclepius-duotone.svg)
-  static const asclepius = PhosphorDuotoneIconData(
-    0xee35,
-    PhosphorIconData(0xee34, 'Duotone'),
-  );
+  static const asclepius = IconData(0xee35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/asterisk-duotone.svg)
-  static const asterisk = PhosphorDuotoneIconData(
-    0xe0ab,
-    PhosphorIconData(0xe0aa, 'Duotone'),
-  );
+  static const asterisk = IconData(0xe0ab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/asterisk-simple-duotone.svg)
-  static const asteriskSimple = PhosphorDuotoneIconData(
-    0xe833,
-    PhosphorIconData(0xe832, 'Duotone'),
-  );
+  static const asteriskSimple = IconData(0xe833,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![at-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/at-duotone.svg)
-  static const at = PhosphorDuotoneIconData(
-    0xe0ad,
-    PhosphorIconData(0xe0ac, 'Duotone'),
-  );
+  static const at = IconData(0xe0ad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![atom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/atom-duotone.svg)
-  static const atom = PhosphorDuotoneIconData(
-    0xe5e5,
-    PhosphorIconData(0xe5e4, 'Duotone'),
-  );
+  static const atom = IconData(0xe5e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![avocado-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/avocado-duotone.svg)
-  static const avocado = PhosphorDuotoneIconData(
-    0xee05,
-    PhosphorIconData(0xee04, 'Duotone'),
-  );
+  static const avocado = IconData(0xee05,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![axe-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/axe-duotone.svg)
-  static const axe = PhosphorDuotoneIconData(
-    0xe9fd,
-    PhosphorIconData(0xe9fc, 'Duotone'),
-  );
+  static const axe = IconData(0xe9fd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/baby-duotone.svg)
-  static const baby = PhosphorDuotoneIconData(
-    0xe775,
-    PhosphorIconData(0xe774, 'Duotone'),
-  );
+  static const baby = IconData(0xe775,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-carriage-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/baby-carriage-duotone.svg)
-  static const babyCarriage = PhosphorDuotoneIconData(
-    0xe819,
-    PhosphorIconData(0xe818, 'Duotone'),
-  );
+  static const babyCarriage = IconData(0xe819,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backpack-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/backpack-duotone.svg)
-  static const backpack = PhosphorDuotoneIconData(
-    0xe923,
-    PhosphorIconData(0xe922, 'Duotone'),
-  );
+  static const backpack = IconData(0xe923,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backspace-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/backspace-duotone.svg)
-  static const backspace = PhosphorDuotoneIconData(
-    0xe0af,
-    PhosphorIconData(0xe0ae, 'Duotone'),
-  );
+  static const backspace = IconData(0xe0af,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bag-duotone.svg)
-  static const bag = PhosphorDuotoneIconData(
-    0xe0b1,
-    PhosphorIconData(0xe0b0, 'Duotone'),
-  );
+  static const bag = IconData(0xe0b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bag-simple-duotone.svg)
-  static const bagSimple = PhosphorDuotoneIconData(
-    0xe5e7,
-    PhosphorIconData(0xe5e6, 'Duotone'),
-  );
+  static const bagSimple = IconData(0xe5e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![balloon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/balloon-duotone.svg)
-  static const balloon = PhosphorDuotoneIconData(
-    0xe76d,
-    PhosphorIconData(0xe76c, 'Duotone'),
-  );
+  static const balloon = IconData(0xe76d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bandaids-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bandaids-duotone.svg)
-  static const bandaids = PhosphorDuotoneIconData(
-    0xe0b3,
-    PhosphorIconData(0xe0b2, 'Duotone'),
-  );
+  static const bandaids = IconData(0xe0b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bank-duotone.svg)
-  static const bank = PhosphorDuotoneIconData(
-    0xe0b5,
-    PhosphorIconData(0xe0b4, 'Duotone'),
-  );
+  static const bank = IconData(0xe0b5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barbell-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/barbell-duotone.svg)
-  static const barbell = PhosphorDuotoneIconData(
-    0xe0b7,
-    PhosphorIconData(0xe0b6, 'Duotone'),
-  );
+  static const barbell = IconData(0xe0b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barcode-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/barcode-duotone.svg)
-  static const barcode = PhosphorDuotoneIconData(
-    0xe0b9,
-    PhosphorIconData(0xe0b8, 'Duotone'),
-  );
+  static const barcode = IconData(0xe0b9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barn-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/barn-duotone.svg)
-  static const barn = PhosphorDuotoneIconData(
-    0xec73,
-    PhosphorIconData(0xec72, 'Duotone'),
-  );
+  static const barn = IconData(0xec73,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barricade-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/barricade-duotone.svg)
-  static const barricade = PhosphorDuotoneIconData(
-    0xe949,
-    PhosphorIconData(0xe948, 'Duotone'),
-  );
+  static const barricade = IconData(0xe949,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/baseball-duotone.svg)
-  static const baseball = PhosphorDuotoneIconData(
-    0xe71b,
-    PhosphorIconData(0xe71a, 'Duotone'),
-  );
+  static const baseball = IconData(0xe71b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-cap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/baseball-cap-duotone.svg)
-  static const baseballCap = PhosphorDuotoneIconData(
-    0xea29,
-    PhosphorIconData(0xea28, 'Duotone'),
-  );
+  static const baseballCap = IconData(0xea29,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-helmet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/baseball-helmet-duotone.svg)
-  static const baseballHelmet = PhosphorDuotoneIconData(
-    0xee4b,
-    PhosphorIconData(0xee4a, 'Duotone'),
-  );
+  static const baseballHelmet = IconData(0xee4b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/basket-duotone.svg)
-  static const basket = PhosphorDuotoneIconData(
-    0xe965,
-    PhosphorIconData(0xe964, 'Duotone'),
-  );
+  static const basket = IconData(0xe965,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basketball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/basketball-duotone.svg)
-  static const basketball = PhosphorDuotoneIconData(
-    0xe725,
-    PhosphorIconData(0xe724, 'Duotone'),
-  );
+  static const basketball = IconData(0xe725,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bathtub-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bathtub-duotone.svg)
-  static const bathtub = PhosphorDuotoneIconData(
-    0xe81f,
-    PhosphorIconData(0xe81e, 'Duotone'),
-  );
+  static const bathtub = IconData(0xe81f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-charging-duotone.svg)
-  static const batteryCharging = PhosphorDuotoneIconData(
-    0xe0bb,
-    PhosphorIconData(0xe0ba, 'Duotone'),
-  );
+  static const batteryCharging = IconData(0xe0bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-charging-vertical-duotone.svg)
-  static const batteryChargingVertical = PhosphorDuotoneIconData(
-    0xe0bd,
-    PhosphorIconData(0xe0bc, 'Duotone'),
-  );
+  static const batteryChargingVertical = IconData(0xe0bd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-empty-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-empty-duotone.svg)
-  static const batteryEmpty = PhosphorDuotoneIconData(
-    0xe0bf,
-    PhosphorIconData(0xe0be, 'Duotone'),
-  );
+  static const batteryEmpty = IconData(0xe0bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-full-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-full-duotone.svg)
-  static const batteryFull = PhosphorDuotoneIconData(
-    0xe0c1,
-    PhosphorIconData(0xe0c0, 'Duotone'),
-  );
+  static const batteryFull = IconData(0xe0c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-high-duotone.svg)
-  static const batteryHigh = PhosphorDuotoneIconData(
-    0xe0c3,
-    PhosphorIconData(0xe0c2, 'Duotone'),
-  );
+  static const batteryHigh = IconData(0xe0c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-low-duotone.svg)
-  static const batteryLow = PhosphorDuotoneIconData(
-    0xe0c5,
-    PhosphorIconData(0xe0c4, 'Duotone'),
-  );
+  static const batteryLow = IconData(0xe0c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-medium-duotone.svg)
-  static const batteryMedium = PhosphorDuotoneIconData(
-    0xe0c7,
-    PhosphorIconData(0xe0c6, 'Duotone'),
-  );
+  static const batteryMedium = IconData(0xe0c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-plus-duotone.svg)
-  static const batteryPlus = PhosphorDuotoneIconData(
-    0xe809,
-    PhosphorIconData(0xe808, 'Duotone'),
-  );
+  static const batteryPlus = IconData(0xe809,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-plus-vertical-duotone.svg)
-  static const batteryPlusVertical = PhosphorDuotoneIconData(
-    0xec51,
-    PhosphorIconData(0xec50, 'Duotone'),
-  );
+  static const batteryPlusVertical = IconData(0xec51,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-empty-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-empty-duotone.svg)
-  static const batteryVerticalEmpty = PhosphorDuotoneIconData(
-    0xe7c7,
-    PhosphorIconData(0xe7c6, 'Duotone'),
-  );
+  static const batteryVerticalEmpty = IconData(0xe7c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-full-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-full-duotone.svg)
-  static const batteryVerticalFull = PhosphorDuotoneIconData(
-    0xe7c5,
-    PhosphorIconData(0xe7c4, 'Duotone'),
-  );
+  static const batteryVerticalFull = IconData(0xe7c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-high-duotone.svg)
-  static const batteryVerticalHigh = PhosphorDuotoneIconData(
-    0xe7c3,
-    PhosphorIconData(0xe7c2, 'Duotone'),
-  );
+  static const batteryVerticalHigh = IconData(0xe7c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-low-duotone.svg)
-  static const batteryVerticalLow = PhosphorDuotoneIconData(
-    0xe7bf,
-    PhosphorIconData(0xe7be, 'Duotone'),
-  );
+  static const batteryVerticalLow = IconData(0xe7bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-vertical-medium-duotone.svg)
-  static const batteryVerticalMedium = PhosphorDuotoneIconData(
-    0xe7c1,
-    PhosphorIconData(0xe7c0, 'Duotone'),
-  );
+  static const batteryVerticalMedium = IconData(0xe7c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-warning-duotone.svg)
-  static const batteryWarning = PhosphorDuotoneIconData(
-    0xe0c9,
-    PhosphorIconData(0xe0c8, 'Duotone'),
-  );
+  static const batteryWarning = IconData(0xe0c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/battery-warning-vertical-duotone.svg)
-  static const batteryWarningVertical = PhosphorDuotoneIconData(
-    0xe0cb,
-    PhosphorIconData(0xe0ca, 'Duotone'),
-  );
+  static const batteryWarningVertical = IconData(0xe0cb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beach-ball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/beach-ball-duotone.svg)
-  static const beachBall = PhosphorDuotoneIconData(
-    0xed25,
-    PhosphorIconData(0xed24, 'Duotone'),
-  );
+  static const beachBall = IconData(0xed25,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beanie-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/beanie-duotone.svg)
-  static const beanie = PhosphorDuotoneIconData(
-    0xea2b,
-    PhosphorIconData(0xea2a, 'Duotone'),
-  );
+  static const beanie = IconData(0xea2b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bed-duotone.svg)
-  static const bed = PhosphorDuotoneIconData(
-    0xe0cd,
-    PhosphorIconData(0xe0cc, 'Duotone'),
-  );
+  static const bed = IconData(0xe0cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-bottle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/beer-bottle-duotone.svg)
-  static const beerBottle = PhosphorDuotoneIconData(
-    0xe7b1,
-    PhosphorIconData(0xe7b0, 'Duotone'),
-  );
+  static const beerBottle = IconData(0xe7b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-stein-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/beer-stein-duotone.svg)
-  static const beerStein = PhosphorDuotoneIconData(
-    0xeb63,
-    PhosphorIconData(0xeb62, 'Duotone'),
-  );
+  static const beerStein = IconData(0xeb63,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![behance-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/behance-logo-duotone.svg)
-  static const behanceLogo = PhosphorDuotoneIconData(
-    0xe7f5,
-    PhosphorIconData(0xe7f4, 'Duotone'),
-  );
+  static const behanceLogo = IconData(0xe7f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-duotone.svg)
-  static const bell = PhosphorDuotoneIconData(
-    0xe0cf,
-    PhosphorIconData(0xe0ce, 'Duotone'),
-  );
+  static const bell = IconData(0xe0cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-ringing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-ringing-duotone.svg)
-  static const bellRinging = PhosphorDuotoneIconData(
-    0xe5e9,
-    PhosphorIconData(0xe5e8, 'Duotone'),
-  );
+  static const bellRinging = IconData(0xe5e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-simple-duotone.svg)
-  static const bellSimple = PhosphorDuotoneIconData(
-    0xe0d1,
-    PhosphorIconData(0xe0d0, 'Duotone'),
-  );
+  static const bellSimple = IconData(0xe0d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-ringing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-simple-ringing-duotone.svg)
-  static const bellSimpleRinging = PhosphorDuotoneIconData(
-    0xe5eb,
-    PhosphorIconData(0xe5ea, 'Duotone'),
-  );
+  static const bellSimpleRinging = IconData(0xe5eb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-simple-slash-duotone.svg)
-  static const bellSimpleSlash = PhosphorDuotoneIconData(
-    0xe0d3,
-    PhosphorIconData(0xe0d2, 'Duotone'),
-  );
+  static const bellSimpleSlash = IconData(0xe0d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-z-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-simple-z-duotone.svg)
-  static const bellSimpleZ = PhosphorDuotoneIconData(
-    0xe5ed,
-    PhosphorIconData(0xe5ec, 'Duotone'),
-  );
+  static const bellSimpleZ = IconData(0xe5ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-slash-duotone.svg)
-  static const bellSlash = PhosphorDuotoneIconData(
-    0xe0d5,
-    PhosphorIconData(0xe0d4, 'Duotone'),
-  );
+  static const bellSlash = IconData(0xe0d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-z-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bell-z-duotone.svg)
-  static const bellZ = PhosphorDuotoneIconData(
-    0xe5ef,
-    PhosphorIconData(0xe5ee, 'Duotone'),
-  );
+  static const bellZ = IconData(0xe5ef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![belt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/belt-duotone.svg)
-  static const belt = PhosphorDuotoneIconData(
-    0xea2d,
-    PhosphorIconData(0xea2c, 'Duotone'),
-  );
+  static const belt = IconData(0xea2d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bezier-curve-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bezier-curve-duotone.svg)
-  static const bezierCurve = PhosphorDuotoneIconData(
-    0xeb01,
-    PhosphorIconData(0xeb00, 'Duotone'),
-  );
+  static const bezierCurve = IconData(0xeb01,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bicycle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bicycle-duotone.svg)
-  static const bicycle = PhosphorDuotoneIconData(
-    0xe0d7,
-    PhosphorIconData(0xe0d6, 'Duotone'),
-  );
+  static const bicycle = IconData(0xe0d7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binary-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/binary-duotone.svg)
-  static const binary = PhosphorDuotoneIconData(
-    0xee61,
-    PhosphorIconData(0xee60, 'Duotone'),
-  );
+  static const binary = IconData(0xee61,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binoculars-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/binoculars-duotone.svg)
-  static const binoculars = PhosphorDuotoneIconData(
-    0xea65,
-    PhosphorIconData(0xea64, 'Duotone'),
-  );
+  static const binoculars = IconData(0xea65,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![biohazard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/biohazard-duotone.svg)
-  static const biohazard = PhosphorDuotoneIconData(
-    0xe9e1,
-    PhosphorIconData(0xe9e0, 'Duotone'),
-  );
+  static const biohazard = IconData(0xe9e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bird-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bird-duotone.svg)
-  static const bird = PhosphorDuotoneIconData(
-    0xe72d,
-    PhosphorIconData(0xe72c, 'Duotone'),
-  );
+  static const bird = IconData(0xe72d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![blueprint-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/blueprint-duotone.svg)
-  static const blueprint = PhosphorDuotoneIconData(
-    0xeda1,
-    PhosphorIconData(0xeda0, 'Duotone'),
-  );
+  static const blueprint = IconData(0xeda1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bluetooth-duotone.svg)
-  static const bluetooth = PhosphorDuotoneIconData(
-    0xe0db,
-    PhosphorIconData(0xe0da, 'Duotone'),
-  );
+  static const bluetooth = IconData(0xe0db,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-connected-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bluetooth-connected-duotone.svg)
-  static const bluetoothConnected = PhosphorDuotoneIconData(
-    0xe0dd,
-    PhosphorIconData(0xe0dc, 'Duotone'),
-  );
+  static const bluetoothConnected = IconData(0xe0dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bluetooth-slash-duotone.svg)
-  static const bluetoothSlash = PhosphorDuotoneIconData(
-    0xe0df,
-    PhosphorIconData(0xe0de, 'Duotone'),
-  );
+  static const bluetoothSlash = IconData(0xe0df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bluetooth-x-duotone.svg)
-  static const bluetoothX = PhosphorDuotoneIconData(
-    0xe0e1,
-    PhosphorIconData(0xe0e0, 'Duotone'),
-  );
+  static const bluetoothX = IconData(0xe0e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/boat-duotone.svg)
-  static const boat = PhosphorDuotoneIconData(
-    0xe787,
-    PhosphorIconData(0xe786, 'Duotone'),
-  );
+  static const boat = IconData(0xe787,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bomb-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bomb-duotone.svg)
-  static const bomb = PhosphorDuotoneIconData(
-    0xee0b,
-    PhosphorIconData(0xee0a, 'Duotone'),
-  );
+  static const bomb = IconData(0xee0b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bone-duotone.svg)
-  static const bone = PhosphorDuotoneIconData(
-    0xe7f3,
-    PhosphorIconData(0xe7f2, 'Duotone'),
-  );
+  static const bone = IconData(0xe7f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-duotone.svg)
-  static const book = PhosphorDuotoneIconData(
-    0xe0e3,
-    PhosphorIconData(0xe0e2, 'Duotone'),
-  );
+  static const book = IconData(0xe0e3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-bookmark-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-bookmark-duotone.svg)
-  static const bookBookmark = PhosphorDuotoneIconData(
-    0xe0e5,
-    PhosphorIconData(0xe0e4, 'Duotone'),
-  );
+  static const bookBookmark = IconData(0xe0e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-open-duotone.svg)
-  static const bookOpen = PhosphorDuotoneIconData(
-    0xe0e7,
-    PhosphorIconData(0xe0e6, 'Duotone'),
-  );
+  static const bookOpen = IconData(0xe0e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-open-text-duotone.svg)
-  static const bookOpenText = PhosphorDuotoneIconData(
-    0xe8f3,
-    PhosphorIconData(0xe8f2, 'Duotone'),
-  );
+  static const bookOpenText = IconData(0xe8f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-user-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/book-open-user-duotone.svg)
-  static const bookOpenUser = PhosphorDuotoneIconData(
-    0xede1,
-    PhosphorIconData(0xede0, 'Duotone'),
-  );
+  static const bookOpenUser = IconData(0xede1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bookmark-duotone.svg)
-  static const bookmark = PhosphorDuotoneIconData(
-    0xe0e9,
-    PhosphorIconData(0xe0e8, 'Duotone'),
-  );
+  static const bookmark = IconData(0xe0e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bookmark-simple-duotone.svg)
-  static const bookmarkSimple = PhosphorDuotoneIconData(
-    0xe0eb,
-    PhosphorIconData(0xe0ea, 'Duotone'),
-  );
+  static const bookmarkSimple = IconData(0xe0eb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bookmarks-duotone.svg)
-  static const bookmarks = PhosphorDuotoneIconData(
-    0xe0ed,
-    PhosphorIconData(0xe0ec, 'Duotone'),
-  );
+  static const bookmarks = IconData(0xe0ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bookmarks-simple-duotone.svg)
-  static const bookmarksSimple = PhosphorDuotoneIconData(
-    0xe5f1,
-    PhosphorIconData(0xe5f0, 'Duotone'),
-  );
+  static const bookmarksSimple = IconData(0xe5f1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![books-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/books-duotone.svg)
-  static const books = PhosphorDuotoneIconData(
-    0xe759,
-    PhosphorIconData(0xe758, 'Duotone'),
-  );
+  static const books = IconData(0xe759,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/boot-duotone.svg)
-  static const boot = PhosphorDuotoneIconData(
-    0xeccb,
-    PhosphorIconData(0xecca, 'Duotone'),
-  );
+  static const boot = IconData(0xeccb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boules-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/boules-duotone.svg)
-  static const boules = PhosphorDuotoneIconData(
-    0xe723,
-    PhosphorIconData(0xe722, 'Duotone'),
-  );
+  static const boules = IconData(0xe723,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bounding-box-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bounding-box-duotone.svg)
-  static const boundingBox = PhosphorDuotoneIconData(
-    0xe6cf,
-    PhosphorIconData(0xe6ce, 'Duotone'),
-  );
+  static const boundingBox = IconData(0xe6cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-food-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bowl-food-duotone.svg)
-  static const bowlFood = PhosphorDuotoneIconData(
-    0xeaa5,
-    PhosphorIconData(0xeaa4, 'Duotone'),
-  );
+  static const bowlFood = IconData(0xeaa5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-steam-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bowl-steam-duotone.svg)
-  static const bowlSteam = PhosphorDuotoneIconData(
-    0xe8e5,
-    PhosphorIconData(0xe8e4, 'Duotone'),
-  );
+  static const bowlSteam = IconData(0xe8e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowling-ball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bowling-ball-duotone.svg)
-  static const bowlingBall = PhosphorDuotoneIconData(
-    0xea35,
-    PhosphorIconData(0xea34, 'Duotone'),
-  );
+  static const bowlingBall = IconData(0xea35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/box-arrow-down-duotone.svg)
-  static const boxArrowDown = PhosphorDuotoneIconData(
-    0xe00f,
-    PhosphorIconData(0xe00e, 'Duotone'),
-  );
+  static const boxArrowDown = IconData(0xe00f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/box-arrow-up-duotone.svg)
-  static const boxArrowUp = PhosphorDuotoneIconData(
-    0xee55,
-    PhosphorIconData(0xee54, 'Duotone'),
-  );
+  static const boxArrowUp = IconData(0xee55,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boxing-glove-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/boxing-glove-duotone.svg)
-  static const boxingGlove = PhosphorDuotoneIconData(
-    0xea37,
-    PhosphorIconData(0xea36, 'Duotone'),
-  );
+  static const boxingGlove = IconData(0xea37,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-angle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brackets-angle-duotone.svg)
-  static const bracketsAngle = PhosphorDuotoneIconData(
-    0xe863,
-    PhosphorIconData(0xe862, 'Duotone'),
-  );
+  static const bracketsAngle = IconData(0xe863,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-curly-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brackets-curly-duotone.svg)
-  static const bracketsCurly = PhosphorDuotoneIconData(
-    0xe861,
-    PhosphorIconData(0xe860, 'Duotone'),
-  );
+  static const bracketsCurly = IconData(0xe861,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-round-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brackets-round-duotone.svg)
-  static const bracketsRound = PhosphorDuotoneIconData(
-    0xe865,
-    PhosphorIconData(0xe864, 'Duotone'),
-  );
+  static const bracketsRound = IconData(0xe865,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brackets-square-duotone.svg)
-  static const bracketsSquare = PhosphorDuotoneIconData(
-    0xe85f,
-    PhosphorIconData(0xe85e, 'Duotone'),
-  );
+  static const bracketsSquare = IconData(0xe85f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brain-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brain-duotone.svg)
-  static const brain = PhosphorDuotoneIconData(
-    0xe74f,
-    PhosphorIconData(0xe74e, 'Duotone'),
-  );
+  static const brain = IconData(0xe74f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brandy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/brandy-duotone.svg)
-  static const brandy = PhosphorDuotoneIconData(
-    0xe6b5,
-    PhosphorIconData(0xe6b4, 'Duotone'),
-  );
+  static const brandy = IconData(0xe6b5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bread-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bread-duotone.svg)
-  static const bread = PhosphorDuotoneIconData(
-    0xe81d,
-    PhosphorIconData(0xe81c, 'Duotone'),
-  );
+  static const bread = IconData(0xe81d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bridge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bridge-duotone.svg)
-  static const bridge = PhosphorDuotoneIconData(
-    0xea69,
-    PhosphorIconData(0xea68, 'Duotone'),
-  );
+  static const bridge = IconData(0xea69,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/briefcase-duotone.svg)
-  static const briefcase = PhosphorDuotoneIconData(
-    0xe0ef,
-    PhosphorIconData(0xe0ee, 'Duotone'),
-  );
+  static const briefcase = IconData(0xe0ef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-metal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/briefcase-metal-duotone.svg)
-  static const briefcaseMetal = PhosphorDuotoneIconData(
-    0xe5f3,
-    PhosphorIconData(0xe5f2, 'Duotone'),
-  );
+  static const briefcaseMetal = IconData(0xe5f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broadcast-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/broadcast-duotone.svg)
-  static const broadcast = PhosphorDuotoneIconData(
-    0xe0f3,
-    PhosphorIconData(0xe0f2, 'Duotone'),
-  );
+  static const broadcast = IconData(0xe0f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/broom-duotone.svg)
-  static const broom = PhosphorDuotoneIconData(
-    0xec55,
-    PhosphorIconData(0xec54, 'Duotone'),
-  );
+  static const broom = IconData(0xec55,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browser-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/browser-duotone.svg)
-  static const browser = PhosphorDuotoneIconData(
-    0xe0f5,
-    PhosphorIconData(0xe0f4, 'Duotone'),
-  );
+  static const browser = IconData(0xe0f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browsers-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/browsers-duotone.svg)
-  static const browsers = PhosphorDuotoneIconData(
-    0xe0f7,
-    PhosphorIconData(0xe0f6, 'Duotone'),
-  );
+  static const browsers = IconData(0xe0f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bug-duotone.svg)
-  static const bug = PhosphorDuotoneIconData(
-    0xe5f5,
-    PhosphorIconData(0xe5f4, 'Duotone'),
-  );
+  static const bug = IconData(0xe5f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-beetle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bug-beetle-duotone.svg)
-  static const bugBeetle = PhosphorDuotoneIconData(
-    0xe5f7,
-    PhosphorIconData(0xe5f6, 'Duotone'),
-  );
+  static const bugBeetle = IconData(0xe5f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-droid-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bug-droid-duotone.svg)
-  static const bugDroid = PhosphorDuotoneIconData(
-    0xe5f9,
-    PhosphorIconData(0xe5f8, 'Duotone'),
-  );
+  static const bugDroid = IconData(0xe5f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/building-duotone.svg)
-  static const building = PhosphorDuotoneIconData(
-    0xe101,
-    PhosphorIconData(0xe100, 'Duotone'),
-  );
+  static const building = IconData(0xe101,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-apartment-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/building-apartment-duotone.svg)
-  static const buildingApartment = PhosphorDuotoneIconData(
-    0xe103,
-    PhosphorIconData(0xe0fe, 'Duotone'),
-  );
+  static const buildingApartment = IconData(0xe103,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-office-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/building-office-duotone.svg)
-  static const buildingOffice = PhosphorDuotoneIconData(
-    0xe104,
-    PhosphorIconData(0xe0ff, 'Duotone'),
-  );
+  static const buildingOffice = IconData(0xe104,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![buildings-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/buildings-duotone.svg)
-  static const buildings = PhosphorDuotoneIconData(
-    0xe105,
-    PhosphorIconData(0xe102, 'Duotone'),
-  );
+  static const buildings = IconData(0xe105,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bulldozer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bulldozer-duotone.svg)
-  static const bulldozer = PhosphorDuotoneIconData(
-    0xec6d,
-    PhosphorIconData(0xec6c, 'Duotone'),
-  );
+  static const bulldozer = IconData(0xec6d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/bus-duotone.svg)
-  static const bus = PhosphorDuotoneIconData(
-    0xe107,
-    PhosphorIconData(0xe106, 'Duotone'),
-  );
+  static const bus = IconData(0xe107,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![butterfly-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/butterfly-duotone.svg)
-  static const butterfly = PhosphorDuotoneIconData(
-    0xea6f,
-    PhosphorIconData(0xea6e, 'Duotone'),
-  );
+  static const butterfly = IconData(0xea6f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cable-car-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cable-car-duotone.svg)
-  static const cableCar = PhosphorDuotoneIconData(
-    0xe49d,
-    PhosphorIconData(0xe49c, 'Duotone'),
-  );
+  static const cableCar = IconData(0xe49d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cactus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cactus-duotone.svg)
-  static const cactus = PhosphorDuotoneIconData(
-    0xe919,
-    PhosphorIconData(0xe918, 'Duotone'),
-  );
+  static const cactus = IconData(0xe919,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cake-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cake-duotone.svg)
-  static const cake = PhosphorDuotoneIconData(
-    0xe781,
-    PhosphorIconData(0xe780, 'Duotone'),
-  );
+  static const cake = IconData(0xe781,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calculator-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calculator-duotone.svg)
-  static const calculator = PhosphorDuotoneIconData(
-    0xe539,
-    PhosphorIconData(0xe538, 'Duotone'),
-  );
+  static const calculator = IconData(0xe539,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-duotone.svg)
-  static const calendar = PhosphorDuotoneIconData(
-    0xe109,
-    PhosphorIconData(0xe108, 'Duotone'),
-  );
+  static const calendar = IconData(0xe109,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-blank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-blank-duotone.svg)
-  static const calendarBlank = PhosphorDuotoneIconData(
-    0xe10b,
-    PhosphorIconData(0xe10a, 'Duotone'),
-  );
+  static const calendarBlank = IconData(0xe10b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-check-duotone.svg)
-  static const calendarCheck = PhosphorDuotoneIconData(
-    0xe713,
-    PhosphorIconData(0xe712, 'Duotone'),
-  );
+  static const calendarCheck = IconData(0xe713,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-dot-duotone.svg)
-  static const calendarDot = PhosphorDuotoneIconData(
-    0xe7b3,
-    PhosphorIconData(0xe7b2, 'Duotone'),
-  );
+  static const calendarDot = IconData(0xe7b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-dots-duotone.svg)
-  static const calendarDots = PhosphorDuotoneIconData(
-    0xe7b5,
-    PhosphorIconData(0xe7b4, 'Duotone'),
-  );
+  static const calendarDots = IconData(0xe7b5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-heart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-heart-duotone.svg)
-  static const calendarHeart = PhosphorDuotoneIconData(
-    0xe8b1,
-    PhosphorIconData(0xe8b0, 'Duotone'),
-  );
+  static const calendarHeart = IconData(0xe8b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-minus-duotone.svg)
-  static const calendarMinus = PhosphorDuotoneIconData(
-    0xea15,
-    PhosphorIconData(0xea14, 'Duotone'),
-  );
+  static const calendarMinus = IconData(0xea15,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-plus-duotone.svg)
-  static const calendarPlus = PhosphorDuotoneIconData(
-    0xe715,
-    PhosphorIconData(0xe714, 'Duotone'),
-  );
+  static const calendarPlus = IconData(0xe715,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-slash-duotone.svg)
-  static const calendarSlash = PhosphorDuotoneIconData(
-    0xea13,
-    PhosphorIconData(0xea12, 'Duotone'),
-  );
+  static const calendarSlash = IconData(0xea13,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-star-duotone.svg)
-  static const calendarStar = PhosphorDuotoneIconData(
-    0xe8b3,
-    PhosphorIconData(0xe8b2, 'Duotone'),
-  );
+  static const calendarStar = IconData(0xe8b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/calendar-x-duotone.svg)
-  static const calendarX = PhosphorDuotoneIconData(
-    0xe10d,
-    PhosphorIconData(0xe10c, 'Duotone'),
-  );
+  static const calendarX = IconData(0xe10d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![call-bell-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/call-bell-duotone.svg)
-  static const callBell = PhosphorDuotoneIconData(
-    0xe7df,
-    PhosphorIconData(0xe7de, 'Duotone'),
-  );
+  static const callBell = IconData(0xe7df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/camera-duotone.svg)
-  static const camera = PhosphorDuotoneIconData(
-    0xe10f,
-    PhosphorIconData(0xe10e, 'Duotone'),
-  );
+  static const camera = IconData(0xe10f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/camera-plus-duotone.svg)
-  static const cameraPlus = PhosphorDuotoneIconData(
-    0xec59,
-    PhosphorIconData(0xec58, 'Duotone'),
-  );
+  static const cameraPlus = IconData(0xec59,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-rotate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/camera-rotate-duotone.svg)
-  static const cameraRotate = PhosphorDuotoneIconData(
-    0xe7a5,
-    PhosphorIconData(0xe7a4, 'Duotone'),
-  );
+  static const cameraRotate = IconData(0xe7a5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/camera-slash-duotone.svg)
-  static const cameraSlash = PhosphorDuotoneIconData(
-    0xe111,
-    PhosphorIconData(0xe110, 'Duotone'),
-  );
+  static const cameraSlash = IconData(0xe111,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![campfire-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/campfire-duotone.svg)
-  static const campfire = PhosphorDuotoneIconData(
-    0xe9d9,
-    PhosphorIconData(0xe9d8, 'Duotone'),
-  );
+  static const campfire = IconData(0xe9d9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/car-duotone.svg)
-  static const car = PhosphorDuotoneIconData(
-    0xe113,
-    PhosphorIconData(0xe112, 'Duotone'),
-  );
+  static const car = IconData(0xe113,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-battery-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/car-battery-duotone.svg)
-  static const carBattery = PhosphorDuotoneIconData(
-    0xee31,
-    PhosphorIconData(0xee30, 'Duotone'),
-  );
+  static const carBattery = IconData(0xee31,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-profile-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/car-profile-duotone.svg)
-  static const carProfile = PhosphorDuotoneIconData(
-    0xe8cd,
-    PhosphorIconData(0xe8cc, 'Duotone'),
-  );
+  static const carProfile = IconData(0xe8cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/car-simple-duotone.svg)
-  static const carSimple = PhosphorDuotoneIconData(
-    0xe115,
-    PhosphorIconData(0xe114, 'Duotone'),
-  );
+  static const carSimple = IconData(0xe115,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cardholder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cardholder-duotone.svg)
-  static const cardholder = PhosphorDuotoneIconData(
-    0xe5fb,
-    PhosphorIconData(0xe5fa, 'Duotone'),
-  );
+  static const cardholder = IconData(0xe5fb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cards-duotone.svg)
-  static const cards = PhosphorDuotoneIconData(
-    0xe0f9,
-    PhosphorIconData(0xe0f8, 'Duotone'),
-  );
+  static const cards = IconData(0xe0f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cards-three-duotone.svg)
-  static const cardsThree = PhosphorDuotoneIconData(
-    0xee51,
-    PhosphorIconData(0xee50, 'Duotone'),
-  );
+  static const cardsThree = IconData(0xee51,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-double-down-duotone.svg)
-  static const caretCircleDoubleDown = PhosphorDuotoneIconData(
-    0xe117,
-    PhosphorIconData(0xe116, 'Duotone'),
-  );
+  static const caretCircleDoubleDown = IconData(0xe117,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-double-left-duotone.svg)
-  static const caretCircleDoubleLeft = PhosphorDuotoneIconData(
-    0xe119,
-    PhosphorIconData(0xe118, 'Duotone'),
-  );
+  static const caretCircleDoubleLeft = IconData(0xe119,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-double-right-duotone.svg)
-  static const caretCircleDoubleRight = PhosphorDuotoneIconData(
-    0xe11b,
-    PhosphorIconData(0xe11a, 'Duotone'),
-  );
+  static const caretCircleDoubleRight = IconData(0xe11b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-double-up-duotone.svg)
-  static const caretCircleDoubleUp = PhosphorDuotoneIconData(
-    0xe11d,
-    PhosphorIconData(0xe11c, 'Duotone'),
-  );
+  static const caretCircleDoubleUp = IconData(0xe11d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-down-duotone.svg)
-  static const caretCircleDown = PhosphorDuotoneIconData(
-    0xe11f,
-    PhosphorIconData(0xe11e, 'Duotone'),
-  );
+  static const caretCircleDown = IconData(0xe11f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-left-duotone.svg)
-  static const caretCircleLeft = PhosphorDuotoneIconData(
-    0xe121,
-    PhosphorIconData(0xe120, 'Duotone'),
-  );
+  static const caretCircleLeft = IconData(0xe121,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-right-duotone.svg)
-  static const caretCircleRight = PhosphorDuotoneIconData(
-    0xe123,
-    PhosphorIconData(0xe122, 'Duotone'),
-  );
+  static const caretCircleRight = IconData(0xe123,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-up-duotone.svg)
-  static const caretCircleUp = PhosphorDuotoneIconData(
-    0xe125,
-    PhosphorIconData(0xe124, 'Duotone'),
-  );
+  static const caretCircleUp = IconData(0xe125,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-circle-up-down-duotone.svg)
-  static const caretCircleUpDown = PhosphorDuotoneIconData(
-    0xe13f,
-    PhosphorIconData(0xe13e, 'Duotone'),
-  );
+  static const caretCircleUpDown = IconData(0xe13f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-double-down-duotone.svg)
-  static const caretDoubleDown = PhosphorDuotoneIconData(
-    0xe127,
-    PhosphorIconData(0xe126, 'Duotone'),
-  );
+  static const caretDoubleDown = IconData(0xe127,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-double-left-duotone.svg)
-  static const caretDoubleLeft = PhosphorDuotoneIconData(
-    0xe129,
-    PhosphorIconData(0xe128, 'Duotone'),
-  );
+  static const caretDoubleLeft = IconData(0xe129,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-double-right-duotone.svg)
-  static const caretDoubleRight = PhosphorDuotoneIconData(
-    0xe12b,
-    PhosphorIconData(0xe12a, 'Duotone'),
-  );
+  static const caretDoubleRight = IconData(0xe12b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-double-up-duotone.svg)
-  static const caretDoubleUp = PhosphorDuotoneIconData(
-    0xe12d,
-    PhosphorIconData(0xe12c, 'Duotone'),
-  );
+  static const caretDoubleUp = IconData(0xe12d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-down-duotone.svg)
-  static const caretDown = PhosphorDuotoneIconData(
-    0xe137,
-    PhosphorIconData(0xe136, 'Duotone'),
-  );
+  static const caretDown = IconData(0xe137,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-left-duotone.svg)
-  static const caretLeft = PhosphorDuotoneIconData(
-    0xe139,
-    PhosphorIconData(0xe138, 'Duotone'),
-  );
+  static const caretLeft = IconData(0xe139,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-line-down-duotone.svg)
-  static const caretLineDown = PhosphorDuotoneIconData(
-    0xe135,
-    PhosphorIconData(0xe134, 'Duotone'),
-  );
+  static const caretLineDown = IconData(0xe135,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-line-left-duotone.svg)
-  static const caretLineLeft = PhosphorDuotoneIconData(
-    0xe133,
-    PhosphorIconData(0xe132, 'Duotone'),
-  );
+  static const caretLineLeft = IconData(0xe133,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-line-right-duotone.svg)
-  static const caretLineRight = PhosphorDuotoneIconData(
-    0xe131,
-    PhosphorIconData(0xe130, 'Duotone'),
-  );
+  static const caretLineRight = IconData(0xe131,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-line-up-duotone.svg)
-  static const caretLineUp = PhosphorDuotoneIconData(
-    0xe12f,
-    PhosphorIconData(0xe12e, 'Duotone'),
-  );
+  static const caretLineUp = IconData(0xe12f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-right-duotone.svg)
-  static const caretRight = PhosphorDuotoneIconData(
-    0xe13b,
-    PhosphorIconData(0xe13a, 'Duotone'),
-  );
+  static const caretRight = IconData(0xe13b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-up-duotone.svg)
-  static const caretUp = PhosphorDuotoneIconData(
-    0xe13d,
-    PhosphorIconData(0xe13c, 'Duotone'),
-  );
+  static const caretUp = IconData(0xe13d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/caret-up-down-duotone.svg)
-  static const caretUpDown = PhosphorDuotoneIconData(
-    0xe141,
-    PhosphorIconData(0xe140, 'Duotone'),
-  );
+  static const caretUpDown = IconData(0xe141,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![carrot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/carrot-duotone.svg)
-  static const carrot = PhosphorDuotoneIconData(
-    0xed39,
-    PhosphorIconData(0xed38, 'Duotone'),
-  );
+  static const carrot = IconData(0xed39,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cash-register-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cash-register-duotone.svg)
-  static const cashRegister = PhosphorDuotoneIconData(
-    0xed81,
-    PhosphorIconData(0xed80, 'Duotone'),
-  );
+  static const cashRegister = IconData(0xed81,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cassette-tape-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cassette-tape-duotone.svg)
-  static const cassetteTape = PhosphorDuotoneIconData(
-    0xed2f,
-    PhosphorIconData(0xed2e, 'Duotone'),
-  );
+  static const cassetteTape = IconData(0xed2f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![castle-turret-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/castle-turret-duotone.svg)
-  static const castleTurret = PhosphorDuotoneIconData(
-    0xe9d1,
-    PhosphorIconData(0xe9d0, 'Duotone'),
-  );
+  static const castleTurret = IconData(0xe9d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cat-duotone.svg)
-  static const cat = PhosphorDuotoneIconData(
-    0xe749,
-    PhosphorIconData(0xe748, 'Duotone'),
-  );
+  static const cat = IconData(0xe749,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-full-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-full-duotone.svg)
-  static const cellSignalFull = PhosphorDuotoneIconData(
-    0xe143,
-    PhosphorIconData(0xe142, 'Duotone'),
-  );
+  static const cellSignalFull = IconData(0xe143,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-high-duotone.svg)
-  static const cellSignalHigh = PhosphorDuotoneIconData(
-    0xe145,
-    PhosphorIconData(0xe144, 'Duotone'),
-  );
+  static const cellSignalHigh = IconData(0xe145,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-low-duotone.svg)
-  static const cellSignalLow = PhosphorDuotoneIconData(
-    0xe147,
-    PhosphorIconData(0xe146, 'Duotone'),
-  );
+  static const cellSignalLow = IconData(0xe147,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-medium-duotone.svg)
-  static const cellSignalMedium = PhosphorDuotoneIconData(
-    0xe149,
-    PhosphorIconData(0xe148, 'Duotone'),
-  );
+  static const cellSignalMedium = IconData(0xe149,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-none-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-none-duotone.svg)
-  static const cellSignalNone = PhosphorFlatIconData(0xe14a, 'Duotone');
+  static const cellSignalNone = IconData(0xe14a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-slash-duotone.svg)
-  static const cellSignalSlash = PhosphorDuotoneIconData(
-    0xe14d,
-    PhosphorIconData(0xe14c, 'Duotone'),
-  );
+  static const cellSignalSlash = IconData(0xe14d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-signal-x-duotone.svg)
-  static const cellSignalX = PhosphorDuotoneIconData(
-    0xe14f,
-    PhosphorIconData(0xe14e, 'Duotone'),
-  );
+  static const cellSignalX = IconData(0xe14f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-tower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cell-tower-duotone.svg)
-  static const cellTower = PhosphorDuotoneIconData(
-    0xebab,
-    PhosphorIconData(0xebaa, 'Duotone'),
-  );
+  static const cellTower = IconData(0xebab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![certificate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/certificate-duotone.svg)
-  static const certificate = PhosphorDuotoneIconData(
-    0xe767,
-    PhosphorIconData(0xe766, 'Duotone'),
-  );
+  static const certificate = IconData(0xe767,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chair-duotone.svg)
-  static const chair = PhosphorDuotoneIconData(
-    0xe951,
-    PhosphorIconData(0xe950, 'Duotone'),
-  );
+  static const chair = IconData(0xe951,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chalkboard-duotone.svg)
-  static const chalkboard = PhosphorDuotoneIconData(
-    0xe5fd,
-    PhosphorIconData(0xe5fc, 'Duotone'),
-  );
+  static const chalkboard = IconData(0xe5fd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chalkboard-simple-duotone.svg)
-  static const chalkboardSimple = PhosphorDuotoneIconData(
-    0xe5ff,
-    PhosphorIconData(0xe5fe, 'Duotone'),
-  );
+  static const chalkboardSimple = IconData(0xe5ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-teacher-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chalkboard-teacher-duotone.svg)
-  static const chalkboardTeacher = PhosphorDuotoneIconData(
-    0xe601,
-    PhosphorIconData(0xe600, 'Duotone'),
-  );
+  static const chalkboardTeacher = IconData(0xe601,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![champagne-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/champagne-duotone.svg)
-  static const champagne = PhosphorDuotoneIconData(
-    0xeacb,
-    PhosphorIconData(0xeaca, 'Duotone'),
-  );
+  static const champagne = IconData(0xeacb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![charging-station-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/charging-station-duotone.svg)
-  static const chargingStation = PhosphorDuotoneIconData(
-    0xe8d1,
-    PhosphorIconData(0xe8d0, 'Duotone'),
-  );
+  static const chargingStation = IconData(0xe8d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-bar-duotone.svg)
-  static const chartBar = PhosphorDuotoneIconData(
-    0xe151,
-    PhosphorIconData(0xe150, 'Duotone'),
-  );
+  static const chartBar = IconData(0xe151,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-bar-horizontal-duotone.svg)
-  static const chartBarHorizontal = PhosphorDuotoneIconData(
-    0xe153,
-    PhosphorIconData(0xe152, 'Duotone'),
-  );
+  static const chartBarHorizontal = IconData(0xe153,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-donut-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-donut-duotone.svg)
-  static const chartDonut = PhosphorDuotoneIconData(
-    0xeaa7,
-    PhosphorIconData(0xeaa6, 'Duotone'),
-  );
+  static const chartDonut = IconData(0xeaa7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-line-duotone.svg)
-  static const chartLine = PhosphorDuotoneIconData(
-    0xe155,
-    PhosphorIconData(0xe154, 'Duotone'),
-  );
+  static const chartLine = IconData(0xe155,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-line-down-duotone.svg)
-  static const chartLineDown = PhosphorDuotoneIconData(
-    0xe8b7,
-    PhosphorIconData(0xe8b6, 'Duotone'),
-  );
+  static const chartLineDown = IconData(0xe8b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-line-up-duotone.svg)
-  static const chartLineUp = PhosphorDuotoneIconData(
-    0xe157,
-    PhosphorIconData(0xe156, 'Duotone'),
-  );
+  static const chartLineUp = IconData(0xe157,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-pie-duotone.svg)
-  static const chartPie = PhosphorDuotoneIconData(
-    0xe159,
-    PhosphorIconData(0xe158, 'Duotone'),
-  );
+  static const chartPie = IconData(0xe159,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-slice-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-pie-slice-duotone.svg)
-  static const chartPieSlice = PhosphorDuotoneIconData(
-    0xe15b,
-    PhosphorIconData(0xe15a, 'Duotone'),
-  );
+  static const chartPieSlice = IconData(0xe15b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-polar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-polar-duotone.svg)
-  static const chartPolar = PhosphorDuotoneIconData(
-    0xeaa9,
-    PhosphorIconData(0xeaa8, 'Duotone'),
-  );
+  static const chartPolar = IconData(0xeaa9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-scatter-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chart-scatter-duotone.svg)
-  static const chartScatter = PhosphorDuotoneIconData(
-    0xeaad,
-    PhosphorIconData(0xeaac, 'Duotone'),
-  );
+  static const chartScatter = IconData(0xeaad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-duotone.svg)
-  static const chat = PhosphorDuotoneIconData(
-    0xe15d,
-    PhosphorIconData(0xe15c, 'Duotone'),
-  );
+  static const chat = IconData(0xe15d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-centered-duotone.svg)
-  static const chatCentered = PhosphorDuotoneIconData(
-    0xe161,
-    PhosphorIconData(0xe160, 'Duotone'),
-  );
+  static const chatCentered = IconData(0xe161,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-centered-dots-duotone.svg)
-  static const chatCenteredDots = PhosphorDuotoneIconData(
-    0xe165,
-    PhosphorIconData(0xe164, 'Duotone'),
-  );
+  static const chatCenteredDots = IconData(0xe165,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-centered-slash-duotone.svg)
-  static const chatCenteredSlash = PhosphorDuotoneIconData(
-    0xe163,
-    PhosphorIconData(0xe162, 'Duotone'),
-  );
+  static const chatCenteredSlash = IconData(0xe163,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-centered-text-duotone.svg)
-  static const chatCenteredText = PhosphorDuotoneIconData(
-    0xe167,
-    PhosphorIconData(0xe166, 'Duotone'),
-  );
+  static const chatCenteredText = IconData(0xe167,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-circle-duotone.svg)
-  static const chatCircle = PhosphorDuotoneIconData(
-    0xe169,
-    PhosphorIconData(0xe168, 'Duotone'),
-  );
+  static const chatCircle = IconData(0xe169,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-circle-dots-duotone.svg)
-  static const chatCircleDots = PhosphorDuotoneIconData(
-    0xe16d,
-    PhosphorIconData(0xe16c, 'Duotone'),
-  );
+  static const chatCircleDots = IconData(0xe16d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-circle-slash-duotone.svg)
-  static const chatCircleSlash = PhosphorDuotoneIconData(
-    0xe16b,
-    PhosphorIconData(0xe16a, 'Duotone'),
-  );
+  static const chatCircleSlash = IconData(0xe16b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-circle-text-duotone.svg)
-  static const chatCircleText = PhosphorDuotoneIconData(
-    0xe16f,
-    PhosphorIconData(0xe16e, 'Duotone'),
-  );
+  static const chatCircleText = IconData(0xe16f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-dots-duotone.svg)
-  static const chatDots = PhosphorDuotoneIconData(
-    0xe171,
-    PhosphorIconData(0xe170, 'Duotone'),
-  );
+  static const chatDots = IconData(0xe171,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-slash-duotone.svg)
-  static const chatSlash = PhosphorDuotoneIconData(
-    0xe15f,
-    PhosphorIconData(0xe15e, 'Duotone'),
-  );
+  static const chatSlash = IconData(0xe15f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-teardrop-duotone.svg)
-  static const chatTeardrop = PhosphorDuotoneIconData(
-    0xe173,
-    PhosphorIconData(0xe172, 'Duotone'),
-  );
+  static const chatTeardrop = IconData(0xe173,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-dots-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-teardrop-dots-duotone.svg)
-  static const chatTeardropDots = PhosphorDuotoneIconData(
-    0xe177,
-    PhosphorIconData(0xe176, 'Duotone'),
-  );
+  static const chatTeardropDots = IconData(0xe177,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-teardrop-slash-duotone.svg)
-  static const chatTeardropSlash = PhosphorDuotoneIconData(
-    0xe175,
-    PhosphorIconData(0xe174, 'Duotone'),
-  );
+  static const chatTeardropSlash = IconData(0xe175,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-teardrop-text-duotone.svg)
-  static const chatTeardropText = PhosphorDuotoneIconData(
-    0xe179,
-    PhosphorIconData(0xe178, 'Duotone'),
-  );
+  static const chatTeardropText = IconData(0xe179,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chat-text-duotone.svg)
-  static const chatText = PhosphorDuotoneIconData(
-    0xe17b,
-    PhosphorIconData(0xe17a, 'Duotone'),
-  );
+  static const chatText = IconData(0xe17b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chats-duotone.svg)
-  static const chats = PhosphorDuotoneIconData(
-    0xe17d,
-    PhosphorIconData(0xe17c, 'Duotone'),
-  );
+  static const chats = IconData(0xe17d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chats-circle-duotone.svg)
-  static const chatsCircle = PhosphorDuotoneIconData(
-    0xe17f,
-    PhosphorIconData(0xe17e, 'Duotone'),
-  );
+  static const chatsCircle = IconData(0xe17f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-teardrop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chats-teardrop-duotone.svg)
-  static const chatsTeardrop = PhosphorDuotoneIconData(
-    0xe181,
-    PhosphorIconData(0xe180, 'Duotone'),
-  );
+  static const chatsTeardrop = IconData(0xe181,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-duotone.svg)
-  static const check = PhosphorDuotoneIconData(
-    0xe183,
-    PhosphorIconData(0xe182, 'Duotone'),
-  );
+  static const check = IconData(0xe183,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-circle-duotone.svg)
-  static const checkCircle = PhosphorDuotoneIconData(
-    0xe185,
-    PhosphorIconData(0xe184, 'Duotone'),
-  );
+  static const checkCircle = IconData(0xe185,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-fat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-fat-duotone.svg)
-  static const checkFat = PhosphorDuotoneIconData(
-    0xeba7,
-    PhosphorIconData(0xeba6, 'Duotone'),
-  );
+  static const checkFat = IconData(0xeba7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-square-duotone.svg)
-  static const checkSquare = PhosphorDuotoneIconData(
-    0xe187,
-    PhosphorIconData(0xe186, 'Duotone'),
-  );
+  static const checkSquare = IconData(0xe187,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-offset-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/check-square-offset-duotone.svg)
-  static const checkSquareOffset = PhosphorDuotoneIconData(
-    0xe189,
-    PhosphorIconData(0xe188, 'Duotone'),
-  );
+  static const checkSquareOffset = IconData(0xe189,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checkerboard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/checkerboard-duotone.svg)
-  static const checkerboard = PhosphorDuotoneIconData(
-    0xe8c5,
-    PhosphorIconData(0xe8c4, 'Duotone'),
-  );
+  static const checkerboard = IconData(0xe8c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checks-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/checks-duotone.svg)
-  static const checks = PhosphorDuotoneIconData(
-    0xe53b,
-    PhosphorIconData(0xe53a, 'Duotone'),
-  );
+  static const checks = IconData(0xe53b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheers-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cheers-duotone.svg)
-  static const cheers = PhosphorDuotoneIconData(
-    0xea4b,
-    PhosphorIconData(0xea4a, 'Duotone'),
-  );
+  static const cheers = IconData(0xea4b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheese-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cheese-duotone.svg)
-  static const cheese = PhosphorDuotoneIconData(
-    0xe9ff,
-    PhosphorIconData(0xe9fe, 'Duotone'),
-  );
+  static const cheese = IconData(0xe9ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chef-hat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/chef-hat-duotone.svg)
-  static const chefHat = PhosphorDuotoneIconData(
-    0xed8f,
-    PhosphorIconData(0xed8e, 'Duotone'),
-  );
+  static const chefHat = IconData(0xed8f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cherries-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cherries-duotone.svg)
-  static const cherries = PhosphorDuotoneIconData(
-    0xe831,
-    PhosphorIconData(0xe830, 'Duotone'),
-  );
+  static const cherries = IconData(0xe831,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![church-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/church-duotone.svg)
-  static const church = PhosphorDuotoneIconData(
-    0xeceb,
-    PhosphorIconData(0xecea, 'Duotone'),
-  );
+  static const church = IconData(0xeceb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cigarette-duotone.svg)
-  static const cigarette = PhosphorDuotoneIconData(
-    0xed91,
-    PhosphorIconData(0xed90, 'Duotone'),
-  );
+  static const cigarette = IconData(0xed91,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cigarette-slash-duotone.svg)
-  static const cigaretteSlash = PhosphorDuotoneIconData(
-    0xed93,
-    PhosphorIconData(0xed92, 'Duotone'),
-  );
+  static const cigaretteSlash = IconData(0xed93,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-duotone.svg)
-  static const circle = PhosphorDuotoneIconData(
-    0xe18b,
-    PhosphorIconData(0xe18a, 'Duotone'),
-  );
+  static const circle = IconData(0xe18b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-dashed-duotone.svg)
-  static const circleDashed = PhosphorDuotoneIconData(
-    0xe603,
-    PhosphorIconData(0xe602, 'Duotone'),
-  );
+  static const circleDashed = IconData(0xe603,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-half-duotone.svg)
-  static const circleHalf = PhosphorDuotoneIconData(
-    0xe18d,
-    PhosphorIconData(0xe18c, 'Duotone'),
-  );
+  static const circleHalf = IconData(0xe18d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-tilt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-half-tilt-duotone.svg)
-  static const circleHalfTilt = PhosphorDuotoneIconData(
-    0xe18f,
-    PhosphorIconData(0xe18e, 'Duotone'),
-  );
+  static const circleHalfTilt = IconData(0xe18f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-notch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circle-notch-duotone.svg)
-  static const circleNotch = PhosphorDuotoneIconData(
-    0xeb45,
-    PhosphorIconData(0xeb44, 'Duotone'),
-  );
+  static const circleNotch = IconData(0xeb45,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circles-four-duotone.svg)
-  static const circlesFour = PhosphorDuotoneIconData(
-    0xe191,
-    PhosphorIconData(0xe190, 'Duotone'),
-  );
+  static const circlesFour = IconData(0xe191,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circles-three-duotone.svg)
-  static const circlesThree = PhosphorDuotoneIconData(
-    0xe193,
-    PhosphorIconData(0xe192, 'Duotone'),
-  );
+  static const circlesThree = IconData(0xe193,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circles-three-plus-duotone.svg)
-  static const circlesThreePlus = PhosphorDuotoneIconData(
-    0xe195,
-    PhosphorIconData(0xe194, 'Duotone'),
-  );
+  static const circlesThreePlus = IconData(0xe195,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circuitry-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/circuitry-duotone.svg)
-  static const circuitry = PhosphorDuotoneIconData(
-    0xe9c3,
-    PhosphorIconData(0xe9c2, 'Duotone'),
-  );
+  static const circuitry = IconData(0xe9c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![city-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/city-duotone.svg)
-  static const city = PhosphorDuotoneIconData(
-    0xea6b,
-    PhosphorIconData(0xea6a, 'Duotone'),
-  );
+  static const city = IconData(0xea6b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clipboard-duotone.svg)
-  static const clipboard = PhosphorDuotoneIconData(
-    0xe197,
-    PhosphorIconData(0xe196, 'Duotone'),
-  );
+  static const clipboard = IconData(0xe197,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clipboard-text-duotone.svg)
-  static const clipboardText = PhosphorDuotoneIconData(
-    0xe199,
-    PhosphorIconData(0xe198, 'Duotone'),
-  );
+  static const clipboardText = IconData(0xe199,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-duotone.svg)
-  static const clock = PhosphorDuotoneIconData(
-    0xe19b,
-    PhosphorIconData(0xe19a, 'Duotone'),
-  );
+  static const clock = IconData(0xe19b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-afternoon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-afternoon-duotone.svg)
-  static const clockAfternoon = PhosphorDuotoneIconData(
-    0xe19d,
-    PhosphorIconData(0xe19c, 'Duotone'),
-  );
+  static const clockAfternoon = IconData(0xe19d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-clockwise-duotone.svg)
-  static const clockClockwise = PhosphorDuotoneIconData(
-    0xe19f,
-    PhosphorIconData(0xe19e, 'Duotone'),
-  );
+  static const clockClockwise = IconData(0xe19f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-countdown-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-countdown-duotone.svg)
-  static const clockCountdown = PhosphorDuotoneIconData(
-    0xed2d,
-    PhosphorIconData(0xed2c, 'Duotone'),
-  );
+  static const clockCountdown = IconData(0xed2d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-counter-clockwise-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-counter-clockwise-duotone.svg)
-  static const clockCounterClockwise = PhosphorDuotoneIconData(
-    0xe1a1,
-    PhosphorIconData(0xe1a0, 'Duotone'),
-  );
+  static const clockCounterClockwise = IconData(0xe1a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-user-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clock-user-duotone.svg)
-  static const clockUser = PhosphorDuotoneIconData(
-    0xeded,
-    PhosphorIconData(0xedec, 'Duotone'),
-  );
+  static const clockUser = IconData(0xeded,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![closed-captioning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/closed-captioning-duotone.svg)
-  static const closedCaptioning = PhosphorDuotoneIconData(
-    0xe1a5,
-    PhosphorIconData(0xe1a4, 'Duotone'),
-  );
+  static const closedCaptioning = IconData(0xe1a5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-duotone.svg)
-  static const cloud = PhosphorDuotoneIconData(
-    0xe1ab,
-    PhosphorIconData(0xe1aa, 'Duotone'),
-  );
+  static const cloud = IconData(0xe1ab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-arrow-down-duotone.svg)
-  static const cloudArrowDown = PhosphorDuotoneIconData(
-    0xe1ad,
-    PhosphorIconData(0xe1ac, 'Duotone'),
-  );
+  static const cloudArrowDown = IconData(0xe1ad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-arrow-up-duotone.svg)
-  static const cloudArrowUp = PhosphorDuotoneIconData(
-    0xe1af,
-    PhosphorIconData(0xe1ae, 'Duotone'),
-  );
+  static const cloudArrowUp = IconData(0xe1af,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-check-duotone.svg)
-  static const cloudCheck = PhosphorDuotoneIconData(
-    0xe1b1,
-    PhosphorIconData(0xe1b0, 'Duotone'),
-  );
+  static const cloudCheck = IconData(0xe1b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-fog-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-fog-duotone.svg)
-  static const cloudFog = PhosphorDuotoneIconData(
-    0xe53d,
-    PhosphorIconData(0xe53c, 'Duotone'),
-  );
+  static const cloudFog = IconData(0xe53d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-lightning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-lightning-duotone.svg)
-  static const cloudLightning = PhosphorDuotoneIconData(
-    0xe1b3,
-    PhosphorIconData(0xe1b2, 'Duotone'),
-  );
+  static const cloudLightning = IconData(0xe1b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-moon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-moon-duotone.svg)
-  static const cloudMoon = PhosphorDuotoneIconData(
-    0xe53f,
-    PhosphorIconData(0xe53e, 'Duotone'),
-  );
+  static const cloudMoon = IconData(0xe53f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-rain-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-rain-duotone.svg)
-  static const cloudRain = PhosphorDuotoneIconData(
-    0xe1b5,
-    PhosphorIconData(0xe1b4, 'Duotone'),
-  );
+  static const cloudRain = IconData(0xe1b5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-slash-duotone.svg)
-  static const cloudSlash = PhosphorDuotoneIconData(
-    0xe1b7,
-    PhosphorIconData(0xe1b6, 'Duotone'),
-  );
+  static const cloudSlash = IconData(0xe1b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-snow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-snow-duotone.svg)
-  static const cloudSnow = PhosphorDuotoneIconData(
-    0xe1b9,
-    PhosphorIconData(0xe1b8, 'Duotone'),
-  );
+  static const cloudSnow = IconData(0xe1b9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-sun-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-sun-duotone.svg)
-  static const cloudSun = PhosphorDuotoneIconData(
-    0xe541,
-    PhosphorIconData(0xe540, 'Duotone'),
-  );
+  static const cloudSun = IconData(0xe541,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-warning-duotone.svg)
-  static const cloudWarning = PhosphorDuotoneIconData(
-    0xea99,
-    PhosphorIconData(0xea98, 'Duotone'),
-  );
+  static const cloudWarning = IconData(0xea99,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cloud-x-duotone.svg)
-  static const cloudX = PhosphorDuotoneIconData(
-    0xea97,
-    PhosphorIconData(0xea96, 'Duotone'),
-  );
+  static const cloudX = IconData(0xea97,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clover-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/clover-duotone.svg)
-  static const clover = PhosphorDuotoneIconData(
-    0xedc9,
-    PhosphorIconData(0xedc8, 'Duotone'),
-  );
+  static const clover = IconData(0xedc9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![club-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/club-duotone.svg)
-  static const club = PhosphorDuotoneIconData(
-    0xe1bb,
-    PhosphorIconData(0xe1ba, 'Duotone'),
-  );
+  static const club = IconData(0xe1bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coat-hanger-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coat-hanger-duotone.svg)
-  static const coatHanger = PhosphorDuotoneIconData(
-    0xe7ff,
-    PhosphorIconData(0xe7fe, 'Duotone'),
-  );
+  static const coatHanger = IconData(0xe7ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coda-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coda-logo-duotone.svg)
-  static const codaLogo = PhosphorDuotoneIconData(
-    0xe7cf,
-    PhosphorIconData(0xe7ce, 'Duotone'),
-  );
+  static const codaLogo = IconData(0xe7cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/code-duotone.svg)
-  static const code = PhosphorDuotoneIconData(
-    0xe1bd,
-    PhosphorIconData(0xe1bc, 'Duotone'),
-  );
+  static const code = IconData(0xe1bd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-block-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/code-block-duotone.svg)
-  static const codeBlock = PhosphorDuotoneIconData(
-    0xeaff,
-    PhosphorIconData(0xeafe, 'Duotone'),
-  );
+  static const codeBlock = IconData(0xeaff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/code-simple-duotone.svg)
-  static const codeSimple = PhosphorDuotoneIconData(
-    0xe1bf,
-    PhosphorIconData(0xe1be, 'Duotone'),
-  );
+  static const codeSimple = IconData(0xe1bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codepen-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/codepen-logo-duotone.svg)
-  static const codepenLogo = PhosphorDuotoneIconData(
-    0xe979,
-    PhosphorIconData(0xe978, 'Duotone'),
-  );
+  static const codepenLogo = IconData(0xe979,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codesandbox-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/codesandbox-logo-duotone.svg)
-  static const codesandboxLogo = PhosphorDuotoneIconData(
-    0xea07,
-    PhosphorIconData(0xea06, 'Duotone'),
-  );
+  static const codesandboxLogo = IconData(0xea07,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coffee-duotone.svg)
-  static const coffee = PhosphorDuotoneIconData(
-    0xe1c3,
-    PhosphorIconData(0xe1c2, 'Duotone'),
-  );
+  static const coffee = IconData(0xe1c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-bean-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coffee-bean-duotone.svg)
-  static const coffeeBean = PhosphorDuotoneIconData(
-    0xe1c1,
-    PhosphorIconData(0xe1c0, 'Duotone'),
-  );
+  static const coffeeBean = IconData(0xe1c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coin-duotone.svg)
-  static const coin = PhosphorDuotoneIconData(
-    0xe60f,
-    PhosphorIconData(0xe60e, 'Duotone'),
-  );
+  static const coin = IconData(0xe60f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coin-vertical-duotone.svg)
-  static const coinVertical = PhosphorDuotoneIconData(
-    0xeb49,
-    PhosphorIconData(0xeb48, 'Duotone'),
-  );
+  static const coinVertical = IconData(0xeb49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coins-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/coins-duotone.svg)
-  static const coins = PhosphorDuotoneIconData(
-    0xe78f,
-    PhosphorIconData(0xe78e, 'Duotone'),
-  );
+  static const coins = IconData(0xe78f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/columns-duotone.svg)
-  static const columns = PhosphorDuotoneIconData(
-    0xe547,
-    PhosphorIconData(0xe546, 'Duotone'),
-  );
+  static const columns = IconData(0xe547,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/columns-plus-left-duotone.svg)
-  static const columnsPlusLeft = PhosphorDuotoneIconData(
-    0xe545,
-    PhosphorIconData(0xe544, 'Duotone'),
-  );
+  static const columnsPlusLeft = IconData(0xe545,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/columns-plus-right-duotone.svg)
-  static const columnsPlusRight = PhosphorDuotoneIconData(
-    0xe543,
-    PhosphorIconData(0xe542, 'Duotone'),
-  );
+  static const columnsPlusRight = IconData(0xe543,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![command-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/command-duotone.svg)
-  static const command = PhosphorDuotoneIconData(
-    0xe1c5,
-    PhosphorIconData(0xe1c4, 'Duotone'),
-  );
+  static const command = IconData(0xe1c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/compass-duotone.svg)
-  static const compass = PhosphorDuotoneIconData(
-    0xe1c9,
-    PhosphorIconData(0xe1c8, 'Duotone'),
-  );
+  static const compass = IconData(0xe1c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-rose-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/compass-rose-duotone.svg)
-  static const compassRose = PhosphorDuotoneIconData(
-    0xe1c7,
-    PhosphorIconData(0xe1c6, 'Duotone'),
-  );
+  static const compassRose = IconData(0xe1c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-tool-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/compass-tool-duotone.svg)
-  static const compassTool = PhosphorDuotoneIconData(
-    0xea0f,
-    PhosphorIconData(0xea0e, 'Duotone'),
-  );
+  static const compassTool = IconData(0xea0f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![computer-tower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/computer-tower-duotone.svg)
-  static const computerTower = PhosphorDuotoneIconData(
-    0xe549,
-    PhosphorIconData(0xe548, 'Duotone'),
-  );
+  static const computerTower = IconData(0xe549,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![confetti-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/confetti-duotone.svg)
-  static const confetti = PhosphorDuotoneIconData(
-    0xe81b,
-    PhosphorIconData(0xe81a, 'Duotone'),
-  );
+  static const confetti = IconData(0xe81b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![contactless-payment-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/contactless-payment-duotone.svg)
-  static const contactlessPayment = PhosphorDuotoneIconData(
-    0xed43,
-    PhosphorIconData(0xed42, 'Duotone'),
-  );
+  static const contactlessPayment = IconData(0xed43,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![control-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/control-duotone.svg)
-  static const control = PhosphorDuotoneIconData(
-    0xeca7,
-    PhosphorIconData(0xeca6, 'Duotone'),
-  );
+  static const control = IconData(0xeca7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cookie-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cookie-duotone.svg)
-  static const cookie = PhosphorDuotoneIconData(
-    0xe6cb,
-    PhosphorIconData(0xe6ca, 'Duotone'),
-  );
+  static const cookie = IconData(0xe6cb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cooking-pot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cooking-pot-duotone.svg)
-  static const cookingPot = PhosphorDuotoneIconData(
-    0xe765,
-    PhosphorIconData(0xe764, 'Duotone'),
-  );
+  static const cookingPot = IconData(0xe765,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/copy-duotone.svg)
-  static const copy = PhosphorDuotoneIconData(
-    0xe1cb,
-    PhosphorIconData(0xe1ca, 'Duotone'),
-  );
+  static const copy = IconData(0xe1cb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/copy-simple-duotone.svg)
-  static const copySimple = PhosphorDuotoneIconData(
-    0xe1cd,
-    PhosphorIconData(0xe1cc, 'Duotone'),
-  );
+  static const copySimple = IconData(0xe1cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyleft-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/copyleft-duotone.svg)
-  static const copyleft = PhosphorDuotoneIconData(
-    0xe86b,
-    PhosphorIconData(0xe86a, 'Duotone'),
-  );
+  static const copyleft = IconData(0xe86b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyright-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/copyright-duotone.svg)
-  static const copyright = PhosphorDuotoneIconData(
-    0xe54b,
-    PhosphorIconData(0xe54a, 'Duotone'),
-  );
+  static const copyright = IconData(0xe54b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-in-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/corners-in-duotone.svg)
-  static const cornersIn = PhosphorDuotoneIconData(
-    0xe1cf,
-    PhosphorIconData(0xe1ce, 'Duotone'),
-  );
+  static const cornersIn = IconData(0xe1cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-out-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/corners-out-duotone.svg)
-  static const cornersOut = PhosphorDuotoneIconData(
-    0xe1d1,
-    PhosphorIconData(0xe1d0, 'Duotone'),
-  );
+  static const cornersOut = IconData(0xe1d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![couch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/couch-duotone.svg)
-  static const couch = PhosphorDuotoneIconData(
-    0xe7f7,
-    PhosphorIconData(0xe7f6, 'Duotone'),
-  );
+  static const couch = IconData(0xe7f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![court-basketball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/court-basketball-duotone.svg)
-  static const courtBasketball = PhosphorDuotoneIconData(
-    0xee37,
-    PhosphorIconData(0xee36, 'Duotone'),
-  );
+  static const courtBasketball = IconData(0xee37,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cow-duotone.svg)
-  static const cow = PhosphorDuotoneIconData(
-    0xeabf,
-    PhosphorIconData(0xeabe, 'Duotone'),
-  );
+  static const cow = IconData(0xeabf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cowboy-hat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cowboy-hat-duotone.svg)
-  static const cowboyHat = PhosphorDuotoneIconData(
-    0xed13,
-    PhosphorIconData(0xed12, 'Duotone'),
-  );
+  static const cowboyHat = IconData(0xed13,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cpu-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cpu-duotone.svg)
-  static const cpu = PhosphorDuotoneIconData(
-    0xe611,
-    PhosphorIconData(0xe610, 'Duotone'),
-  );
+  static const cpu = IconData(0xe611,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crane-duotone.svg)
-  static const crane = PhosphorDuotoneIconData(
-    0xed4b,
-    PhosphorIconData(0xed48, 'Duotone'),
-  );
+  static const crane = IconData(0xed4b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-tower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crane-tower-duotone.svg)
-  static const craneTower = PhosphorDuotoneIconData(
-    0xed4d,
-    PhosphorIconData(0xed49, 'Duotone'),
-  );
+  static const craneTower = IconData(0xed4d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![credit-card-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/credit-card-duotone.svg)
-  static const creditCard = PhosphorDuotoneIconData(
-    0xe1d3,
-    PhosphorIconData(0xe1d2, 'Duotone'),
-  );
+  static const creditCard = IconData(0xe1d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cricket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cricket-duotone.svg)
-  static const cricket = PhosphorDuotoneIconData(
-    0xee13,
-    PhosphorIconData(0xee12, 'Duotone'),
-  );
+  static const cricket = IconData(0xee13,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crop-duotone.svg)
-  static const crop = PhosphorDuotoneIconData(
-    0xe1d5,
-    PhosphorIconData(0xe1d4, 'Duotone'),
-  );
+  static const crop = IconData(0xe1d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cross-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cross-duotone.svg)
-  static const cross = PhosphorDuotoneIconData(
-    0xe8a1,
-    PhosphorIconData(0xe8a0, 'Duotone'),
-  );
+  static const cross = IconData(0xe8a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crosshair-duotone.svg)
-  static const crosshair = PhosphorDuotoneIconData(
-    0xe1d7,
-    PhosphorIconData(0xe1d6, 'Duotone'),
-  );
+  static const crosshair = IconData(0xe1d7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crosshair-simple-duotone.svg)
-  static const crosshairSimple = PhosphorDuotoneIconData(
-    0xe1d9,
-    PhosphorIconData(0xe1d8, 'Duotone'),
-  );
+  static const crosshairSimple = IconData(0xe1d9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crown-duotone.svg)
-  static const crown = PhosphorDuotoneIconData(
-    0xe615,
-    PhosphorIconData(0xe614, 'Duotone'),
-  );
+  static const crown = IconData(0xe615,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-cross-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crown-cross-duotone.svg)
-  static const crownCross = PhosphorDuotoneIconData(
-    0xee5f,
-    PhosphorIconData(0xee5e, 'Duotone'),
-  );
+  static const crownCross = IconData(0xee5f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/crown-simple-duotone.svg)
-  static const crownSimple = PhosphorDuotoneIconData(
-    0xe617,
-    PhosphorIconData(0xe616, 'Duotone'),
-  );
+  static const crownSimple = IconData(0xe617,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cube-duotone.svg)
-  static const cube = PhosphorDuotoneIconData(
-    0xe1db,
-    PhosphorIconData(0xe1da, 'Duotone'),
-  );
+  static const cube = IconData(0xe1db,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-focus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cube-focus-duotone.svg)
-  static const cubeFocus = PhosphorDuotoneIconData(
-    0xed0b,
-    PhosphorIconData(0xed0a, 'Duotone'),
-  );
+  static const cubeFocus = IconData(0xed0b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-transparent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cube-transparent-duotone.svg)
-  static const cubeTransparent = PhosphorDuotoneIconData(
-    0xec7d,
-    PhosphorIconData(0xec7c, 'Duotone'),
-  );
+  static const cubeTransparent = IconData(0xec7d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-btc-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-btc-duotone.svg)
-  static const currencyBtc = PhosphorDuotoneIconData(
-    0xe619,
-    PhosphorIconData(0xe618, 'Duotone'),
-  );
+  static const currencyBtc = IconData(0xe619,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-circle-dollar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-circle-dollar-duotone.svg)
-  static const currencyCircleDollar = PhosphorDuotoneIconData(
-    0xe54d,
-    PhosphorIconData(0xe54c, 'Duotone'),
-  );
+  static const currencyCircleDollar = IconData(0xe54d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-cny-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-cny-duotone.svg)
-  static const currencyCny = PhosphorDuotoneIconData(
-    0xe54f,
-    PhosphorIconData(0xe54e, 'Duotone'),
-  );
+  static const currencyCny = IconData(0xe54f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-dollar-duotone.svg)
-  static const currencyDollar = PhosphorDuotoneIconData(
-    0xe551,
-    PhosphorIconData(0xe550, 'Duotone'),
-  );
+  static const currencyDollar = IconData(0xe551,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-dollar-simple-duotone.svg)
-  static const currencyDollarSimple = PhosphorDuotoneIconData(
-    0xe553,
-    PhosphorIconData(0xe552, 'Duotone'),
-  );
+  static const currencyDollarSimple = IconData(0xe553,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eth-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-eth-duotone.svg)
-  static const currencyEth = PhosphorDuotoneIconData(
-    0xeadb,
-    PhosphorIconData(0xeada, 'Duotone'),
-  );
+  static const currencyEth = IconData(0xeadb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eur-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-eur-duotone.svg)
-  static const currencyEur = PhosphorDuotoneIconData(
-    0xe555,
-    PhosphorIconData(0xe554, 'Duotone'),
-  );
+  static const currencyEur = IconData(0xe555,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-gbp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-gbp-duotone.svg)
-  static const currencyGbp = PhosphorDuotoneIconData(
-    0xe557,
-    PhosphorIconData(0xe556, 'Duotone'),
-  );
+  static const currencyGbp = IconData(0xe557,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-inr-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-inr-duotone.svg)
-  static const currencyInr = PhosphorDuotoneIconData(
-    0xe559,
-    PhosphorIconData(0xe558, 'Duotone'),
-  );
+  static const currencyInr = IconData(0xe559,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-jpy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-jpy-duotone.svg)
-  static const currencyJpy = PhosphorDuotoneIconData(
-    0xe55b,
-    PhosphorIconData(0xe55a, 'Duotone'),
-  );
+  static const currencyJpy = IconData(0xe55b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-krw-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-krw-duotone.svg)
-  static const currencyKrw = PhosphorDuotoneIconData(
-    0xe55d,
-    PhosphorIconData(0xe55c, 'Duotone'),
-  );
+  static const currencyKrw = IconData(0xe55d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-kzt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-kzt-duotone.svg)
-  static const currencyKzt = PhosphorDuotoneIconData(
-    0xec4d,
-    PhosphorIconData(0xec4c, 'Duotone'),
-  );
+  static const currencyKzt = IconData(0xec4d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-ngn-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-ngn-duotone.svg)
-  static const currencyNgn = PhosphorDuotoneIconData(
-    0xeb53,
-    PhosphorIconData(0xeb52, 'Duotone'),
-  );
+  static const currencyNgn = IconData(0xeb53,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-rub-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/currency-rub-duotone.svg)
-  static const currencyRub = PhosphorDuotoneIconData(
-    0xe55f,
-    PhosphorIconData(0xe55e, 'Duotone'),
-  );
+  static const currencyRub = IconData(0xe55f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cursor-duotone.svg)
-  static const cursor = PhosphorDuotoneIconData(
-    0xe1dd,
-    PhosphorIconData(0xe1dc, 'Duotone'),
-  );
+  static const cursor = IconData(0xe1dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-click-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cursor-click-duotone.svg)
-  static const cursorClick = PhosphorDuotoneIconData(
-    0xe7c9,
-    PhosphorIconData(0xe7c8, 'Duotone'),
-  );
+  static const cursorClick = IconData(0xe7c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cursor-text-duotone.svg)
-  static const cursorText = PhosphorDuotoneIconData(
-    0xe7d9,
-    PhosphorIconData(0xe7d8, 'Duotone'),
-  );
+  static const cursorText = IconData(0xe7d9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cylinder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/cylinder-duotone.svg)
-  static const cylinder = PhosphorDuotoneIconData(
-    0xe8fd,
-    PhosphorIconData(0xe8fc, 'Duotone'),
-  );
+  static const cylinder = IconData(0xe8fd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![database-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/database-duotone.svg)
-  static const database = PhosphorDuotoneIconData(
-    0xe1df,
-    PhosphorIconData(0xe1de, 'Duotone'),
-  );
+  static const database = IconData(0xe1df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desk-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/desk-duotone.svg)
-  static const desk = PhosphorDuotoneIconData(
-    0xed17,
-    PhosphorIconData(0xed16, 'Duotone'),
-  );
+  static const desk = IconData(0xed17,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/desktop-duotone.svg)
-  static const desktop = PhosphorDuotoneIconData(
-    0xe561,
-    PhosphorIconData(0xe560, 'Duotone'),
-  );
+  static const desktop = IconData(0xe561,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-tower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/desktop-tower-duotone.svg)
-  static const desktopTower = PhosphorDuotoneIconData(
-    0xe563,
-    PhosphorIconData(0xe562, 'Duotone'),
-  );
+  static const desktopTower = IconData(0xe563,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![detective-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/detective-duotone.svg)
-  static const detective = PhosphorDuotoneIconData(
-    0xe83f,
-    PhosphorIconData(0xe83e, 'Duotone'),
-  );
+  static const detective = IconData(0xe83f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dev-to-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dev-to-logo-duotone.svg)
-  static const devToLogo = PhosphorDuotoneIconData(
-    0xed0f,
-    PhosphorIconData(0xed0e, 'Duotone'),
-  );
+  static const devToLogo = IconData(0xed0f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-mobile-duotone.svg)
-  static const deviceMobile = PhosphorDuotoneIconData(
-    0xe1e1,
-    PhosphorIconData(0xe1e0, 'Duotone'),
-  );
+  static const deviceMobile = IconData(0xe1e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-mobile-camera-duotone.svg)
-  static const deviceMobileCamera = PhosphorDuotoneIconData(
-    0xe1e3,
-    PhosphorIconData(0xe1e2, 'Duotone'),
-  );
+  static const deviceMobileCamera = IconData(0xe1e3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-mobile-slash-duotone.svg)
-  static const deviceMobileSlash = PhosphorDuotoneIconData(
-    0xee47,
-    PhosphorIconData(0xee46, 'Duotone'),
-  );
+  static const deviceMobileSlash = IconData(0xee47,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-speaker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-mobile-speaker-duotone.svg)
-  static const deviceMobileSpeaker = PhosphorDuotoneIconData(
-    0xe1e5,
-    PhosphorIconData(0xe1e4, 'Duotone'),
-  );
+  static const deviceMobileSpeaker = IconData(0xe1e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-rotate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-rotate-duotone.svg)
-  static const deviceRotate = PhosphorDuotoneIconData(
-    0xedf3,
-    PhosphorIconData(0xedf2, 'Duotone'),
-  );
+  static const deviceRotate = IconData(0xedf3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-tablet-duotone.svg)
-  static const deviceTablet = PhosphorDuotoneIconData(
-    0xe1e7,
-    PhosphorIconData(0xe1e6, 'Duotone'),
-  );
+  static const deviceTablet = IconData(0xe1e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-tablet-camera-duotone.svg)
-  static const deviceTabletCamera = PhosphorDuotoneIconData(
-    0xe1e9,
-    PhosphorIconData(0xe1e8, 'Duotone'),
-  );
+  static const deviceTabletCamera = IconData(0xe1e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-speaker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/device-tablet-speaker-duotone.svg)
-  static const deviceTabletSpeaker = PhosphorDuotoneIconData(
-    0xe1eb,
-    PhosphorIconData(0xe1ea, 'Duotone'),
-  );
+  static const deviceTabletSpeaker = IconData(0xe1eb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![devices-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/devices-duotone.svg)
-  static const devices = PhosphorDuotoneIconData(
-    0xeba5,
-    PhosphorIconData(0xeba4, 'Duotone'),
-  );
+  static const devices = IconData(0xeba5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamond-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/diamond-duotone.svg)
-  static const diamond = PhosphorDuotoneIconData(
-    0xe1ed,
-    PhosphorIconData(0xe1ec, 'Duotone'),
-  );
+  static const diamond = IconData(0xe1ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamonds-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/diamonds-four-duotone.svg)
-  static const diamondsFour = PhosphorDuotoneIconData(
-    0xe8f5,
-    PhosphorIconData(0xe8f4, 'Duotone'),
-  );
+  static const diamondsFour = IconData(0xe8f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-five-duotone.svg)
-  static const diceFive = PhosphorDuotoneIconData(
-    0xe1ef,
-    PhosphorIconData(0xe1ee, 'Duotone'),
-  );
+  static const diceFive = IconData(0xe1ef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-four-duotone.svg)
-  static const diceFour = PhosphorDuotoneIconData(
-    0xe1f1,
-    PhosphorIconData(0xe1f0, 'Duotone'),
-  );
+  static const diceFour = IconData(0xe1f1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-one-duotone.svg)
-  static const diceOne = PhosphorDuotoneIconData(
-    0xe1f3,
-    PhosphorIconData(0xe1f2, 'Duotone'),
-  );
+  static const diceOne = IconData(0xe1f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-six-duotone.svg)
-  static const diceSix = PhosphorDuotoneIconData(
-    0xe1f5,
-    PhosphorIconData(0xe1f4, 'Duotone'),
-  );
+  static const diceSix = IconData(0xe1f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-three-duotone.svg)
-  static const diceThree = PhosphorDuotoneIconData(
-    0xe1f7,
-    PhosphorIconData(0xe1f6, 'Duotone'),
-  );
+  static const diceThree = IconData(0xe1f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dice-two-duotone.svg)
-  static const diceTwo = PhosphorDuotoneIconData(
-    0xe1f9,
-    PhosphorIconData(0xe1f8, 'Duotone'),
-  );
+  static const diceTwo = IconData(0xe1f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disc-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/disc-duotone.svg)
-  static const disc = PhosphorDuotoneIconData(
-    0xe565,
-    PhosphorIconData(0xe564, 'Duotone'),
-  );
+  static const disc = IconData(0xe565,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disco-ball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/disco-ball-duotone.svg)
-  static const discoBall = PhosphorDuotoneIconData(
-    0xed99,
-    PhosphorIconData(0xed98, 'Duotone'),
-  );
+  static const discoBall = IconData(0xed99,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![discord-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/discord-logo-duotone.svg)
-  static const discordLogo = PhosphorDuotoneIconData(
-    0xe61b,
-    PhosphorIconData(0xe61a, 'Duotone'),
-  );
+  static const discordLogo = IconData(0xe61b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![divide-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/divide-duotone.svg)
-  static const divide = PhosphorDuotoneIconData(
-    0xe1fb,
-    PhosphorIconData(0xe1fa, 'Duotone'),
-  );
+  static const divide = IconData(0xe1fb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dna-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dna-duotone.svg)
-  static const dna = PhosphorDuotoneIconData(
-    0xe925,
-    PhosphorIconData(0xe924, 'Duotone'),
-  );
+  static const dna = IconData(0xe925,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dog-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dog-duotone.svg)
-  static const dog = PhosphorDuotoneIconData(
-    0xe74b,
-    PhosphorIconData(0xe74a, 'Duotone'),
-  );
+  static const dog = IconData(0xe74b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/door-duotone.svg)
-  static const door = PhosphorDuotoneIconData(
-    0xe61d,
-    PhosphorIconData(0xe61c, 'Duotone'),
-  );
+  static const door = IconData(0xe61d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/door-open-duotone.svg)
-  static const doorOpen = PhosphorDuotoneIconData(
-    0xe7e7,
-    PhosphorIconData(0xe7e6, 'Duotone'),
-  );
+  static const doorOpen = IconData(0xe7e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dot-duotone.svg)
-  static const dot = PhosphorDuotoneIconData(
-    0xecdf,
-    PhosphorIconData(0xecde, 'Duotone'),
-  );
+  static const dot = IconData(0xecdf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-outline-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dot-outline-duotone.svg)
-  static const dotOutline = PhosphorDuotoneIconData(
-    0xece1,
-    PhosphorIconData(0xece0, 'Duotone'),
-  );
+  static const dotOutline = IconData(0xece1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-nine-duotone.svg)
-  static const dotsNine = PhosphorDuotoneIconData(
-    0xe1fd,
-    PhosphorIconData(0xe1fc, 'Duotone'),
-  );
+  static const dotsNine = IconData(0xe1fd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-six-duotone.svg)
-  static const dotsSix = PhosphorDuotoneIconData(
-    0xe795,
-    PhosphorIconData(0xe794, 'Duotone'),
-  );
+  static const dotsSix = IconData(0xe795,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-six-vertical-duotone.svg)
-  static const dotsSixVertical = PhosphorDuotoneIconData(
-    0xeae3,
-    PhosphorIconData(0xeae2, 'Duotone'),
-  );
+  static const dotsSixVertical = IconData(0xeae3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-duotone.svg)
-  static const dotsThree = PhosphorDuotoneIconData(
-    0xe1ff,
-    PhosphorIconData(0xe1fe, 'Duotone'),
-  );
+  static const dotsThree = IconData(0xe1ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-circle-duotone.svg)
-  static const dotsThreeCircle = PhosphorDuotoneIconData(
-    0xe201,
-    PhosphorIconData(0xe200, 'Duotone'),
-  );
+  static const dotsThreeCircle = IconData(0xe201,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-circle-vertical-duotone.svg)
-  static const dotsThreeCircleVertical = PhosphorDuotoneIconData(
-    0xe203,
-    PhosphorIconData(0xe202, 'Duotone'),
-  );
+  static const dotsThreeCircleVertical = IconData(0xe203,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-outline-duotone.svg)
-  static const dotsThreeOutline = PhosphorDuotoneIconData(
-    0xe205,
-    PhosphorIconData(0xe204, 'Duotone'),
-  );
+  static const dotsThreeOutline = IconData(0xe205,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-outline-vertical-duotone.svg)
-  static const dotsThreeOutlineVertical = PhosphorDuotoneIconData(
-    0xe207,
-    PhosphorIconData(0xe206, 'Duotone'),
-  );
+  static const dotsThreeOutlineVertical = IconData(0xe207,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dots-three-vertical-duotone.svg)
-  static const dotsThreeVertical = PhosphorDuotoneIconData(
-    0xe209,
-    PhosphorIconData(0xe208, 'Duotone'),
-  );
+  static const dotsThreeVertical = IconData(0xe209,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/download-duotone.svg)
-  static const download = PhosphorDuotoneIconData(
-    0xe20b,
-    PhosphorIconData(0xe20a, 'Duotone'),
-  );
+  static const download = IconData(0xe20b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/download-simple-duotone.svg)
-  static const downloadSimple = PhosphorDuotoneIconData(
-    0xe20d,
-    PhosphorIconData(0xe20c, 'Duotone'),
-  );
+  static const downloadSimple = IconData(0xe20d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dress-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dress-duotone.svg)
-  static const dress = PhosphorDuotoneIconData(
-    0xea7f,
-    PhosphorIconData(0xea7e, 'Duotone'),
-  );
+  static const dress = IconData(0xea7f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dresser-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dresser-duotone.svg)
-  static const dresser = PhosphorDuotoneIconData(
-    0xe94f,
-    PhosphorIconData(0xe94e, 'Duotone'),
-  );
+  static const dresser = IconData(0xe94f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dribbble-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dribbble-logo-duotone.svg)
-  static const dribbbleLogo = PhosphorDuotoneIconData(
-    0xe20f,
-    PhosphorIconData(0xe20e, 'Duotone'),
-  );
+  static const dribbbleLogo = IconData(0xe20f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drone-duotone.svg)
-  static const drone = PhosphorDuotoneIconData(
-    0xed75,
-    PhosphorIconData(0xed74, 'Duotone'),
-  );
+  static const drone = IconData(0xed75,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drop-duotone.svg)
-  static const drop = PhosphorDuotoneIconData(
-    0xe211,
-    PhosphorIconData(0xe210, 'Duotone'),
-  );
+  static const drop = IconData(0xe211,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drop-half-duotone.svg)
-  static const dropHalf = PhosphorDuotoneIconData(
-    0xe567,
-    PhosphorIconData(0xe566, 'Duotone'),
-  );
+  static const dropHalf = IconData(0xe567,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-bottom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drop-half-bottom-duotone.svg)
-  static const dropHalfBottom = PhosphorDuotoneIconData(
-    0xeb41,
-    PhosphorIconData(0xeb40, 'Duotone'),
-  );
+  static const dropHalfBottom = IconData(0xeb41,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drop-simple-duotone.svg)
-  static const dropSimple = PhosphorDuotoneIconData(
-    0xee33,
-    PhosphorIconData(0xee32, 'Duotone'),
-  );
+  static const dropSimple = IconData(0xee33,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/drop-slash-duotone.svg)
-  static const dropSlash = PhosphorDuotoneIconData(
-    0xe955,
-    PhosphorIconData(0xe954, 'Duotone'),
-  );
+  static const dropSlash = IconData(0xe955,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dropbox-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/dropbox-logo-duotone.svg)
-  static const dropboxLogo = PhosphorDuotoneIconData(
-    0xe7d1,
-    PhosphorIconData(0xe7d0, 'Duotone'),
-  );
+  static const dropboxLogo = IconData(0xe7d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ear-duotone.svg)
-  static const ear = PhosphorDuotoneIconData(
-    0xe70d,
-    PhosphorIconData(0xe70c, 'Duotone'),
-  );
+  static const ear = IconData(0xe70d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ear-slash-duotone.svg)
-  static const earSlash = PhosphorDuotoneIconData(
-    0xe70f,
-    PhosphorIconData(0xe70e, 'Duotone'),
-  );
+  static const earSlash = IconData(0xe70f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/egg-duotone.svg)
-  static const egg = PhosphorDuotoneIconData(
-    0xe813,
-    PhosphorIconData(0xe812, 'Duotone'),
-  );
+  static const egg = IconData(0xe813,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-crack-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/egg-crack-duotone.svg)
-  static const eggCrack = PhosphorDuotoneIconData(
-    0xeb65,
-    PhosphorIconData(0xeb64, 'Duotone'),
-  );
+  static const eggCrack = IconData(0xeb65,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eject-duotone.svg)
-  static const eject = PhosphorDuotoneIconData(
-    0xe213,
-    PhosphorIconData(0xe212, 'Duotone'),
-  );
+  static const eject = IconData(0xe213,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eject-simple-duotone.svg)
-  static const ejectSimple = PhosphorDuotoneIconData(
-    0xe6af,
-    PhosphorIconData(0xe6ae, 'Duotone'),
-  );
+  static const ejectSimple = IconData(0xe6af,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![elevator-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/elevator-duotone.svg)
-  static const elevator = PhosphorDuotoneIconData(
-    0xecc1,
-    PhosphorIconData(0xecc0, 'Duotone'),
-  );
+  static const elevator = IconData(0xecc1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![empty-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/empty-duotone.svg)
-  static const empty = PhosphorDuotoneIconData(
-    0xedbd,
-    PhosphorIconData(0xedbc, 'Duotone'),
-  );
+  static const empty = IconData(0xedbd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![engine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/engine-duotone.svg)
-  static const engine = PhosphorDuotoneIconData(
-    0xea81,
-    PhosphorIconData(0xea80, 'Duotone'),
-  );
+  static const engine = IconData(0xea81,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/envelope-duotone.svg)
-  static const envelope = PhosphorDuotoneIconData(
-    0xe215,
-    PhosphorIconData(0xe214, 'Duotone'),
-  );
+  static const envelope = IconData(0xe215,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/envelope-open-duotone.svg)
-  static const envelopeOpen = PhosphorDuotoneIconData(
-    0xe217,
-    PhosphorIconData(0xe216, 'Duotone'),
-  );
+  static const envelopeOpen = IconData(0xe217,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/envelope-simple-duotone.svg)
-  static const envelopeSimple = PhosphorDuotoneIconData(
-    0xe219,
-    PhosphorIconData(0xe218, 'Duotone'),
-  );
+  static const envelopeSimple = IconData(0xe219,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/envelope-simple-open-duotone.svg)
-  static const envelopeSimpleOpen = PhosphorDuotoneIconData(
-    0xe21b,
-    PhosphorIconData(0xe21a, 'Duotone'),
-  );
+  static const envelopeSimpleOpen = IconData(0xe21b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equalizer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/equalizer-duotone.svg)
-  static const equalizer = PhosphorDuotoneIconData(
-    0xebbd,
-    PhosphorIconData(0xebbc, 'Duotone'),
-  );
+  static const equalizer = IconData(0xebbd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equals-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/equals-duotone.svg)
-  static const equals = PhosphorDuotoneIconData(
-    0xe21d,
-    PhosphorIconData(0xe21c, 'Duotone'),
-  );
+  static const equals = IconData(0xe21d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eraser-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eraser-duotone.svg)
-  static const eraser = PhosphorDuotoneIconData(
-    0xe21f,
-    PhosphorIconData(0xe21e, 'Duotone'),
-  );
+  static const eraser = IconData(0xe21f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/escalator-down-duotone.svg)
-  static const escalatorDown = PhosphorDuotoneIconData(
-    0xecbb,
-    PhosphorIconData(0xecba, 'Duotone'),
-  );
+  static const escalatorDown = IconData(0xecbb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/escalator-up-duotone.svg)
-  static const escalatorUp = PhosphorDuotoneIconData(
-    0xecbd,
-    PhosphorIconData(0xecbc, 'Duotone'),
-  );
+  static const escalatorUp = IconData(0xecbd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exam-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/exam-duotone.svg)
-  static const exam = PhosphorDuotoneIconData(
-    0xe743,
-    PhosphorIconData(0xe742, 'Duotone'),
-  );
+  static const exam = IconData(0xe743,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclamation-mark-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/exclamation-mark-duotone.svg)
-  static const exclamationMark = PhosphorDuotoneIconData(
-    0xee45,
-    PhosphorIconData(0xee44, 'Duotone'),
-  );
+  static const exclamationMark = IconData(0xee45,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/exclude-duotone.svg)
-  static const exclude = PhosphorDuotoneIconData(
-    0xe883,
-    PhosphorIconData(0xe882, 'Duotone'),
-  );
+  static const exclude = IconData(0xe883,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/exclude-square-duotone.svg)
-  static const excludeSquare = PhosphorDuotoneIconData(
-    0xe881,
-    PhosphorIconData(0xe880, 'Duotone'),
-  );
+  static const excludeSquare = IconData(0xe881,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![export-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/export-duotone.svg)
-  static const export = PhosphorDuotoneIconData(
-    0xeaf1,
-    PhosphorIconData(0xeaf0, 'Duotone'),
-  );
+  static const export = IconData(0xeaf1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eye-duotone.svg)
-  static const eye = PhosphorDuotoneIconData(
-    0xe221,
-    PhosphorIconData(0xe220, 'Duotone'),
-  );
+  static const eye = IconData(0xe221,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-closed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eye-closed-duotone.svg)
-  static const eyeClosed = PhosphorDuotoneIconData(
-    0xe223,
-    PhosphorIconData(0xe222, 'Duotone'),
-  );
+  static const eyeClosed = IconData(0xe223,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eye-slash-duotone.svg)
-  static const eyeSlash = PhosphorDuotoneIconData(
-    0xe225,
-    PhosphorIconData(0xe224, 'Duotone'),
-  );
+  static const eyeSlash = IconData(0xe225,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eyedropper-duotone.svg)
-  static const eyedropper = PhosphorDuotoneIconData(
-    0xe569,
-    PhosphorIconData(0xe568, 'Duotone'),
-  );
+  static const eyedropper = IconData(0xe569,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-sample-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eyedropper-sample-duotone.svg)
-  static const eyedropperSample = PhosphorDuotoneIconData(
-    0xeac5,
-    PhosphorIconData(0xeac4, 'Duotone'),
-  );
+  static const eyedropperSample = IconData(0xeac5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyeglasses-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eyeglasses-duotone.svg)
-  static const eyeglasses = PhosphorDuotoneIconData(
-    0xe7bb,
-    PhosphorIconData(0xe7ba, 'Duotone'),
-  );
+  static const eyeglasses = IconData(0xe7bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/eyes-duotone.svg)
-  static const eyes = PhosphorDuotoneIconData(
-    0xee5d,
-    PhosphorIconData(0xee5c, 'Duotone'),
-  );
+  static const eyes = IconData(0xee5d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![face-mask-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/face-mask-duotone.svg)
-  static const faceMask = PhosphorDuotoneIconData(
-    0xe56b,
-    PhosphorIconData(0xe56a, 'Duotone'),
-  );
+  static const faceMask = IconData(0xe56b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![facebook-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/facebook-logo-duotone.svg)
-  static const facebookLogo = PhosphorDuotoneIconData(
-    0xe227,
-    PhosphorIconData(0xe226, 'Duotone'),
-  );
+  static const facebookLogo = IconData(0xe227,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![factory-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/factory-duotone.svg)
-  static const factory = PhosphorDuotoneIconData(
-    0xe761,
-    PhosphorIconData(0xe760, 'Duotone'),
-  );
+  static const factory = IconData(0xe761,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/faders-duotone.svg)
-  static const faders = PhosphorDuotoneIconData(
-    0xe229,
-    PhosphorIconData(0xe228, 'Duotone'),
-  );
+  static const faders = IconData(0xe229,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/faders-horizontal-duotone.svg)
-  static const fadersHorizontal = PhosphorDuotoneIconData(
-    0xe22b,
-    PhosphorIconData(0xe22a, 'Duotone'),
-  );
+  static const fadersHorizontal = IconData(0xe22b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fallout-shelter-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fallout-shelter-duotone.svg)
-  static const falloutShelter = PhosphorDuotoneIconData(
-    0xe9df,
-    PhosphorIconData(0xe9de, 'Duotone'),
-  );
+  static const falloutShelter = IconData(0xe9df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fan-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fan-duotone.svg)
-  static const fan = PhosphorDuotoneIconData(
-    0xe9f3,
-    PhosphorIconData(0xe9f2, 'Duotone'),
-  );
+  static const fan = IconData(0xe9f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![farm-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/farm-duotone.svg)
-  static const farm = PhosphorDuotoneIconData(
-    0xec71,
-    PhosphorIconData(0xec70, 'Duotone'),
-  );
+  static const farm = IconData(0xec71,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fast-forward-duotone.svg)
-  static const fastForward = PhosphorDuotoneIconData(
-    0xe6a7,
-    PhosphorIconData(0xe6a6, 'Duotone'),
-  );
+  static const fastForward = IconData(0xe6a7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fast-forward-circle-duotone.svg)
-  static const fastForwardCircle = PhosphorDuotoneIconData(
-    0xe22d,
-    PhosphorIconData(0xe22c, 'Duotone'),
-  );
+  static const fastForwardCircle = IconData(0xe22d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![feather-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/feather-duotone.svg)
-  static const feather = PhosphorDuotoneIconData(
-    0xe9c1,
-    PhosphorIconData(0xe9c0, 'Duotone'),
-  );
+  static const feather = IconData(0xe9c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fediverse-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fediverse-logo-duotone.svg)
-  static const fediverseLogo = PhosphorDuotoneIconData(
-    0xed67,
-    PhosphorIconData(0xed66, 'Duotone'),
-  );
+  static const fediverseLogo = IconData(0xed67,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![figma-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/figma-logo-duotone.svg)
-  static const figmaLogo = PhosphorDuotoneIconData(
-    0xe22f,
-    PhosphorIconData(0xe22e, 'Duotone'),
-  );
+  static const figmaLogo = IconData(0xe22f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-duotone.svg)
-  static const file = PhosphorDuotoneIconData(
-    0xe231,
-    PhosphorIconData(0xe230, 'Duotone'),
-  );
+  static const file = IconData(0xe231,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-archive-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-archive-duotone.svg)
-  static const fileArchive = PhosphorDuotoneIconData(
-    0xeb2b,
-    PhosphorIconData(0xeb2a, 'Duotone'),
-  );
+  static const fileArchive = IconData(0xeb2b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-arrow-down-duotone.svg)
-  static const fileArrowDown = PhosphorDuotoneIconData(
-    0xe233,
-    PhosphorIconData(0xe232, 'Duotone'),
-  );
+  static const fileArrowDown = IconData(0xe233,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-arrow-up-duotone.svg)
-  static const fileArrowUp = PhosphorDuotoneIconData(
-    0xe61f,
-    PhosphorIconData(0xe61e, 'Duotone'),
-  );
+  static const fileArrowUp = IconData(0xe61f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-audio-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-audio-duotone.svg)
-  static const fileAudio = PhosphorDuotoneIconData(
-    0xea21,
-    PhosphorIconData(0xea20, 'Duotone'),
-  );
+  static const fileAudio = IconData(0xea21,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-c-duotone.svg)
-  static const fileC = PhosphorDuotoneIconData(
-    0xeb36,
-    PhosphorIconData(0xeb32, 'Duotone'),
-  );
+  static const fileC = IconData(0xeb36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-sharp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-c-sharp-duotone.svg)
-  static const fileCSharp = PhosphorDuotoneIconData(
-    0xeb31,
-    PhosphorIconData(0xeb30, 'Duotone'),
-  );
+  static const fileCSharp = IconData(0xeb31,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cloud-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-cloud-duotone.svg)
-  static const fileCloud = PhosphorDuotoneIconData(
-    0xe95f,
-    PhosphorIconData(0xe95e, 'Duotone'),
-  );
+  static const fileCloud = IconData(0xe95f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-code-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-code-duotone.svg)
-  static const fileCode = PhosphorDuotoneIconData(
-    0xe915,
-    PhosphorIconData(0xe914, 'Duotone'),
-  );
+  static const fileCode = IconData(0xe915,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cpp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-cpp-duotone.svg)
-  static const fileCpp = PhosphorDuotoneIconData(
-    0xeb2f,
-    PhosphorIconData(0xeb2e, 'Duotone'),
-  );
+  static const fileCpp = IconData(0xeb2f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-css-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-css-duotone.svg)
-  static const fileCss = PhosphorDuotoneIconData(
-    0xeb37,
-    PhosphorIconData(0xeb34, 'Duotone'),
-  );
+  static const fileCss = IconData(0xeb37,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-csv-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-csv-duotone.svg)
-  static const fileCsv = PhosphorDuotoneIconData(
-    0xeb1d,
-    PhosphorIconData(0xeb1c, 'Duotone'),
-  );
+  static const fileCsv = IconData(0xeb1d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-dashed-duotone.svg)
-  static const fileDashed = PhosphorDuotoneIconData(
-    0xe705,
-    PhosphorIconData(0xe704, 'Duotone'),
-  );
+  static const fileDashed = IconData(0xe705,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-doc-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-doc-duotone.svg)
-  static const fileDoc = PhosphorDuotoneIconData(
-    0xeb1f,
-    PhosphorIconData(0xeb1e, 'Duotone'),
-  );
+  static const fileDoc = IconData(0xeb1f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-html-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-html-duotone.svg)
-  static const fileHtml = PhosphorDuotoneIconData(
-    0xeb39,
-    PhosphorIconData(0xeb38, 'Duotone'),
-  );
+  static const fileHtml = IconData(0xeb39,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-image-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-image-duotone.svg)
-  static const fileImage = PhosphorDuotoneIconData(
-    0xea25,
-    PhosphorIconData(0xea24, 'Duotone'),
-  );
+  static const fileImage = IconData(0xea25,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ini-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-ini-duotone.svg)
-  static const fileIni = PhosphorDuotoneIconData(
-    0xeb3b,
-    PhosphorIconData(0xeb33, 'Duotone'),
-  );
+  static const fileIni = IconData(0xeb3b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jpg-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-jpg-duotone.svg)
-  static const fileJpg = PhosphorDuotoneIconData(
-    0xeb1b,
-    PhosphorIconData(0xeb1a, 'Duotone'),
-  );
+  static const fileJpg = IconData(0xeb1b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-js-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-js-duotone.svg)
-  static const fileJs = PhosphorDuotoneIconData(
-    0xeb25,
-    PhosphorIconData(0xeb24, 'Duotone'),
-  );
+  static const fileJs = IconData(0xeb25,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jsx-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-jsx-duotone.svg)
-  static const fileJsx = PhosphorDuotoneIconData(
-    0xeb3d,
-    PhosphorIconData(0xeb3a, 'Duotone'),
-  );
+  static const fileJsx = IconData(0xeb3d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-lock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-lock-duotone.svg)
-  static const fileLock = PhosphorDuotoneIconData(
-    0xe95d,
-    PhosphorIconData(0xe95c, 'Duotone'),
-  );
+  static const fileLock = IconData(0xe95d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-magnifying-glass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-magnifying-glass-duotone.svg)
-  static const fileMagnifyingGlass = PhosphorDuotoneIconData(
-    0xe239,
-    PhosphorIconData(0xe238, 'Duotone'),
-  );
+  static const fileMagnifyingGlass = IconData(0xe239,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-md-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-md-duotone.svg)
-  static const fileMd = PhosphorDuotoneIconData(
-    0xed51,
-    PhosphorIconData(0xed50, 'Duotone'),
-  );
+  static const fileMd = IconData(0xed51,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-minus-duotone.svg)
-  static const fileMinus = PhosphorDuotoneIconData(
-    0xe235,
-    PhosphorIconData(0xe234, 'Duotone'),
-  );
+  static const fileMinus = IconData(0xe235,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-pdf-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-pdf-duotone.svg)
-  static const filePdf = PhosphorDuotoneIconData(
-    0xe703,
-    PhosphorIconData(0xe702, 'Duotone'),
-  );
+  static const filePdf = IconData(0xe703,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-plus-duotone.svg)
-  static const filePlus = PhosphorDuotoneIconData(
-    0xe237,
-    PhosphorIconData(0xe236, 'Duotone'),
-  );
+  static const filePlus = IconData(0xe237,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-png-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-png-duotone.svg)
-  static const filePng = PhosphorDuotoneIconData(
-    0xeb19,
-    PhosphorIconData(0xeb18, 'Duotone'),
-  );
+  static const filePng = IconData(0xeb19,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ppt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-ppt-duotone.svg)
-  static const filePpt = PhosphorDuotoneIconData(
-    0xeb21,
-    PhosphorIconData(0xeb20, 'Duotone'),
-  );
+  static const filePpt = IconData(0xeb21,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-py-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-py-duotone.svg)
-  static const filePy = PhosphorDuotoneIconData(
-    0xeb2d,
-    PhosphorIconData(0xeb2c, 'Duotone'),
-  );
+  static const filePy = IconData(0xeb2d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-rs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-rs-duotone.svg)
-  static const fileRs = PhosphorDuotoneIconData(
-    0xeb29,
-    PhosphorIconData(0xeb28, 'Duotone'),
-  );
+  static const fileRs = IconData(0xeb29,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-sql-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-sql-duotone.svg)
-  static const fileSql = PhosphorDuotoneIconData(
-    0xed4f,
-    PhosphorIconData(0xed4e, 'Duotone'),
-  );
+  static const fileSql = IconData(0xed4f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-svg-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-svg-duotone.svg)
-  static const fileSvg = PhosphorDuotoneIconData(
-    0xed09,
-    PhosphorIconData(0xed08, 'Duotone'),
-  );
+  static const fileSvg = IconData(0xed09,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-text-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-text-duotone.svg)
-  static const fileText = PhosphorDuotoneIconData(
-    0xe23b,
-    PhosphorIconData(0xe23a, 'Duotone'),
-  );
+  static const fileText = IconData(0xe23b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ts-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-ts-duotone.svg)
-  static const fileTs = PhosphorDuotoneIconData(
-    0xeb27,
-    PhosphorIconData(0xeb26, 'Duotone'),
-  );
+  static const fileTs = IconData(0xeb27,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-tsx-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-tsx-duotone.svg)
-  static const fileTsx = PhosphorDuotoneIconData(
-    0xeb3f,
-    PhosphorIconData(0xeb3c, 'Duotone'),
-  );
+  static const fileTsx = IconData(0xeb3f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-txt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-txt-duotone.svg)
-  static const fileTxt = PhosphorDuotoneIconData(
-    0xeb43,
-    PhosphorIconData(0xeb35, 'Duotone'),
-  );
+  static const fileTxt = IconData(0xeb43,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-video-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-video-duotone.svg)
-  static const fileVideo = PhosphorDuotoneIconData(
-    0xea23,
-    PhosphorIconData(0xea22, 'Duotone'),
-  );
+  static const fileVideo = IconData(0xea23,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-vue-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-vue-duotone.svg)
-  static const fileVue = PhosphorDuotoneIconData(
-    0xeb47,
-    PhosphorIconData(0xeb3e, 'Duotone'),
-  );
+  static const fileVue = IconData(0xeb47,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-x-duotone.svg)
-  static const fileX = PhosphorDuotoneIconData(
-    0xe23d,
-    PhosphorIconData(0xe23c, 'Duotone'),
-  );
+  static const fileX = IconData(0xe23d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-xls-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-xls-duotone.svg)
-  static const fileXls = PhosphorDuotoneIconData(
-    0xeb23,
-    PhosphorIconData(0xeb22, 'Duotone'),
-  );
+  static const fileXls = IconData(0xeb23,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-zip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/file-zip-duotone.svg)
-  static const fileZip = PhosphorDuotoneIconData(
-    0xe959,
-    PhosphorIconData(0xe958, 'Duotone'),
-  );
+  static const fileZip = IconData(0xe959,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![files-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/files-duotone.svg)
-  static const files = PhosphorDuotoneIconData(
-    0xe711,
-    PhosphorIconData(0xe710, 'Duotone'),
-  );
+  static const files = IconData(0xe711,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-reel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/film-reel-duotone.svg)
-  static const filmReel = PhosphorDuotoneIconData(
-    0xe8c1,
-    PhosphorIconData(0xe8c0, 'Duotone'),
-  );
+  static const filmReel = IconData(0xe8c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-script-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/film-script-duotone.svg)
-  static const filmScript = PhosphorDuotoneIconData(
-    0xeb51,
-    PhosphorIconData(0xeb50, 'Duotone'),
-  );
+  static const filmScript = IconData(0xeb51,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-slate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/film-slate-duotone.svg)
-  static const filmSlate = PhosphorDuotoneIconData(
-    0xe8c3,
-    PhosphorIconData(0xe8c2, 'Duotone'),
-  );
+  static const filmSlate = IconData(0xe8c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-strip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/film-strip-duotone.svg)
-  static const filmStrip = PhosphorDuotoneIconData(
-    0xe793,
-    PhosphorIconData(0xe792, 'Duotone'),
-  );
+  static const filmStrip = IconData(0xe793,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fingerprint-duotone.svg)
-  static const fingerprint = PhosphorDuotoneIconData(
-    0xe23f,
-    PhosphorIconData(0xe23e, 'Duotone'),
-  );
+  static const fingerprint = IconData(0xe23f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fingerprint-simple-duotone.svg)
-  static const fingerprintSimple = PhosphorDuotoneIconData(
-    0xe241,
-    PhosphorIconData(0xe240, 'Duotone'),
-  );
+  static const fingerprintSimple = IconData(0xe241,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![finn-the-human-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/finn-the-human-duotone.svg)
-  static const finnTheHuman = PhosphorDuotoneIconData(
-    0xe56d,
-    PhosphorIconData(0xe56c, 'Duotone'),
-  );
+  static const finnTheHuman = IconData(0xe56d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fire-duotone.svg)
-  static const fire = PhosphorDuotoneIconData(
-    0xe243,
-    PhosphorIconData(0xe242, 'Duotone'),
-  );
+  static const fire = IconData(0xe243,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-extinguisher-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fire-extinguisher-duotone.svg)
-  static const fireExtinguisher = PhosphorDuotoneIconData(
-    0xe9e9,
-    PhosphorIconData(0xe9e8, 'Duotone'),
-  );
+  static const fireExtinguisher = IconData(0xe9e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fire-simple-duotone.svg)
-  static const fireSimple = PhosphorDuotoneIconData(
-    0xe621,
-    PhosphorIconData(0xe620, 'Duotone'),
-  );
+  static const fireSimple = IconData(0xe621,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-truck-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fire-truck-duotone.svg)
-  static const fireTruck = PhosphorDuotoneIconData(
-    0xe575,
-    PhosphorIconData(0xe574, 'Duotone'),
-  );
+  static const fireTruck = IconData(0xe575,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/first-aid-duotone.svg)
-  static const firstAid = PhosphorDuotoneIconData(
-    0xe56f,
-    PhosphorIconData(0xe56e, 'Duotone'),
-  );
+  static const firstAid = IconData(0xe56f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-kit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/first-aid-kit-duotone.svg)
-  static const firstAidKit = PhosphorDuotoneIconData(
-    0xe571,
-    PhosphorIconData(0xe570, 'Duotone'),
-  );
+  static const firstAidKit = IconData(0xe571,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fish-duotone.svg)
-  static const fish = PhosphorDuotoneIconData(
-    0xe729,
-    PhosphorIconData(0xe728, 'Duotone'),
-  );
+  static const fish = IconData(0xe729,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fish-simple-duotone.svg)
-  static const fishSimple = PhosphorDuotoneIconData(
-    0xe72b,
-    PhosphorIconData(0xe72a, 'Duotone'),
-  );
+  static const fishSimple = IconData(0xe72b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-duotone.svg)
-  static const flag = PhosphorDuotoneIconData(
-    0xe245,
-    PhosphorIconData(0xe244, 'Duotone'),
-  );
+  static const flag = IconData(0xe245,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-banner-duotone.svg)
-  static const flagBanner = PhosphorDuotoneIconData(
-    0xe623,
-    PhosphorIconData(0xe622, 'Duotone'),
-  );
+  static const flagBanner = IconData(0xe623,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-fold-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-banner-fold-duotone.svg)
-  static const flagBannerFold = PhosphorDuotoneIconData(
-    0xecf3,
-    PhosphorIconData(0xecf2, 'Duotone'),
-  );
+  static const flagBannerFold = IconData(0xecf3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-checkered-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-checkered-duotone.svg)
-  static const flagCheckered = PhosphorDuotoneIconData(
-    0xea39,
-    PhosphorIconData(0xea38, 'Duotone'),
-  );
+  static const flagCheckered = IconData(0xea39,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-pennant-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flag-pennant-duotone.svg)
-  static const flagPennant = PhosphorDuotoneIconData(
-    0xecf1,
-    PhosphorIconData(0xecf0, 'Duotone'),
-  );
+  static const flagPennant = IconData(0xecf1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flame-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flame-duotone.svg)
-  static const flame = PhosphorDuotoneIconData(
-    0xe625,
-    PhosphorIconData(0xe624, 'Duotone'),
-  );
+  static const flame = IconData(0xe625,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flashlight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flashlight-duotone.svg)
-  static const flashlight = PhosphorDuotoneIconData(
-    0xe247,
-    PhosphorIconData(0xe246, 'Duotone'),
-  );
+  static const flashlight = IconData(0xe247,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flask-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flask-duotone.svg)
-  static const flask = PhosphorDuotoneIconData(
-    0xe79f,
-    PhosphorIconData(0xe79e, 'Duotone'),
-  );
+  static const flask = IconData(0xe79f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flip-horizontal-duotone.svg)
-  static const flipHorizontal = PhosphorDuotoneIconData(
-    0xed6b,
-    PhosphorIconData(0xed6a, 'Duotone'),
-  );
+  static const flipHorizontal = IconData(0xed6b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flip-vertical-duotone.svg)
-  static const flipVertical = PhosphorDuotoneIconData(
-    0xed6d,
-    PhosphorIconData(0xed6c, 'Duotone'),
-  );
+  static const flipVertical = IconData(0xed6d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/floppy-disk-duotone.svg)
-  static const floppyDisk = PhosphorDuotoneIconData(
-    0xe249,
-    PhosphorIconData(0xe248, 'Duotone'),
-  );
+  static const floppyDisk = IconData(0xe249,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-back-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/floppy-disk-back-duotone.svg)
-  static const floppyDiskBack = PhosphorDuotoneIconData(
-    0xeaf5,
-    PhosphorIconData(0xeaf4, 'Duotone'),
-  );
+  static const floppyDiskBack = IconData(0xeaf5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flow-arrow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flow-arrow-duotone.svg)
-  static const flowArrow = PhosphorDuotoneIconData(
-    0xe6ed,
-    PhosphorIconData(0xe6ec, 'Duotone'),
-  );
+  static const flowArrow = IconData(0xe6ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flower-duotone.svg)
-  static const flower = PhosphorDuotoneIconData(
-    0xe75f,
-    PhosphorIconData(0xe75e, 'Duotone'),
-  );
+  static const flower = IconData(0xe75f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-lotus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flower-lotus-duotone.svg)
-  static const flowerLotus = PhosphorDuotoneIconData(
-    0xe6cd,
-    PhosphorIconData(0xe6cc, 'Duotone'),
-  );
+  static const flowerLotus = IconData(0xe6cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-tulip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flower-tulip-duotone.svg)
-  static const flowerTulip = PhosphorDuotoneIconData(
-    0xeacd,
-    PhosphorIconData(0xeacc, 'Duotone'),
-  );
+  static const flowerTulip = IconData(0xeacd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flying-saucer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/flying-saucer-duotone.svg)
-  static const flyingSaucer = PhosphorDuotoneIconData(
-    0xeb4b,
-    PhosphorIconData(0xeb4a, 'Duotone'),
-  );
+  static const flyingSaucer = IconData(0xeb4b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-duotone.svg)
-  static const folder = PhosphorDuotoneIconData(
-    0xe24b,
-    PhosphorIconData(0xe24a, 'Duotone'),
-  );
+  static const folder = IconData(0xe24b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-dashed-duotone.svg)
-  static const folderDashed = PhosphorDuotoneIconData(
-    0xe8f9,
-    PhosphorIconData(0xe8f8, 'Duotone'),
-  );
+  static const folderDashed = IconData(0xe8f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-lock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-lock-duotone.svg)
-  static const folderLock = PhosphorDuotoneIconData(
-    0xea3d,
-    PhosphorIconData(0xea3c, 'Duotone'),
-  );
+  static const folderLock = IconData(0xea3d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-minus-duotone.svg)
-  static const folderMinus = PhosphorDuotoneIconData(
-    0xe255,
-    PhosphorIconData(0xe254, 'Duotone'),
-  );
+  static const folderMinus = IconData(0xe255,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-open-duotone.svg)
-  static const folderOpen = PhosphorDuotoneIconData(
-    0xe257,
-    PhosphorIconData(0xe256, 'Duotone'),
-  );
+  static const folderOpen = IconData(0xe257,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-plus-duotone.svg)
-  static const folderPlus = PhosphorDuotoneIconData(
-    0xe259,
-    PhosphorIconData(0xe258, 'Duotone'),
-  );
+  static const folderPlus = IconData(0xe259,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-duotone.svg)
-  static const folderSimple = PhosphorDuotoneIconData(
-    0xe25b,
-    PhosphorIconData(0xe25a, 'Duotone'),
-  );
+  static const folderSimple = IconData(0xe25b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-dashed-duotone.svg)
-  static const folderSimpleDashed = PhosphorDuotoneIconData(
-    0xec2b,
-    PhosphorIconData(0xec2a, 'Duotone'),
-  );
+  static const folderSimpleDashed = IconData(0xec2b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-lock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-lock-duotone.svg)
-  static const folderSimpleLock = PhosphorDuotoneIconData(
-    0xeb5f,
-    PhosphorIconData(0xeb5e, 'Duotone'),
-  );
+  static const folderSimpleLock = IconData(0xeb5f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-minus-duotone.svg)
-  static const folderSimpleMinus = PhosphorDuotoneIconData(
-    0xe25d,
-    PhosphorIconData(0xe25c, 'Duotone'),
-  );
+  static const folderSimpleMinus = IconData(0xe25d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-plus-duotone.svg)
-  static const folderSimplePlus = PhosphorDuotoneIconData(
-    0xe25f,
-    PhosphorIconData(0xe25e, 'Duotone'),
-  );
+  static const folderSimplePlus = IconData(0xe25f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-star-duotone.svg)
-  static const folderSimpleStar = PhosphorDuotoneIconData(
-    0xec2f,
-    PhosphorIconData(0xec2e, 'Duotone'),
-  );
+  static const folderSimpleStar = IconData(0xec2f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-user-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-simple-user-duotone.svg)
-  static const folderSimpleUser = PhosphorDuotoneIconData(
-    0xeb61,
-    PhosphorIconData(0xeb60, 'Duotone'),
-  );
+  static const folderSimpleUser = IconData(0xeb61,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-star-duotone.svg)
-  static const folderStar = PhosphorDuotoneIconData(
-    0xea87,
-    PhosphorIconData(0xea86, 'Duotone'),
-  );
+  static const folderStar = IconData(0xea87,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-user-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folder-user-duotone.svg)
-  static const folderUser = PhosphorDuotoneIconData(
-    0xeb4c,
-    PhosphorIconData(0xeb46, 'Duotone'),
-  );
+  static const folderUser = IconData(0xeb4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folders-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/folders-duotone.svg)
-  static const folders = PhosphorDuotoneIconData(
-    0xe261,
-    PhosphorIconData(0xe260, 'Duotone'),
-  );
+  static const folders = IconData(0xe261,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/football-duotone.svg)
-  static const football = PhosphorDuotoneIconData(
-    0xe719,
-    PhosphorIconData(0xe718, 'Duotone'),
-  );
+  static const football = IconData(0xe719,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-helmet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/football-helmet-duotone.svg)
-  static const footballHelmet = PhosphorDuotoneIconData(
-    0xee4d,
-    PhosphorIconData(0xee4c, 'Duotone'),
-  );
+  static const footballHelmet = IconData(0xee4d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![footprints-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/footprints-duotone.svg)
-  static const footprints = PhosphorDuotoneIconData(
-    0xea89,
-    PhosphorIconData(0xea88, 'Duotone'),
-  );
+  static const footprints = IconData(0xea89,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fork-knife-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/fork-knife-duotone.svg)
-  static const forkKnife = PhosphorDuotoneIconData(
-    0xe263,
-    PhosphorIconData(0xe262, 'Duotone'),
-  );
+  static const forkKnife = IconData(0xe263,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![four-k-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/four-k-duotone.svg)
-  static const fourK = PhosphorDuotoneIconData(
-    0xea5d,
-    PhosphorIconData(0xea5c, 'Duotone'),
-  );
+  static const fourK = IconData(0xea5d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![frame-corners-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/frame-corners-duotone.svg)
-  static const frameCorners = PhosphorDuotoneIconData(
-    0xe627,
-    PhosphorIconData(0xe626, 'Duotone'),
-  );
+  static const frameCorners = IconData(0xe627,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![framer-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/framer-logo-duotone.svg)
-  static const framerLogo = PhosphorDuotoneIconData(
-    0xe265,
-    PhosphorIconData(0xe264, 'Duotone'),
-  );
+  static const framerLogo = IconData(0xe265,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![function-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/function-duotone.svg)
-  static const function = PhosphorDuotoneIconData(
-    0xebe5,
-    PhosphorIconData(0xebe4, 'Duotone'),
-  );
+  static const function = IconData(0xebe5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/funnel-duotone.svg)
-  static const funnel = PhosphorDuotoneIconData(
-    0xe267,
-    PhosphorIconData(0xe266, 'Duotone'),
-  );
+  static const funnel = IconData(0xe267,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/funnel-simple-duotone.svg)
-  static const funnelSimple = PhosphorDuotoneIconData(
-    0xe269,
-    PhosphorIconData(0xe268, 'Duotone'),
-  );
+  static const funnelSimple = IconData(0xe269,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/funnel-simple-x-duotone.svg)
-  static const funnelSimpleX = PhosphorDuotoneIconData(
-    0xe26b,
-    PhosphorIconData(0xe26a, 'Duotone'),
-  );
+  static const funnelSimpleX = IconData(0xe26b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/funnel-x-duotone.svg)
-  static const funnelX = PhosphorDuotoneIconData(
-    0xe26d,
-    PhosphorIconData(0xe26c, 'Duotone'),
-  );
+  static const funnelX = IconData(0xe26d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![game-controller-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/game-controller-duotone.svg)
-  static const gameController = PhosphorDuotoneIconData(
-    0xe26f,
-    PhosphorIconData(0xe26e, 'Duotone'),
-  );
+  static const gameController = IconData(0xe26f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![garage-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/garage-duotone.svg)
-  static const garage = PhosphorDuotoneIconData(
-    0xecd7,
-    PhosphorIconData(0xecd6, 'Duotone'),
-  );
+  static const garage = IconData(0xecd7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-can-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gas-can-duotone.svg)
-  static const gasCan = PhosphorDuotoneIconData(
-    0xe8cf,
-    PhosphorIconData(0xe8ce, 'Duotone'),
-  );
+  static const gasCan = IconData(0xe8cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-pump-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gas-pump-duotone.svg)
-  static const gasPump = PhosphorDuotoneIconData(
-    0xe769,
-    PhosphorIconData(0xe768, 'Duotone'),
-  );
+  static const gasPump = IconData(0xe769,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gauge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gauge-duotone.svg)
-  static const gauge = PhosphorDuotoneIconData(
-    0xe629,
-    PhosphorIconData(0xe628, 'Duotone'),
-  );
+  static const gauge = IconData(0xe629,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gavel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gavel-duotone.svg)
-  static const gavel = PhosphorDuotoneIconData(
-    0xea33,
-    PhosphorIconData(0xea32, 'Duotone'),
-  );
+  static const gavel = IconData(0xea33,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gear-duotone.svg)
-  static const gear = PhosphorDuotoneIconData(
-    0xe271,
-    PhosphorIconData(0xe270, 'Duotone'),
-  );
+  static const gear = IconData(0xe271,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-fine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gear-fine-duotone.svg)
-  static const gearFine = PhosphorDuotoneIconData(
-    0xe87d,
-    PhosphorIconData(0xe87c, 'Duotone'),
-  );
+  static const gearFine = IconData(0xe87d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gear-six-duotone.svg)
-  static const gearSix = PhosphorDuotoneIconData(
-    0xe273,
-    PhosphorIconData(0xe272, 'Duotone'),
-  );
+  static const gearSix = IconData(0xe273,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-female-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-female-duotone.svg)
-  static const genderFemale = PhosphorDuotoneIconData(
-    0xe6e1,
-    PhosphorIconData(0xe6e0, 'Duotone'),
-  );
+  static const genderFemale = IconData(0xe6e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-intersex-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-intersex-duotone.svg)
-  static const genderIntersex = PhosphorDuotoneIconData(
-    0xe6e7,
-    PhosphorIconData(0xe6e6, 'Duotone'),
-  );
+  static const genderIntersex = IconData(0xe6e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-male-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-male-duotone.svg)
-  static const genderMale = PhosphorDuotoneIconData(
-    0xe6e3,
-    PhosphorIconData(0xe6e2, 'Duotone'),
-  );
+  static const genderMale = IconData(0xe6e3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-neuter-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-neuter-duotone.svg)
-  static const genderNeuter = PhosphorDuotoneIconData(
-    0xe6eb,
-    PhosphorIconData(0xe6ea, 'Duotone'),
-  );
+  static const genderNeuter = IconData(0xe6eb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-nonbinary-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-nonbinary-duotone.svg)
-  static const genderNonbinary = PhosphorDuotoneIconData(
-    0xe6e5,
-    PhosphorIconData(0xe6e4, 'Duotone'),
-  );
+  static const genderNonbinary = IconData(0xe6e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-transgender-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gender-transgender-duotone.svg)
-  static const genderTransgender = PhosphorDuotoneIconData(
-    0xe6e9,
-    PhosphorIconData(0xe6e8, 'Duotone'),
-  );
+  static const genderTransgender = IconData(0xe6e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ghost-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ghost-duotone.svg)
-  static const ghost = PhosphorDuotoneIconData(
-    0xe62b,
-    PhosphorIconData(0xe62a, 'Duotone'),
-  );
+  static const ghost = IconData(0xe62b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gif-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gif-duotone.svg)
-  static const gif = PhosphorDuotoneIconData(
-    0xe275,
-    PhosphorIconData(0xe274, 'Duotone'),
-  );
+  static const gif = IconData(0xe275,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gift-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gift-duotone.svg)
-  static const gift = PhosphorDuotoneIconData(
-    0xe277,
-    PhosphorIconData(0xe276, 'Duotone'),
-  );
+  static const gift = IconData(0xe277,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-branch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-branch-duotone.svg)
-  static const gitBranch = PhosphorDuotoneIconData(
-    0xe279,
-    PhosphorIconData(0xe278, 'Duotone'),
-  );
+  static const gitBranch = IconData(0xe279,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-commit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-commit-duotone.svg)
-  static const gitCommit = PhosphorDuotoneIconData(
-    0xe27b,
-    PhosphorIconData(0xe27a, 'Duotone'),
-  );
+  static const gitCommit = IconData(0xe27b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-diff-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-diff-duotone.svg)
-  static const gitDiff = PhosphorDuotoneIconData(
-    0xe27d,
-    PhosphorIconData(0xe27c, 'Duotone'),
-  );
+  static const gitDiff = IconData(0xe27d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-fork-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-fork-duotone.svg)
-  static const gitFork = PhosphorDuotoneIconData(
-    0xe27f,
-    PhosphorIconData(0xe27e, 'Duotone'),
-  );
+  static const gitFork = IconData(0xe27f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-merge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-merge-duotone.svg)
-  static const gitMerge = PhosphorDuotoneIconData(
-    0xe281,
-    PhosphorIconData(0xe280, 'Duotone'),
-  );
+  static const gitMerge = IconData(0xe281,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-pull-request-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/git-pull-request-duotone.svg)
-  static const gitPullRequest = PhosphorDuotoneIconData(
-    0xe283,
-    PhosphorIconData(0xe282, 'Duotone'),
-  );
+  static const gitPullRequest = IconData(0xe283,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![github-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/github-logo-duotone.svg)
-  static const githubLogo = PhosphorDuotoneIconData(
-    0xe577,
-    PhosphorIconData(0xe576, 'Duotone'),
-  );
+  static const githubLogo = IconData(0xe577,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gitlab-logo-duotone.svg)
-  static const gitlabLogo = PhosphorDuotoneIconData(
-    0xe695,
-    PhosphorIconData(0xe694, 'Duotone'),
-  );
+  static const gitlabLogo = IconData(0xe695,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gitlab-logo-simple-duotone.svg)
-  static const gitlabLogoSimple = PhosphorDuotoneIconData(
-    0xe697,
-    PhosphorIconData(0xe696, 'Duotone'),
-  );
+  static const gitlabLogoSimple = IconData(0xe697,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-duotone.svg)
-  static const globe = PhosphorDuotoneIconData(
-    0xe289,
-    PhosphorIconData(0xe288, 'Duotone'),
-  );
+  static const globe = IconData(0xe289,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-east-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-hemisphere-east-duotone.svg)
-  static const globeHemisphereEast = PhosphorDuotoneIconData(
-    0xe28b,
-    PhosphorIconData(0xe28a, 'Duotone'),
-  );
+  static const globeHemisphereEast = IconData(0xe28b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-west-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-hemisphere-west-duotone.svg)
-  static const globeHemisphereWest = PhosphorDuotoneIconData(
-    0xe28d,
-    PhosphorIconData(0xe28c, 'Duotone'),
-  );
+  static const globeHemisphereWest = IconData(0xe28d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-simple-duotone.svg)
-  static const globeSimple = PhosphorDuotoneIconData(
-    0xe28f,
-    PhosphorIconData(0xe28e, 'Duotone'),
-  );
+  static const globeSimple = IconData(0xe28f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-simple-x-duotone.svg)
-  static const globeSimpleX = PhosphorDuotoneIconData(
-    0xe285,
-    PhosphorIconData(0xe284, 'Duotone'),
-  );
+  static const globeSimpleX = IconData(0xe285,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-stand-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-stand-duotone.svg)
-  static const globeStand = PhosphorDuotoneIconData(
-    0xe291,
-    PhosphorIconData(0xe290, 'Duotone'),
-  );
+  static const globeStand = IconData(0xe291,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/globe-x-duotone.svg)
-  static const globeX = PhosphorDuotoneIconData(
-    0xe287,
-    PhosphorIconData(0xe286, 'Duotone'),
-  );
+  static const globeX = IconData(0xe287,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goggles-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/goggles-duotone.svg)
-  static const goggles = PhosphorDuotoneIconData(
-    0xecb5,
-    PhosphorIconData(0xecb4, 'Duotone'),
-  );
+  static const goggles = IconData(0xecb5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![golf-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/golf-duotone.svg)
-  static const golf = PhosphorDuotoneIconData(
-    0xea3f,
-    PhosphorIconData(0xea3e, 'Duotone'),
-  );
+  static const golf = IconData(0xea3f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goodreads-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/goodreads-logo-duotone.svg)
-  static const goodreadsLogo = PhosphorDuotoneIconData(
-    0xed11,
-    PhosphorIconData(0xed10, 'Duotone'),
-  );
+  static const goodreadsLogo = IconData(0xed11,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-cardboard-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-cardboard-logo-duotone.svg)
-  static const googleCardboardLogo = PhosphorDuotoneIconData(
-    0xe7b7,
-    PhosphorIconData(0xe7b6, 'Duotone'),
-  );
+  static const googleCardboardLogo = IconData(0xe7b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-chrome-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-chrome-logo-duotone.svg)
-  static const googleChromeLogo = PhosphorDuotoneIconData(
-    0xe977,
-    PhosphorIconData(0xe976, 'Duotone'),
-  );
+  static const googleChromeLogo = IconData(0xe977,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-drive-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-drive-logo-duotone.svg)
-  static const googleDriveLogo = PhosphorDuotoneIconData(
-    0xe8f7,
-    PhosphorIconData(0xe8f6, 'Duotone'),
-  );
+  static const googleDriveLogo = IconData(0xe8f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-logo-duotone.svg)
-  static const googleLogo = PhosphorDuotoneIconData(
-    0xe293,
-    PhosphorIconData(0xe292, 'Duotone'),
-  );
+  static const googleLogo = IconData(0xe293,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-photos-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-photos-logo-duotone.svg)
-  static const googlePhotosLogo = PhosphorDuotoneIconData(
-    0xeb93,
-    PhosphorIconData(0xeb92, 'Duotone'),
-  );
+  static const googlePhotosLogo = IconData(0xeb93,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-play-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-play-logo-duotone.svg)
-  static const googlePlayLogo = PhosphorDuotoneIconData(
-    0xe295,
-    PhosphorIconData(0xe294, 'Duotone'),
-  );
+  static const googlePlayLogo = IconData(0xe295,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-podcasts-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/google-podcasts-logo-duotone.svg)
-  static const googlePodcastsLogo = PhosphorDuotoneIconData(
-    0xeb95,
-    PhosphorIconData(0xeb94, 'Duotone'),
-  );
+  static const googlePodcastsLogo = IconData(0xeb95,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gps-duotone.svg)
-  static const gps = PhosphorDuotoneIconData(
-    0xedd9,
-    PhosphorIconData(0xedd8, 'Duotone'),
-  );
+  static const gps = IconData(0xedd9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-fix-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gps-fix-duotone.svg)
-  static const gpsFix = PhosphorDuotoneIconData(
-    0xedd7,
-    PhosphorIconData(0xedd6, 'Duotone'),
-  );
+  static const gpsFix = IconData(0xedd7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gps-slash-duotone.svg)
-  static const gpsSlash = PhosphorDuotoneIconData(
-    0xedd5,
-    PhosphorIconData(0xedd4, 'Duotone'),
-  );
+  static const gpsSlash = IconData(0xedd5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gradient-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/gradient-duotone.svg)
-  static const gradient = PhosphorDuotoneIconData(
-    0xeb4d,
-    PhosphorIconData(0xeb42, 'Duotone'),
-  );
+  static const gradient = IconData(0xeb4d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graduation-cap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/graduation-cap-duotone.svg)
-  static const graduationCap = PhosphorDuotoneIconData(
-    0xe62d,
-    PhosphorIconData(0xe62c, 'Duotone'),
-  );
+  static const graduationCap = IconData(0xe62d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/grains-duotone.svg)
-  static const grains = PhosphorDuotoneIconData(
-    0xec69,
-    PhosphorIconData(0xec68, 'Duotone'),
-  );
+  static const grains = IconData(0xec69,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/grains-slash-duotone.svg)
-  static const grainsSlash = PhosphorDuotoneIconData(
-    0xec6b,
-    PhosphorIconData(0xec6a, 'Duotone'),
-  );
+  static const grainsSlash = IconData(0xec6b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graph-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/graph-duotone.svg)
-  static const graph = PhosphorDuotoneIconData(
-    0xeb59,
-    PhosphorIconData(0xeb58, 'Duotone'),
-  );
+  static const graph = IconData(0xeb59,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graphics-card-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/graphics-card-duotone.svg)
-  static const graphicsCard = PhosphorDuotoneIconData(
-    0xe613,
-    PhosphorIconData(0xe612, 'Duotone'),
-  );
+  static const graphicsCard = IconData(0xe613,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/greater-than-duotone.svg)
-  static const greaterThan = PhosphorDuotoneIconData(
-    0xedc5,
-    PhosphorIconData(0xedc4, 'Duotone'),
-  );
+  static const greaterThan = IconData(0xedc5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-or-equal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/greater-than-or-equal-duotone.svg)
-  static const greaterThanOrEqual = PhosphorDuotoneIconData(
-    0xeda3,
-    PhosphorIconData(0xeda2, 'Duotone'),
-  );
+  static const greaterThanOrEqual = IconData(0xeda3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/grid-four-duotone.svg)
-  static const gridFour = PhosphorDuotoneIconData(
-    0xe297,
-    PhosphorIconData(0xe296, 'Duotone'),
-  );
+  static const gridFour = IconData(0xe297,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/grid-nine-duotone.svg)
-  static const gridNine = PhosphorDuotoneIconData(
-    0xec8d,
-    PhosphorIconData(0xec8c, 'Duotone'),
-  );
+  static const gridNine = IconData(0xec8d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![guitar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/guitar-duotone.svg)
-  static const guitar = PhosphorDuotoneIconData(
-    0xea8b,
-    PhosphorIconData(0xea8a, 'Duotone'),
-  );
+  static const guitar = IconData(0xea8b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hair-dryer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hair-dryer-duotone.svg)
-  static const hairDryer = PhosphorDuotoneIconData(
-    0xea67,
-    PhosphorIconData(0xea66, 'Duotone'),
-  );
+  static const hairDryer = IconData(0xea67,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hamburger-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hamburger-duotone.svg)
-  static const hamburger = PhosphorDuotoneIconData(
-    0xe791,
-    PhosphorIconData(0xe790, 'Duotone'),
-  );
+  static const hamburger = IconData(0xe791,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hammer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hammer-duotone.svg)
-  static const hammer = PhosphorDuotoneIconData(
-    0xe80f,
-    PhosphorIconData(0xe80e, 'Duotone'),
-  );
+  static const hammer = IconData(0xe80f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-duotone.svg)
-  static const hand = PhosphorDuotoneIconData(
-    0xe299,
-    PhosphorIconData(0xe298, 'Duotone'),
-  );
+  static const hand = IconData(0xe299,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-arrow-down-duotone.svg)
-  static const handArrowDown = PhosphorDuotoneIconData(
-    0xea4f,
-    PhosphorIconData(0xea4e, 'Duotone'),
-  );
+  static const handArrowDown = IconData(0xea4f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-arrow-up-duotone.svg)
-  static const handArrowUp = PhosphorDuotoneIconData(
-    0xee5b,
-    PhosphorIconData(0xee5a, 'Duotone'),
-  );
+  static const handArrowUp = IconData(0xee5b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-coins-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-coins-duotone.svg)
-  static const handCoins = PhosphorDuotoneIconData(
-    0xea8d,
-    PhosphorIconData(0xea8c, 'Duotone'),
-  );
+  static const handCoins = IconData(0xea8d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-deposit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-deposit-duotone.svg)
-  static const handDeposit = PhosphorDuotoneIconData(
-    0xee83,
-    PhosphorIconData(0xee82, 'Duotone'),
-  );
+  static const handDeposit = IconData(0xee83,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-eye-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-eye-duotone.svg)
-  static const handEye = PhosphorDuotoneIconData(
-    0xea4d,
-    PhosphorIconData(0xea4c, 'Duotone'),
-  );
+  static const handEye = IconData(0xea4d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-fist-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-fist-duotone.svg)
-  static const handFist = PhosphorDuotoneIconData(
-    0xe57b,
-    PhosphorIconData(0xe57a, 'Duotone'),
-  );
+  static const handFist = IconData(0xe57b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-grabbing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-grabbing-duotone.svg)
-  static const handGrabbing = PhosphorDuotoneIconData(
-    0xe57d,
-    PhosphorIconData(0xe57c, 'Duotone'),
-  );
+  static const handGrabbing = IconData(0xe57d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-heart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-heart-duotone.svg)
-  static const handHeart = PhosphorDuotoneIconData(
-    0xe811,
-    PhosphorIconData(0xe810, 'Duotone'),
-  );
+  static const handHeart = IconData(0xe811,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-palm-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-palm-duotone.svg)
-  static const handPalm = PhosphorDuotoneIconData(
-    0xe57f,
-    PhosphorIconData(0xe57e, 'Duotone'),
-  );
+  static const handPalm = IconData(0xe57f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-peace-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-peace-duotone.svg)
-  static const handPeace = PhosphorDuotoneIconData(
-    0xe7cd,
-    PhosphorIconData(0xe7cc, 'Duotone'),
-  );
+  static const handPeace = IconData(0xe7cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-pointing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-pointing-duotone.svg)
-  static const handPointing = PhosphorDuotoneIconData(
-    0xe29b,
-    PhosphorIconData(0xe29a, 'Duotone'),
-  );
+  static const handPointing = IconData(0xe29b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-soap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-soap-duotone.svg)
-  static const handSoap = PhosphorDuotoneIconData(
-    0xe631,
-    PhosphorIconData(0xe630, 'Duotone'),
-  );
+  static const handSoap = IconData(0xe631,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-swipe-left-duotone.svg)
-  static const handSwipeLeft = PhosphorDuotoneIconData(
-    0xec95,
-    PhosphorIconData(0xec94, 'Duotone'),
-  );
+  static const handSwipeLeft = IconData(0xec95,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-swipe-right-duotone.svg)
-  static const handSwipeRight = PhosphorDuotoneIconData(
-    0xec93,
-    PhosphorIconData(0xec92, 'Duotone'),
-  );
+  static const handSwipeRight = IconData(0xec93,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-tap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-tap-duotone.svg)
-  static const handTap = PhosphorDuotoneIconData(
-    0xec91,
-    PhosphorIconData(0xec90, 'Duotone'),
-  );
+  static const handTap = IconData(0xec91,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-waving-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-waving-duotone.svg)
-  static const handWaving = PhosphorDuotoneIconData(
-    0xe581,
-    PhosphorIconData(0xe580, 'Duotone'),
-  );
+  static const handWaving = IconData(0xe581,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-withdraw-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hand-withdraw-duotone.svg)
-  static const handWithdraw = PhosphorDuotoneIconData(
-    0xee81,
-    PhosphorIconData(0xee80, 'Duotone'),
-  );
+  static const handWithdraw = IconData(0xee81,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/handbag-duotone.svg)
-  static const handbag = PhosphorDuotoneIconData(
-    0xe29d,
-    PhosphorIconData(0xe29c, 'Duotone'),
-  );
+  static const handbag = IconData(0xe29d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/handbag-simple-duotone.svg)
-  static const handbagSimple = PhosphorDuotoneIconData(
-    0xe62f,
-    PhosphorIconData(0xe62e, 'Duotone'),
-  );
+  static const handbagSimple = IconData(0xe62f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-clapping-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hands-clapping-duotone.svg)
-  static const handsClapping = PhosphorDuotoneIconData(
-    0xe6a1,
-    PhosphorIconData(0xe6a0, 'Duotone'),
-  );
+  static const handsClapping = IconData(0xe6a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-praying-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hands-praying-duotone.svg)
-  static const handsPraying = PhosphorDuotoneIconData(
-    0xecc9,
-    PhosphorIconData(0xecc8, 'Duotone'),
-  );
+  static const handsPraying = IconData(0xecc9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handshake-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/handshake-duotone.svg)
-  static const handshake = PhosphorDuotoneIconData(
-    0xe583,
-    PhosphorIconData(0xe582, 'Duotone'),
-  );
+  static const handshake = IconData(0xe583,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drive-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hard-drive-duotone.svg)
-  static const hardDrive = PhosphorDuotoneIconData(
-    0xe29f,
-    PhosphorIconData(0xe29e, 'Duotone'),
-  );
+  static const hardDrive = IconData(0xe29f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drives-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hard-drives-duotone.svg)
-  static const hardDrives = PhosphorDuotoneIconData(
-    0xe2a1,
-    PhosphorIconData(0xe2a0, 'Duotone'),
-  );
+  static const hardDrives = IconData(0xe2a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-hat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hard-hat-duotone.svg)
-  static const hardHat = PhosphorDuotoneIconData(
-    0xed47,
-    PhosphorIconData(0xed46, 'Duotone'),
-  );
+  static const hardHat = IconData(0xed47,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hash-duotone.svg)
-  static const hash = PhosphorDuotoneIconData(
-    0xe2a3,
-    PhosphorIconData(0xe2a2, 'Duotone'),
-  );
+  static const hash = IconData(0xe2a3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-straight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hash-straight-duotone.svg)
-  static const hashStraight = PhosphorDuotoneIconData(
-    0xe2a5,
-    PhosphorIconData(0xe2a4, 'Duotone'),
-  );
+  static const hashStraight = IconData(0xe2a5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![head-circuit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/head-circuit-duotone.svg)
-  static const headCircuit = PhosphorDuotoneIconData(
-    0xe7d5,
-    PhosphorIconData(0xe7d4, 'Duotone'),
-  );
+  static const headCircuit = IconData(0xe7d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headlights-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/headlights-duotone.svg)
-  static const headlights = PhosphorDuotoneIconData(
-    0xe6ff,
-    PhosphorIconData(0xe6fe, 'Duotone'),
-  );
+  static const headlights = IconData(0xe6ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headphones-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/headphones-duotone.svg)
-  static const headphones = PhosphorDuotoneIconData(
-    0xe2a7,
-    PhosphorIconData(0xe2a6, 'Duotone'),
-  );
+  static const headphones = IconData(0xe2a7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headset-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/headset-duotone.svg)
-  static const headset = PhosphorDuotoneIconData(
-    0xe585,
-    PhosphorIconData(0xe584, 'Duotone'),
-  );
+  static const headset = IconData(0xe585,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-duotone.svg)
-  static const heart = PhosphorDuotoneIconData(
-    0xe2a9,
-    PhosphorIconData(0xe2a8, 'Duotone'),
-  );
+  static const heart = IconData(0xe2a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-break-duotone.svg)
-  static const heartBreak = PhosphorDuotoneIconData(
-    0xebe9,
-    PhosphorIconData(0xebe8, 'Duotone'),
-  );
+  static const heartBreak = IconData(0xebe9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-half-duotone.svg)
-  static const heartHalf = PhosphorDuotoneIconData(
-    0xec49,
-    PhosphorIconData(0xec48, 'Duotone'),
-  );
+  static const heartHalf = IconData(0xec49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-straight-duotone.svg)
-  static const heartStraight = PhosphorDuotoneIconData(
-    0xe2ab,
-    PhosphorIconData(0xe2aa, 'Duotone'),
-  );
+  static const heartStraight = IconData(0xe2ab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heart-straight-break-duotone.svg)
-  static const heartStraightBreak = PhosphorDuotoneIconData(
-    0xeb99,
-    PhosphorIconData(0xeb98, 'Duotone'),
-  );
+  static const heartStraightBreak = IconData(0xeb99,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heartbeat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/heartbeat-duotone.svg)
-  static const heartbeat = PhosphorDuotoneIconData(
-    0xe2ad,
-    PhosphorIconData(0xe2ac, 'Duotone'),
-  );
+  static const heartbeat = IconData(0xe2ad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hexagon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hexagon-duotone.svg)
-  static const hexagon = PhosphorDuotoneIconData(
-    0xe2af,
-    PhosphorIconData(0xe2ae, 'Duotone'),
-  );
+  static const hexagon = IconData(0xe2af,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-definition-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/high-definition-duotone.svg)
-  static const highDefinition = PhosphorDuotoneIconData(
-    0xea8f,
-    PhosphorIconData(0xea8e, 'Duotone'),
-  );
+  static const highDefinition = IconData(0xea8f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-heel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/high-heel-duotone.svg)
-  static const highHeel = PhosphorDuotoneIconData(
-    0xe8e9,
-    PhosphorIconData(0xe8e8, 'Duotone'),
-  );
+  static const highHeel = IconData(0xe8e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/highlighter-duotone.svg)
-  static const highlighter = PhosphorDuotoneIconData(
-    0xec77,
-    PhosphorIconData(0xec76, 'Duotone'),
-  );
+  static const highlighter = IconData(0xec77,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/highlighter-circle-duotone.svg)
-  static const highlighterCircle = PhosphorDuotoneIconData(
-    0xe633,
-    PhosphorIconData(0xe632, 'Duotone'),
-  );
+  static const highlighterCircle = IconData(0xe633,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hockey-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hockey-duotone.svg)
-  static const hockey = PhosphorDuotoneIconData(
-    0xec87,
-    PhosphorIconData(0xec86, 'Duotone'),
-  );
+  static const hockey = IconData(0xec87,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hoodie-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hoodie-duotone.svg)
-  static const hoodie = PhosphorDuotoneIconData(
-    0xecd1,
-    PhosphorIconData(0xecd0, 'Duotone'),
-  );
+  static const hoodie = IconData(0xecd1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![horse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/horse-duotone.svg)
-  static const horse = PhosphorDuotoneIconData(
-    0xe2b1,
-    PhosphorIconData(0xe2b0, 'Duotone'),
-  );
+  static const horse = IconData(0xe2b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hospital-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hospital-duotone.svg)
-  static const hospital = PhosphorDuotoneIconData(
-    0xe845,
-    PhosphorIconData(0xe844, 'Duotone'),
-  );
+  static const hospital = IconData(0xe845,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-duotone.svg)
-  static const hourglass = PhosphorDuotoneIconData(
-    0xe2b3,
-    PhosphorIconData(0xe2b2, 'Duotone'),
-  );
+  static const hourglass = IconData(0xe2b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-high-duotone.svg)
-  static const hourglassHigh = PhosphorDuotoneIconData(
-    0xe2b5,
-    PhosphorIconData(0xe2b4, 'Duotone'),
-  );
+  static const hourglassHigh = IconData(0xe2b5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-low-duotone.svg)
-  static const hourglassLow = PhosphorDuotoneIconData(
-    0xe2b7,
-    PhosphorIconData(0xe2b6, 'Duotone'),
-  );
+  static const hourglassLow = IconData(0xe2b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-medium-duotone.svg)
-  static const hourglassMedium = PhosphorDuotoneIconData(
-    0xe2b9,
-    PhosphorIconData(0xe2b8, 'Duotone'),
-  );
+  static const hourglassMedium = IconData(0xe2b9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-simple-duotone.svg)
-  static const hourglassSimple = PhosphorDuotoneIconData(
-    0xe2bb,
-    PhosphorIconData(0xe2ba, 'Duotone'),
-  );
+  static const hourglassSimple = IconData(0xe2bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-simple-high-duotone.svg)
-  static const hourglassSimpleHigh = PhosphorDuotoneIconData(
-    0xe2bd,
-    PhosphorIconData(0xe2bc, 'Duotone'),
-  );
+  static const hourglassSimpleHigh = IconData(0xe2bd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-simple-low-duotone.svg)
-  static const hourglassSimpleLow = PhosphorDuotoneIconData(
-    0xe2bf,
-    PhosphorIconData(0xe2be, 'Duotone'),
-  );
+  static const hourglassSimpleLow = IconData(0xe2bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hourglass-simple-medium-duotone.svg)
-  static const hourglassSimpleMedium = PhosphorDuotoneIconData(
-    0xe2c1,
-    PhosphorIconData(0xe2c0, 'Duotone'),
-  );
+  static const hourglassSimpleMedium = IconData(0xe2c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/house-duotone.svg)
-  static const house = PhosphorDuotoneIconData(
-    0xe2c3,
-    PhosphorIconData(0xe2c2, 'Duotone'),
-  );
+  static const house = IconData(0xe2c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/house-line-duotone.svg)
-  static const houseLine = PhosphorDuotoneIconData(
-    0xe2c5,
-    PhosphorIconData(0xe2c4, 'Duotone'),
-  );
+  static const houseLine = IconData(0xe2c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/house-simple-duotone.svg)
-  static const houseSimple = PhosphorDuotoneIconData(
-    0xe2c7,
-    PhosphorIconData(0xe2c6, 'Duotone'),
-  );
+  static const houseSimple = IconData(0xe2c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hurricane-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/hurricane-duotone.svg)
-  static const hurricane = PhosphorDuotoneIconData(
-    0xe88f,
-    PhosphorIconData(0xe88e, 'Duotone'),
-  );
+  static const hurricane = IconData(0xe88f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ice-cream-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ice-cream-duotone.svg)
-  static const iceCream = PhosphorDuotoneIconData(
-    0xe805,
-    PhosphorIconData(0xe804, 'Duotone'),
-  );
+  static const iceCream = IconData(0xe805,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-badge-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/identification-badge-duotone.svg)
-  static const identificationBadge = PhosphorDuotoneIconData(
-    0xe6f7,
-    PhosphorIconData(0xe6f6, 'Duotone'),
-  );
+  static const identificationBadge = IconData(0xe6f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-card-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/identification-card-duotone.svg)
-  static const identificationCard = PhosphorDuotoneIconData(
-    0xe2c9,
-    PhosphorIconData(0xe2c8, 'Duotone'),
-  );
+  static const identificationCard = IconData(0xe2c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/image-duotone.svg)
-  static const image = PhosphorDuotoneIconData(
-    0xe2cb,
-    PhosphorIconData(0xe2ca, 'Duotone'),
-  );
+  static const image = IconData(0xe2cb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-broken-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/image-broken-duotone.svg)
-  static const imageBroken = PhosphorDuotoneIconData(
-    0xe7a9,
-    PhosphorIconData(0xe7a8, 'Duotone'),
-  );
+  static const imageBroken = IconData(0xe7a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/image-square-duotone.svg)
-  static const imageSquare = PhosphorDuotoneIconData(
-    0xe2cd,
-    PhosphorIconData(0xe2cc, 'Duotone'),
-  );
+  static const imageSquare = IconData(0xe2cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/images-duotone.svg)
-  static const images = PhosphorDuotoneIconData(
-    0xe837,
-    PhosphorIconData(0xe836, 'Duotone'),
-  );
+  static const images = IconData(0xe837,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/images-square-duotone.svg)
-  static const imagesSquare = PhosphorDuotoneIconData(
-    0xe835,
-    PhosphorIconData(0xe834, 'Duotone'),
-  );
+  static const imagesSquare = IconData(0xe835,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![infinity-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/infinity-duotone.svg)
-  static const infinity = PhosphorDuotoneIconData(
-    0xe635,
-    PhosphorIconData(0xe634, 'Duotone'),
-  );
+  static const infinity = IconData(0xe635,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![info-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/info-duotone.svg)
-  static const info = PhosphorDuotoneIconData(
-    0xe2cf,
-    PhosphorIconData(0xe2ce, 'Duotone'),
-  );
+  static const info = IconData(0xe2cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![instagram-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/instagram-logo-duotone.svg)
-  static const instagramLogo = PhosphorDuotoneIconData(
-    0xe2d1,
-    PhosphorIconData(0xe2d0, 'Duotone'),
-  );
+  static const instagramLogo = IconData(0xe2d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/intersect-duotone.svg)
-  static const intersect = PhosphorDuotoneIconData(
-    0xe2d3,
-    PhosphorIconData(0xe2d2, 'Duotone'),
-  );
+  static const intersect = IconData(0xe2d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/intersect-square-duotone.svg)
-  static const intersectSquare = PhosphorDuotoneIconData(
-    0xe87b,
-    PhosphorIconData(0xe87a, 'Duotone'),
-  );
+  static const intersectSquare = IconData(0xe87b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/intersect-three-duotone.svg)
-  static const intersectThree = PhosphorDuotoneIconData(
-    0xecc5,
-    PhosphorIconData(0xecc4, 'Duotone'),
-  );
+  static const intersectThree = IconData(0xecc5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersection-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/intersection-duotone.svg)
-  static const intersection = PhosphorDuotoneIconData(
-    0xedbb,
-    PhosphorIconData(0xedba, 'Duotone'),
-  );
+  static const intersection = IconData(0xedbb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![invoice-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/invoice-duotone.svg)
-  static const invoice = PhosphorDuotoneIconData(
-    0xee43,
-    PhosphorIconData(0xee42, 'Duotone'),
-  );
+  static const invoice = IconData(0xee43,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![island-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/island-duotone.svg)
-  static const island = PhosphorDuotoneIconData(
-    0xee07,
-    PhosphorIconData(0xee06, 'Duotone'),
-  );
+  static const island = IconData(0xee07,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/jar-duotone.svg)
-  static const jar = PhosphorDuotoneIconData(
-    0xe7e3,
-    PhosphorIconData(0xe7e0, 'Duotone'),
-  );
+  static const jar = IconData(0xe7e3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-label-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/jar-label-duotone.svg)
-  static const jarLabel = PhosphorDuotoneIconData(
-    0xe7e5,
-    PhosphorIconData(0xe7e1, 'Duotone'),
-  );
+  static const jarLabel = IconData(0xe7e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jeep-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/jeep-duotone.svg)
-  static const jeep = PhosphorDuotoneIconData(
-    0xe2d5,
-    PhosphorIconData(0xe2d4, 'Duotone'),
-  );
+  static const jeep = IconData(0xe2d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![joystick-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/joystick-duotone.svg)
-  static const joystick = PhosphorDuotoneIconData(
-    0xea5f,
-    PhosphorIconData(0xea5e, 'Duotone'),
-  );
+  static const joystick = IconData(0xea5f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![kanban-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/kanban-duotone.svg)
-  static const kanban = PhosphorDuotoneIconData(
-    0xeb55,
-    PhosphorIconData(0xeb54, 'Duotone'),
-  );
+  static const kanban = IconData(0xeb55,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/key-duotone.svg)
-  static const key = PhosphorDuotoneIconData(
-    0xe2d7,
-    PhosphorIconData(0xe2d6, 'Duotone'),
-  );
+  static const key = IconData(0xe2d7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-return-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/key-return-duotone.svg)
-  static const keyReturn = PhosphorDuotoneIconData(
-    0xe783,
-    PhosphorIconData(0xe782, 'Duotone'),
-  );
+  static const keyReturn = IconData(0xe783,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyboard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/keyboard-duotone.svg)
-  static const keyboard = PhosphorDuotoneIconData(
-    0xe2d9,
-    PhosphorIconData(0xe2d8, 'Duotone'),
-  );
+  static const keyboard = IconData(0xe2d9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyhole-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/keyhole-duotone.svg)
-  static const keyhole = PhosphorDuotoneIconData(
-    0xea79,
-    PhosphorIconData(0xea78, 'Duotone'),
-  );
+  static const keyhole = IconData(0xea79,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![knife-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/knife-duotone.svg)
-  static const knife = PhosphorDuotoneIconData(
-    0xe637,
-    PhosphorIconData(0xe636, 'Duotone'),
-  );
+  static const knife = IconData(0xe637,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ladder-duotone.svg)
-  static const ladder = PhosphorDuotoneIconData(
-    0xe9e5,
-    PhosphorIconData(0xe9e4, 'Duotone'),
-  );
+  static const ladder = IconData(0xe9e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ladder-simple-duotone.svg)
-  static const ladderSimple = PhosphorDuotoneIconData(
-    0xec27,
-    PhosphorIconData(0xec26, 'Duotone'),
-  );
+  static const ladderSimple = IconData(0xec27,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lamp-duotone.svg)
-  static const lamp = PhosphorDuotoneIconData(
-    0xe639,
-    PhosphorIconData(0xe638, 'Duotone'),
-  );
+  static const lamp = IconData(0xe639,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-pendant-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lamp-pendant-duotone.svg)
-  static const lampPendant = PhosphorDuotoneIconData(
-    0xee2f,
-    PhosphorIconData(0xee2e, 'Duotone'),
-  );
+  static const lampPendant = IconData(0xee2f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![laptop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/laptop-duotone.svg)
-  static const laptop = PhosphorDuotoneIconData(
-    0xe587,
-    PhosphorIconData(0xe586, 'Duotone'),
-  );
+  static const laptop = IconData(0xe587,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lasso-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lasso-duotone.svg)
-  static const lasso = PhosphorDuotoneIconData(
-    0xedc7,
-    PhosphorIconData(0xedc6, 'Duotone'),
-  );
+  static const lasso = IconData(0xedc7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lastfm-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lastfm-logo-duotone.svg)
-  static const lastfmLogo = PhosphorDuotoneIconData(
-    0xe843,
-    PhosphorIconData(0xe842, 'Duotone'),
-  );
+  static const lastfmLogo = IconData(0xe843,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![layout-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/layout-duotone.svg)
-  static const layout = PhosphorDuotoneIconData(
-    0xe6d7,
-    PhosphorIconData(0xe6d6, 'Duotone'),
-  );
+  static const layout = IconData(0xe6d7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![leaf-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/leaf-duotone.svg)
-  static const leaf = PhosphorDuotoneIconData(
-    0xe2db,
-    PhosphorIconData(0xe2da, 'Duotone'),
-  );
+  static const leaf = IconData(0xe2db,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lectern-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lectern-duotone.svg)
-  static const lectern = PhosphorDuotoneIconData(
-    0xe95b,
-    PhosphorIconData(0xe95a, 'Duotone'),
-  );
+  static const lectern = IconData(0xe95b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lego-duotone.svg)
-  static const lego = PhosphorDuotoneIconData(
-    0xe8c8,
-    PhosphorIconData(0xe8c6, 'Duotone'),
-  );
+  static const lego = IconData(0xe8c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-smiley-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lego-smiley-duotone.svg)
-  static const legoSmiley = PhosphorDuotoneIconData(
-    0xe8c9,
-    PhosphorIconData(0xe8c7, 'Duotone'),
-  );
+  static const legoSmiley = IconData(0xe8c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/less-than-duotone.svg)
-  static const lessThan = PhosphorDuotoneIconData(
-    0xedad,
-    PhosphorIconData(0xedac, 'Duotone'),
-  );
+  static const lessThan = IconData(0xedad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-or-equal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/less-than-or-equal-duotone.svg)
-  static const lessThanOrEqual = PhosphorDuotoneIconData(
-    0xeda5,
-    PhosphorIconData(0xeda4, 'Duotone'),
-  );
+  static const lessThanOrEqual = IconData(0xeda5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-h-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/letter-circle-h-duotone.svg)
-  static const letterCircleH = PhosphorDuotoneIconData(
-    0xebf9,
-    PhosphorIconData(0xebf8, 'Duotone'),
-  );
+  static const letterCircleH = IconData(0xebf9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-p-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/letter-circle-p-duotone.svg)
-  static const letterCircleP = PhosphorDuotoneIconData(
-    0xec09,
-    PhosphorIconData(0xec08, 'Duotone'),
-  );
+  static const letterCircleP = IconData(0xec09,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-v-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/letter-circle-v-duotone.svg)
-  static const letterCircleV = PhosphorDuotoneIconData(
-    0xec15,
-    PhosphorIconData(0xec14, 'Duotone'),
-  );
+  static const letterCircleV = IconData(0xec15,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lifebuoy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lifebuoy-duotone.svg)
-  static const lifebuoy = PhosphorDuotoneIconData(
-    0xe63b,
-    PhosphorIconData(0xe63a, 'Duotone'),
-  );
+  static const lifebuoy = IconData(0xe63b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightbulb-duotone.svg)
-  static const lightbulb = PhosphorDuotoneIconData(
-    0xe2dd,
-    PhosphorIconData(0xe2dc, 'Duotone'),
-  );
+  static const lightbulb = IconData(0xe2dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-filament-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightbulb-filament-duotone.svg)
-  static const lightbulbFilament = PhosphorDuotoneIconData(
-    0xe63d,
-    PhosphorIconData(0xe63c, 'Duotone'),
-  );
+  static const lightbulbFilament = IconData(0xe63d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lighthouse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lighthouse-duotone.svg)
-  static const lighthouse = PhosphorDuotoneIconData(
-    0xe9f7,
-    PhosphorIconData(0xe9f6, 'Duotone'),
-  );
+  static const lighthouse = IconData(0xe9f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightning-duotone.svg)
-  static const lightning = PhosphorDuotoneIconData(
-    0xe2df,
-    PhosphorIconData(0xe2de, 'Duotone'),
-  );
+  static const lightning = IconData(0xe2df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-a-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightning-a-duotone.svg)
-  static const lightningA = PhosphorDuotoneIconData(
-    0xea85,
-    PhosphorIconData(0xea84, 'Duotone'),
-  );
+  static const lightningA = IconData(0xea85,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lightning-slash-duotone.svg)
-  static const lightningSlash = PhosphorDuotoneIconData(
-    0xe2e1,
-    PhosphorIconData(0xe2e0, 'Duotone'),
-  );
+  static const lightningSlash = IconData(0xe2e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segment-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/line-segment-duotone.svg)
-  static const lineSegment = PhosphorDuotoneIconData(
-    0xe6d3,
-    PhosphorIconData(0xe6d2, 'Duotone'),
-  );
+  static const lineSegment = IconData(0xe6d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segments-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/line-segments-duotone.svg)
-  static const lineSegments = PhosphorDuotoneIconData(
-    0xe6d5,
-    PhosphorIconData(0xe6d4, 'Duotone'),
-  );
+  static const lineSegments = IconData(0xe6d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/line-vertical-duotone.svg)
-  static const lineVertical = PhosphorDuotoneIconData(
-    0xed71,
-    PhosphorIconData(0xed70, 'Duotone'),
-  );
+  static const lineVertical = IconData(0xed71,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-duotone.svg)
-  static const link = PhosphorDuotoneIconData(
-    0xe2e3,
-    PhosphorIconData(0xe2e2, 'Duotone'),
-  );
+  static const link = IconData(0xe2e3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-break-duotone.svg)
-  static const linkBreak = PhosphorDuotoneIconData(
-    0xe2e5,
-    PhosphorIconData(0xe2e4, 'Duotone'),
-  );
+  static const linkBreak = IconData(0xe2e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-simple-duotone.svg)
-  static const linkSimple = PhosphorDuotoneIconData(
-    0xe2e7,
-    PhosphorIconData(0xe2e6, 'Duotone'),
-  );
+  static const linkSimple = IconData(0xe2e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-simple-break-duotone.svg)
-  static const linkSimpleBreak = PhosphorDuotoneIconData(
-    0xe2e9,
-    PhosphorIconData(0xe2e8, 'Duotone'),
-  );
+  static const linkSimpleBreak = IconData(0xe2e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-simple-horizontal-duotone.svg)
-  static const linkSimpleHorizontal = PhosphorDuotoneIconData(
-    0xe2eb,
-    PhosphorIconData(0xe2ea, 'Duotone'),
-  );
+  static const linkSimpleHorizontal = IconData(0xe2eb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-break-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/link-simple-horizontal-break-duotone.svg)
-  static const linkSimpleHorizontalBreak = PhosphorDuotoneIconData(
-    0xe2ed,
-    PhosphorIconData(0xe2ec, 'Duotone'),
-  );
+  static const linkSimpleHorizontalBreak = IconData(0xe2ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linkedin-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/linkedin-logo-duotone.svg)
-  static const linkedinLogo = PhosphorDuotoneIconData(
-    0xe2ef,
-    PhosphorIconData(0xe2ee, 'Duotone'),
-  );
+  static const linkedinLogo = IconData(0xe2ef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linktree-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/linktree-logo-duotone.svg)
-  static const linktreeLogo = PhosphorDuotoneIconData(
-    0xedef,
-    PhosphorIconData(0xedee, 'Duotone'),
-  );
+  static const linktreeLogo = IconData(0xedef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linux-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/linux-logo-duotone.svg)
-  static const linuxLogo = PhosphorDuotoneIconData(
-    0xeb03,
-    PhosphorIconData(0xeb02, 'Duotone'),
-  );
+  static const linuxLogo = IconData(0xeb03,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-duotone.svg)
-  static const list = PhosphorDuotoneIconData(
-    0xe2f1,
-    PhosphorIconData(0xe2f0, 'Duotone'),
-  );
+  static const list = IconData(0xe2f1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-bullets-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-bullets-duotone.svg)
-  static const listBullets = PhosphorDuotoneIconData(
-    0xe2f3,
-    PhosphorIconData(0xe2f2, 'Duotone'),
-  );
+  static const listBullets = IconData(0xe2f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-checks-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-checks-duotone.svg)
-  static const listChecks = PhosphorDuotoneIconData(
-    0xeadd,
-    PhosphorIconData(0xeadc, 'Duotone'),
-  );
+  static const listChecks = IconData(0xeadd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-dashes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-dashes-duotone.svg)
-  static const listDashes = PhosphorDuotoneIconData(
-    0xe2f5,
-    PhosphorIconData(0xe2f4, 'Duotone'),
-  );
+  static const listDashes = IconData(0xe2f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-heart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-heart-duotone.svg)
-  static const listHeart = PhosphorDuotoneIconData(
-    0xebdf,
-    PhosphorIconData(0xebde, 'Duotone'),
-  );
+  static const listHeart = IconData(0xebdf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-magnifying-glass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-magnifying-glass-duotone.svg)
-  static const listMagnifyingGlass = PhosphorDuotoneIconData(
-    0xebe1,
-    PhosphorIconData(0xebe0, 'Duotone'),
-  );
+  static const listMagnifyingGlass = IconData(0xebe1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-numbers-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-numbers-duotone.svg)
-  static const listNumbers = PhosphorDuotoneIconData(
-    0xe2f7,
-    PhosphorIconData(0xe2f6, 'Duotone'),
-  );
+  static const listNumbers = IconData(0xe2f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-plus-duotone.svg)
-  static const listPlus = PhosphorDuotoneIconData(
-    0xe2f9,
-    PhosphorIconData(0xe2f8, 'Duotone'),
-  );
+  static const listPlus = IconData(0xe2f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/list-star-duotone.svg)
-  static const listStar = PhosphorDuotoneIconData(
-    0xebdd,
-    PhosphorIconData(0xebdc, 'Duotone'),
-  );
+  static const listStar = IconData(0xebdd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-duotone.svg)
-  static const lock = PhosphorDuotoneIconData(
-    0xe2fb,
-    PhosphorIconData(0xe2fa, 'Duotone'),
-  );
+  static const lock = IconData(0xe2fb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-key-duotone.svg)
-  static const lockKey = PhosphorDuotoneIconData(
-    0xe2ff,
-    PhosphorIconData(0xe2fe, 'Duotone'),
-  );
+  static const lockKey = IconData(0xe2ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-key-open-duotone.svg)
-  static const lockKeyOpen = PhosphorDuotoneIconData(
-    0xe301,
-    PhosphorIconData(0xe300, 'Duotone'),
-  );
+  static const lockKeyOpen = IconData(0xe301,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-laminated-duotone.svg)
-  static const lockLaminated = PhosphorDuotoneIconData(
-    0xe303,
-    PhosphorIconData(0xe302, 'Duotone'),
-  );
+  static const lockLaminated = IconData(0xe303,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-laminated-open-duotone.svg)
-  static const lockLaminatedOpen = PhosphorDuotoneIconData(
-    0xe305,
-    PhosphorIconData(0xe304, 'Duotone'),
-  );
+  static const lockLaminatedOpen = IconData(0xe305,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-open-duotone.svg)
-  static const lockOpen = PhosphorDuotoneIconData(
-    0xe307,
-    PhosphorIconData(0xe306, 'Duotone'),
-  );
+  static const lockOpen = IconData(0xe307,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-simple-duotone.svg)
-  static const lockSimple = PhosphorDuotoneIconData(
-    0xe309,
-    PhosphorIconData(0xe308, 'Duotone'),
-  );
+  static const lockSimple = IconData(0xe309,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lock-simple-open-duotone.svg)
-  static const lockSimpleOpen = PhosphorDuotoneIconData(
-    0xe30b,
-    PhosphorIconData(0xe30a, 'Duotone'),
-  );
+  static const lockSimpleOpen = IconData(0xe30b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lockers-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/lockers-duotone.svg)
-  static const lockers = PhosphorDuotoneIconData(
-    0xecb9,
-    PhosphorIconData(0xecb8, 'Duotone'),
-  );
+  static const lockers = IconData(0xecb9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![log-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/log-duotone.svg)
-  static const log = PhosphorDuotoneIconData(
-    0xed83,
-    PhosphorIconData(0xed82, 'Duotone'),
-  );
+  static const log = IconData(0xed83,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magic-wand-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magic-wand-duotone.svg)
-  static const magicWand = PhosphorDuotoneIconData(
-    0xe6b7,
-    PhosphorIconData(0xe6b6, 'Duotone'),
-  );
+  static const magicWand = IconData(0xe6b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnet-duotone.svg)
-  static const magnet = PhosphorDuotoneIconData(
-    0xe681,
-    PhosphorIconData(0xe680, 'Duotone'),
-  );
+  static const magnet = IconData(0xe681,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-straight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnet-straight-duotone.svg)
-  static const magnetStraight = PhosphorDuotoneIconData(
-    0xe683,
-    PhosphorIconData(0xe682, 'Duotone'),
-  );
+  static const magnetStraight = IconData(0xe683,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnifying-glass-duotone.svg)
-  static const magnifyingGlass = PhosphorDuotoneIconData(
-    0xe30d,
-    PhosphorIconData(0xe30c, 'Duotone'),
-  );
+  static const magnifyingGlass = IconData(0xe30d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnifying-glass-minus-duotone.svg)
-  static const magnifyingGlassMinus = PhosphorDuotoneIconData(
-    0xe30f,
-    PhosphorIconData(0xe30e, 'Duotone'),
-  );
+  static const magnifyingGlassMinus = IconData(0xe30f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/magnifying-glass-plus-duotone.svg)
-  static const magnifyingGlassPlus = PhosphorDuotoneIconData(
-    0xe311,
-    PhosphorIconData(0xe310, 'Duotone'),
-  );
+  static const magnifyingGlassPlus = IconData(0xe311,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mailbox-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mailbox-duotone.svg)
-  static const mailbox = PhosphorDuotoneIconData(
-    0xec1f,
-    PhosphorIconData(0xec1e, 'Duotone'),
-  );
+  static const mailbox = IconData(0xec1f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-duotone.svg)
-  static const mapPin = PhosphorDuotoneIconData(
-    0xe317,
-    PhosphorIconData(0xe316, 'Duotone'),
-  );
+  static const mapPin = IconData(0xe317,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-area-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-area-duotone.svg)
-  static const mapPinArea = PhosphorDuotoneIconData(
-    0xee3b,
-    PhosphorIconData(0xee3a, 'Duotone'),
-  );
+  static const mapPinArea = IconData(0xee3b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-line-duotone.svg)
-  static const mapPinLine = PhosphorDuotoneIconData(
-    0xe319,
-    PhosphorIconData(0xe318, 'Duotone'),
-  );
+  static const mapPinLine = IconData(0xe319,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-plus-duotone.svg)
-  static const mapPinPlus = PhosphorDuotoneIconData(
-    0xe315,
-    PhosphorIconData(0xe314, 'Duotone'),
-  );
+  static const mapPinPlus = IconData(0xe315,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-simple-duotone.svg)
-  static const mapPinSimple = PhosphorDuotoneIconData(
-    0xee3f,
-    PhosphorIconData(0xee3e, 'Duotone'),
-  );
+  static const mapPinSimple = IconData(0xee3f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-area-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-simple-area-duotone.svg)
-  static const mapPinSimpleArea = PhosphorDuotoneIconData(
-    0xee3d,
-    PhosphorIconData(0xee3c, 'Duotone'),
-  );
+  static const mapPinSimpleArea = IconData(0xee3d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-pin-simple-line-duotone.svg)
-  static const mapPinSimpleLine = PhosphorDuotoneIconData(
-    0xee39,
-    PhosphorIconData(0xee38, 'Duotone'),
-  );
+  static const mapPinSimpleLine = IconData(0xee39,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-trifold-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/map-trifold-duotone.svg)
-  static const mapTrifold = PhosphorDuotoneIconData(
-    0xe31b,
-    PhosphorIconData(0xe31a, 'Duotone'),
-  );
+  static const mapTrifold = IconData(0xe31b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![markdown-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/markdown-logo-duotone.svg)
-  static const markdownLogo = PhosphorDuotoneIconData(
-    0xe509,
-    PhosphorIconData(0xe508, 'Duotone'),
-  );
+  static const markdownLogo = IconData(0xe509,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![marker-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/marker-circle-duotone.svg)
-  static const markerCircle = PhosphorDuotoneIconData(
-    0xe641,
-    PhosphorIconData(0xe640, 'Duotone'),
-  );
+  static const markerCircle = IconData(0xe641,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![martini-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/martini-duotone.svg)
-  static const martini = PhosphorDuotoneIconData(
-    0xe31d,
-    PhosphorIconData(0xe31c, 'Duotone'),
-  );
+  static const martini = IconData(0xe31d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-happy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mask-happy-duotone.svg)
-  static const maskHappy = PhosphorDuotoneIconData(
-    0xe9f5,
-    PhosphorIconData(0xe9f4, 'Duotone'),
-  );
+  static const maskHappy = IconData(0xe9f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-sad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mask-sad-duotone.svg)
-  static const maskSad = PhosphorDuotoneIconData(
-    0xeb9f,
-    PhosphorIconData(0xeb9e, 'Duotone'),
-  );
+  static const maskSad = IconData(0xeb9f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mastodon-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mastodon-logo-duotone.svg)
-  static const mastodonLogo = PhosphorDuotoneIconData(
-    0xed69,
-    PhosphorIconData(0xed68, 'Duotone'),
-  );
+  static const mastodonLogo = IconData(0xed69,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![math-operations-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/math-operations-duotone.svg)
-  static const mathOperations = PhosphorDuotoneIconData(
-    0xe31f,
-    PhosphorIconData(0xe31e, 'Duotone'),
-  );
+  static const mathOperations = IconData(0xe31f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![matrix-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/matrix-logo-duotone.svg)
-  static const matrixLogo = PhosphorDuotoneIconData(
-    0xed65,
-    PhosphorIconData(0xed64, 'Duotone'),
-  );
+  static const matrixLogo = IconData(0xed65,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/medal-duotone.svg)
-  static const medal = PhosphorDuotoneIconData(
-    0xe321,
-    PhosphorIconData(0xe320, 'Duotone'),
-  );
+  static const medal = IconData(0xe321,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-military-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/medal-military-duotone.svg)
-  static const medalMilitary = PhosphorDuotoneIconData(
-    0xecfd,
-    PhosphorIconData(0xecfc, 'Duotone'),
-  );
+  static const medalMilitary = IconData(0xecfd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medium-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/medium-logo-duotone.svg)
-  static const mediumLogo = PhosphorDuotoneIconData(
-    0xe323,
-    PhosphorIconData(0xe322, 'Duotone'),
-  );
+  static const mediumLogo = IconData(0xe323,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/megaphone-duotone.svg)
-  static const megaphone = PhosphorDuotoneIconData(
-    0xe325,
-    PhosphorIconData(0xe324, 'Duotone'),
-  );
+  static const megaphone = IconData(0xe325,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/megaphone-simple-duotone.svg)
-  static const megaphoneSimple = PhosphorDuotoneIconData(
-    0xe643,
-    PhosphorIconData(0xe642, 'Duotone'),
-  );
+  static const megaphoneSimple = IconData(0xe643,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![member-of-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/member-of-duotone.svg)
-  static const memberOf = PhosphorDuotoneIconData(
-    0xedc3,
-    PhosphorIconData(0xedc2, 'Duotone'),
-  );
+  static const memberOf = IconData(0xedc3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![memory-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/memory-duotone.svg)
-  static const memory = PhosphorDuotoneIconData(
-    0xe9c5,
-    PhosphorIconData(0xe9c4, 'Duotone'),
-  );
+  static const memory = IconData(0xe9c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![messenger-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/messenger-logo-duotone.svg)
-  static const messengerLogo = PhosphorDuotoneIconData(
-    0xe6d9,
-    PhosphorIconData(0xe6d8, 'Duotone'),
-  );
+  static const messengerLogo = IconData(0xe6d9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meta-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/meta-logo-duotone.svg)
-  static const metaLogo = PhosphorDuotoneIconData(
-    0xed03,
-    PhosphorIconData(0xed02, 'Duotone'),
-  );
+  static const metaLogo = IconData(0xed03,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meteor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/meteor-duotone.svg)
-  static const meteor = PhosphorDuotoneIconData(
-    0xe9bb,
-    PhosphorIconData(0xe9ba, 'Duotone'),
-  );
+  static const meteor = IconData(0xe9bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![metronome-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/metronome-duotone.svg)
-  static const metronome = PhosphorDuotoneIconData(
-    0xec8f,
-    PhosphorIconData(0xec8e, 'Duotone'),
-  );
+  static const metronome = IconData(0xec8f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microphone-duotone.svg)
-  static const microphone = PhosphorDuotoneIconData(
-    0xe327,
-    PhosphorIconData(0xe326, 'Duotone'),
-  );
+  static const microphone = IconData(0xe327,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microphone-slash-duotone.svg)
-  static const microphoneSlash = PhosphorDuotoneIconData(
-    0xe329,
-    PhosphorIconData(0xe328, 'Duotone'),
-  );
+  static const microphoneSlash = IconData(0xe329,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-stage-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microphone-stage-duotone.svg)
-  static const microphoneStage = PhosphorDuotoneIconData(
-    0xe75d,
-    PhosphorIconData(0xe75c, 'Duotone'),
-  );
+  static const microphoneStage = IconData(0xe75d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microscope-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microscope-duotone.svg)
-  static const microscope = PhosphorDuotoneIconData(
-    0xec7b,
-    PhosphorIconData(0xec7a, 'Duotone'),
-  );
+  static const microscope = IconData(0xec7b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-excel-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-excel-logo-duotone.svg)
-  static const microsoftExcelLogo = PhosphorDuotoneIconData(
-    0xeb6d,
-    PhosphorIconData(0xeb6c, 'Duotone'),
-  );
+  static const microsoftExcelLogo = IconData(0xeb6d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-outlook-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-outlook-logo-duotone.svg)
-  static const microsoftOutlookLogo = PhosphorDuotoneIconData(
-    0xeb71,
-    PhosphorIconData(0xeb70, 'Duotone'),
-  );
+  static const microsoftOutlookLogo = IconData(0xeb71,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-powerpoint-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-powerpoint-logo-duotone.svg)
-  static const microsoftPowerpointLogo = PhosphorDuotoneIconData(
-    0xeacf,
-    PhosphorIconData(0xeace, 'Duotone'),
-  );
+  static const microsoftPowerpointLogo = IconData(0xeacf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-teams-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-teams-logo-duotone.svg)
-  static const microsoftTeamsLogo = PhosphorDuotoneIconData(
-    0xeb67,
-    PhosphorIconData(0xeb66, 'Duotone'),
-  );
+  static const microsoftTeamsLogo = IconData(0xeb67,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-word-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/microsoft-word-logo-duotone.svg)
-  static const microsoftWordLogo = PhosphorDuotoneIconData(
-    0xeb6b,
-    PhosphorIconData(0xeb6a, 'Duotone'),
-  );
+  static const microsoftWordLogo = IconData(0xeb6b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/minus-duotone.svg)
-  static const minus = PhosphorDuotoneIconData(
-    0xe32b,
-    PhosphorIconData(0xe32a, 'Duotone'),
-  );
+  static const minus = IconData(0xe32b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/minus-circle-duotone.svg)
-  static const minusCircle = PhosphorDuotoneIconData(
-    0xe32d,
-    PhosphorIconData(0xe32c, 'Duotone'),
-  );
+  static const minusCircle = IconData(0xe32d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/minus-square-duotone.svg)
-  static const minusSquare = PhosphorDuotoneIconData(
-    0xed53,
-    PhosphorIconData(0xed4c, 'Duotone'),
-  );
+  static const minusSquare = IconData(0xed53,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/money-duotone.svg)
-  static const money = PhosphorDuotoneIconData(
-    0xe589,
-    PhosphorIconData(0xe588, 'Duotone'),
-  );
+  static const money = IconData(0xe589,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-wavy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/money-wavy-duotone.svg)
-  static const moneyWavy = PhosphorDuotoneIconData(
-    0xee69,
-    PhosphorIconData(0xee68, 'Duotone'),
-  );
+  static const moneyWavy = IconData(0xee69,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/monitor-duotone.svg)
-  static const monitor = PhosphorDuotoneIconData(
-    0xe32f,
-    PhosphorIconData(0xe32e, 'Duotone'),
-  );
+  static const monitor = IconData(0xe32f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/monitor-arrow-up-duotone.svg)
-  static const monitorArrowUp = PhosphorDuotoneIconData(
-    0xe58b,
-    PhosphorIconData(0xe58a, 'Duotone'),
-  );
+  static const monitorArrowUp = IconData(0xe58b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-play-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/monitor-play-duotone.svg)
-  static const monitorPlay = PhosphorDuotoneIconData(
-    0xe58d,
-    PhosphorIconData(0xe58c, 'Duotone'),
-  );
+  static const monitorPlay = IconData(0xe58d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/moon-duotone.svg)
-  static const moon = PhosphorDuotoneIconData(
-    0xe331,
-    PhosphorIconData(0xe330, 'Duotone'),
-  );
+  static const moon = IconData(0xe331,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-stars-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/moon-stars-duotone.svg)
-  static const moonStars = PhosphorDuotoneIconData(
-    0xe58f,
-    PhosphorIconData(0xe58e, 'Duotone'),
-  );
+  static const moonStars = IconData(0xe58f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/moped-duotone.svg)
-  static const moped = PhosphorDuotoneIconData(
-    0xe825,
-    PhosphorIconData(0xe824, 'Duotone'),
-  );
+  static const moped = IconData(0xe825,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-front-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/moped-front-duotone.svg)
-  static const mopedFront = PhosphorDuotoneIconData(
-    0xe823,
-    PhosphorIconData(0xe822, 'Duotone'),
-  );
+  static const mopedFront = IconData(0xe823,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mosque-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mosque-duotone.svg)
-  static const mosque = PhosphorDuotoneIconData(
-    0xecef,
-    PhosphorIconData(0xecee, 'Duotone'),
-  );
+  static const mosque = IconData(0xecef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![motorcycle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/motorcycle-duotone.svg)
-  static const motorcycle = PhosphorDuotoneIconData(
-    0xe80b,
-    PhosphorIconData(0xe80a, 'Duotone'),
-  );
+  static const motorcycle = IconData(0xe80b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mountains-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mountains-duotone.svg)
-  static const mountains = PhosphorDuotoneIconData(
-    0xe7af,
-    PhosphorIconData(0xe7ae, 'Duotone'),
-  );
+  static const mountains = IconData(0xe7af,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mouse-duotone.svg)
-  static const mouse = PhosphorDuotoneIconData(
-    0xe33b,
-    PhosphorIconData(0xe33a, 'Duotone'),
-  );
+  static const mouse = IconData(0xe33b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-left-click-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mouse-left-click-duotone.svg)
-  static const mouseLeftClick = PhosphorDuotoneIconData(
-    0xe335,
-    PhosphorIconData(0xe334, 'Duotone'),
-  );
+  static const mouseLeftClick = IconData(0xe335,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-middle-click-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mouse-middle-click-duotone.svg)
-  static const mouseMiddleClick = PhosphorDuotoneIconData(
-    0xe339,
-    PhosphorIconData(0xe338, 'Duotone'),
-  );
+  static const mouseMiddleClick = IconData(0xe339,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-right-click-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mouse-right-click-duotone.svg)
-  static const mouseRightClick = PhosphorDuotoneIconData(
-    0xe337,
-    PhosphorIconData(0xe336, 'Duotone'),
-  );
+  static const mouseRightClick = IconData(0xe337,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-scroll-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mouse-scroll-duotone.svg)
-  static const mouseScroll = PhosphorDuotoneIconData(
-    0xe333,
-    PhosphorIconData(0xe332, 'Duotone'),
-  );
+  static const mouseScroll = IconData(0xe333,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/mouse-simple-duotone.svg)
-  static const mouseSimple = PhosphorDuotoneIconData(
-    0xe645,
-    PhosphorIconData(0xe644, 'Duotone'),
-  );
+  static const mouseSimple = IconData(0xe645,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-note-duotone.svg)
-  static const musicNote = PhosphorDuotoneIconData(
-    0xe33d,
-    PhosphorIconData(0xe33c, 'Duotone'),
-  );
+  static const musicNote = IconData(0xe33d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-note-simple-duotone.svg)
-  static const musicNoteSimple = PhosphorDuotoneIconData(
-    0xe33f,
-    PhosphorIconData(0xe33e, 'Duotone'),
-  );
+  static const musicNoteSimple = IconData(0xe33f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-notes-duotone.svg)
-  static const musicNotes = PhosphorDuotoneIconData(
-    0xe341,
-    PhosphorIconData(0xe340, 'Duotone'),
-  );
+  static const musicNotes = IconData(0xe341,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-notes-minus-duotone.svg)
-  static const musicNotesMinus = PhosphorDuotoneIconData(
-    0xee0d,
-    PhosphorIconData(0xee0c, 'Duotone'),
-  );
+  static const musicNotesMinus = IconData(0xee0d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-notes-plus-duotone.svg)
-  static const musicNotesPlus = PhosphorDuotoneIconData(
-    0xeb7d,
-    PhosphorIconData(0xeb7c, 'Duotone'),
-  );
+  static const musicNotesPlus = IconData(0xeb7d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/music-notes-simple-duotone.svg)
-  static const musicNotesSimple = PhosphorDuotoneIconData(
-    0xe343,
-    PhosphorIconData(0xe342, 'Duotone'),
-  );
+  static const musicNotesSimple = IconData(0xe343,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![navigation-arrow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/navigation-arrow-duotone.svg)
-  static const navigationArrow = PhosphorDuotoneIconData(
-    0xeadf,
-    PhosphorIconData(0xeade, 'Duotone'),
-  );
+  static const navigationArrow = IconData(0xeadf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![needle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/needle-duotone.svg)
-  static const needle = PhosphorDuotoneIconData(
-    0xe82f,
-    PhosphorIconData(0xe82e, 'Duotone'),
-  );
+  static const needle = IconData(0xe82f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/network-duotone.svg)
-  static const network = PhosphorDuotoneIconData(
-    0xeddf,
-    PhosphorIconData(0xedde, 'Duotone'),
-  );
+  static const network = IconData(0xeddf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/network-slash-duotone.svg)
-  static const networkSlash = PhosphorDuotoneIconData(
-    0xeddd,
-    PhosphorIconData(0xeddc, 'Duotone'),
-  );
+  static const networkSlash = IconData(0xeddd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/network-x-duotone.svg)
-  static const networkX = PhosphorDuotoneIconData(
-    0xeddb,
-    PhosphorIconData(0xedda, 'Duotone'),
-  );
+  static const networkX = IconData(0xeddb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/newspaper-duotone.svg)
-  static const newspaper = PhosphorDuotoneIconData(
-    0xe345,
-    PhosphorIconData(0xe344, 'Duotone'),
-  );
+  static const newspaper = IconData(0xe345,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-clipping-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/newspaper-clipping-duotone.svg)
-  static const newspaperClipping = PhosphorDuotoneIconData(
-    0xe347,
-    PhosphorIconData(0xe346, 'Duotone'),
-  );
+  static const newspaperClipping = IconData(0xe347,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-equals-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/not-equals-duotone.svg)
-  static const notEquals = PhosphorDuotoneIconData(
-    0xeda7,
-    PhosphorIconData(0xeda6, 'Duotone'),
-  );
+  static const notEquals = IconData(0xeda7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-member-of-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/not-member-of-duotone.svg)
-  static const notMemberOf = PhosphorDuotoneIconData(
-    0xedaf,
-    PhosphorIconData(0xedae, 'Duotone'),
-  );
+  static const notMemberOf = IconData(0xedaf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-subset-of-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/not-subset-of-duotone.svg)
-  static const notSubsetOf = PhosphorDuotoneIconData(
-    0xedb1,
-    PhosphorIconData(0xedb0, 'Duotone'),
-  );
+  static const notSubsetOf = IconData(0xedb1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-superset-of-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/not-superset-of-duotone.svg)
-  static const notSupersetOf = PhosphorDuotoneIconData(
-    0xedb3,
-    PhosphorIconData(0xedb2, 'Duotone'),
-  );
+  static const notSupersetOf = IconData(0xedb3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notches-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notches-duotone.svg)
-  static const notches = PhosphorDuotoneIconData(
-    0xed3b,
-    PhosphorIconData(0xed3a, 'Duotone'),
-  );
+  static const notches = IconData(0xed3b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/note-duotone.svg)
-  static const note = PhosphorDuotoneIconData(
-    0xe349,
-    PhosphorIconData(0xe348, 'Duotone'),
-  );
+  static const note = IconData(0xe349,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-blank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/note-blank-duotone.svg)
-  static const noteBlank = PhosphorDuotoneIconData(
-    0xe34b,
-    PhosphorIconData(0xe34a, 'Duotone'),
-  );
+  static const noteBlank = IconData(0xe34b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-pencil-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/note-pencil-duotone.svg)
-  static const notePencil = PhosphorDuotoneIconData(
-    0xe34d,
-    PhosphorIconData(0xe34c, 'Duotone'),
-  );
+  static const notePencil = IconData(0xe34d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notebook-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notebook-duotone.svg)
-  static const notebook = PhosphorDuotoneIconData(
-    0xe34f,
-    PhosphorIconData(0xe34e, 'Duotone'),
-  );
+  static const notebook = IconData(0xe34f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notepad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notepad-duotone.svg)
-  static const notepad = PhosphorDuotoneIconData(
-    0xe63f,
-    PhosphorIconData(0xe63e, 'Duotone'),
-  );
+  static const notepad = IconData(0xe63f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notification-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notification-duotone.svg)
-  static const notification = PhosphorDuotoneIconData(
-    0xe6fb,
-    PhosphorIconData(0xe6fa, 'Duotone'),
-  );
+  static const notification = IconData(0xe6fb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notion-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/notion-logo-duotone.svg)
-  static const notionLogo = PhosphorDuotoneIconData(
-    0xe9a1,
-    PhosphorIconData(0xe9a0, 'Duotone'),
-  );
+  static const notionLogo = IconData(0xe9a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nuclear-plant-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/nuclear-plant-duotone.svg)
-  static const nuclearPlant = PhosphorDuotoneIconData(
-    0xed7d,
-    PhosphorIconData(0xed7c, 'Duotone'),
-  );
+  static const nuclearPlant = IconData(0xed7d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-eight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-eight-duotone.svg)
-  static const numberCircleEight = PhosphorDuotoneIconData(
-    0xe353,
-    PhosphorIconData(0xe352, 'Duotone'),
-  );
+  static const numberCircleEight = IconData(0xe353,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-five-duotone.svg)
-  static const numberCircleFive = PhosphorDuotoneIconData(
-    0xe359,
-    PhosphorIconData(0xe358, 'Duotone'),
-  );
+  static const numberCircleFive = IconData(0xe359,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-four-duotone.svg)
-  static const numberCircleFour = PhosphorDuotoneIconData(
-    0xe35f,
-    PhosphorIconData(0xe35e, 'Duotone'),
-  );
+  static const numberCircleFour = IconData(0xe35f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-nine-duotone.svg)
-  static const numberCircleNine = PhosphorDuotoneIconData(
-    0xe365,
-    PhosphorIconData(0xe364, 'Duotone'),
-  );
+  static const numberCircleNine = IconData(0xe365,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-one-duotone.svg)
-  static const numberCircleOne = PhosphorDuotoneIconData(
-    0xe36b,
-    PhosphorIconData(0xe36a, 'Duotone'),
-  );
+  static const numberCircleOne = IconData(0xe36b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-seven-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-seven-duotone.svg)
-  static const numberCircleSeven = PhosphorDuotoneIconData(
-    0xe371,
-    PhosphorIconData(0xe370, 'Duotone'),
-  );
+  static const numberCircleSeven = IconData(0xe371,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-six-duotone.svg)
-  static const numberCircleSix = PhosphorDuotoneIconData(
-    0xe377,
-    PhosphorIconData(0xe376, 'Duotone'),
-  );
+  static const numberCircleSix = IconData(0xe377,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-three-duotone.svg)
-  static const numberCircleThree = PhosphorDuotoneIconData(
-    0xe37d,
-    PhosphorIconData(0xe37c, 'Duotone'),
-  );
+  static const numberCircleThree = IconData(0xe37d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-two-duotone.svg)
-  static const numberCircleTwo = PhosphorDuotoneIconData(
-    0xe383,
-    PhosphorIconData(0xe382, 'Duotone'),
-  );
+  static const numberCircleTwo = IconData(0xe383,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-zero-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-circle-zero-duotone.svg)
-  static const numberCircleZero = PhosphorDuotoneIconData(
-    0xe389,
-    PhosphorIconData(0xe388, 'Duotone'),
-  );
+  static const numberCircleZero = IconData(0xe389,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-eight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-eight-duotone.svg)
-  static const numberEight = PhosphorDuotoneIconData(
-    0xe351,
-    PhosphorIconData(0xe350, 'Duotone'),
-  );
+  static const numberEight = IconData(0xe351,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-five-duotone.svg)
-  static const numberFive = PhosphorDuotoneIconData(
-    0xe357,
-    PhosphorIconData(0xe356, 'Duotone'),
-  );
+  static const numberFive = IconData(0xe357,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-four-duotone.svg)
-  static const numberFour = PhosphorDuotoneIconData(
-    0xe35d,
-    PhosphorIconData(0xe35c, 'Duotone'),
-  );
+  static const numberFour = IconData(0xe35d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-nine-duotone.svg)
-  static const numberNine = PhosphorDuotoneIconData(
-    0xe363,
-    PhosphorIconData(0xe362, 'Duotone'),
-  );
+  static const numberNine = IconData(0xe363,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-one-duotone.svg)
-  static const numberOne = PhosphorDuotoneIconData(
-    0xe369,
-    PhosphorIconData(0xe368, 'Duotone'),
-  );
+  static const numberOne = IconData(0xe369,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-seven-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-seven-duotone.svg)
-  static const numberSeven = PhosphorDuotoneIconData(
-    0xe36f,
-    PhosphorIconData(0xe36e, 'Duotone'),
-  );
+  static const numberSeven = IconData(0xe36f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-six-duotone.svg)
-  static const numberSix = PhosphorDuotoneIconData(
-    0xe375,
-    PhosphorIconData(0xe374, 'Duotone'),
-  );
+  static const numberSix = IconData(0xe375,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-eight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-eight-duotone.svg)
-  static const numberSquareEight = PhosphorDuotoneIconData(
-    0xe355,
-    PhosphorIconData(0xe354, 'Duotone'),
-  );
+  static const numberSquareEight = IconData(0xe355,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-five-duotone.svg)
-  static const numberSquareFive = PhosphorDuotoneIconData(
-    0xe35b,
-    PhosphorIconData(0xe35a, 'Duotone'),
-  );
+  static const numberSquareFive = IconData(0xe35b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-four-duotone.svg)
-  static const numberSquareFour = PhosphorDuotoneIconData(
-    0xe361,
-    PhosphorIconData(0xe360, 'Duotone'),
-  );
+  static const numberSquareFour = IconData(0xe361,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-nine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-nine-duotone.svg)
-  static const numberSquareNine = PhosphorDuotoneIconData(
-    0xe367,
-    PhosphorIconData(0xe366, 'Duotone'),
-  );
+  static const numberSquareNine = IconData(0xe367,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-one-duotone.svg)
-  static const numberSquareOne = PhosphorDuotoneIconData(
-    0xe36d,
-    PhosphorIconData(0xe36c, 'Duotone'),
-  );
+  static const numberSquareOne = IconData(0xe36d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-seven-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-seven-duotone.svg)
-  static const numberSquareSeven = PhosphorDuotoneIconData(
-    0xe373,
-    PhosphorIconData(0xe372, 'Duotone'),
-  );
+  static const numberSquareSeven = IconData(0xe373,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-six-duotone.svg)
-  static const numberSquareSix = PhosphorDuotoneIconData(
-    0xe379,
-    PhosphorIconData(0xe378, 'Duotone'),
-  );
+  static const numberSquareSix = IconData(0xe379,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-three-duotone.svg)
-  static const numberSquareThree = PhosphorDuotoneIconData(
-    0xe37f,
-    PhosphorIconData(0xe37e, 'Duotone'),
-  );
+  static const numberSquareThree = IconData(0xe37f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-two-duotone.svg)
-  static const numberSquareTwo = PhosphorDuotoneIconData(
-    0xe385,
-    PhosphorIconData(0xe384, 'Duotone'),
-  );
+  static const numberSquareTwo = IconData(0xe385,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-zero-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-square-zero-duotone.svg)
-  static const numberSquareZero = PhosphorDuotoneIconData(
-    0xe38b,
-    PhosphorIconData(0xe38a, 'Duotone'),
-  );
+  static const numberSquareZero = IconData(0xe38b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-three-duotone.svg)
-  static const numberThree = PhosphorDuotoneIconData(
-    0xe37b,
-    PhosphorIconData(0xe37a, 'Duotone'),
-  );
+  static const numberThree = IconData(0xe37b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-two-duotone.svg)
-  static const numberTwo = PhosphorDuotoneIconData(
-    0xe381,
-    PhosphorIconData(0xe380, 'Duotone'),
-  );
+  static const numberTwo = IconData(0xe381,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-zero-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/number-zero-duotone.svg)
-  static const numberZero = PhosphorDuotoneIconData(
-    0xe387,
-    PhosphorIconData(0xe386, 'Duotone'),
-  );
+  static const numberZero = IconData(0xe387,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![numpad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/numpad-duotone.svg)
-  static const numpad = PhosphorDuotoneIconData(
-    0xe3c9,
-    PhosphorIconData(0xe3c8, 'Duotone'),
-  );
+  static const numpad = IconData(0xe3c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nut-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/nut-duotone.svg)
-  static const nut = PhosphorDuotoneIconData(
-    0xe38d,
-    PhosphorIconData(0xe38c, 'Duotone'),
-  );
+  static const nut = IconData(0xe38d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ny-times-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ny-times-logo-duotone.svg)
-  static const nyTimesLogo = PhosphorDuotoneIconData(
-    0xe647,
-    PhosphorIconData(0xe646, 'Duotone'),
-  );
+  static const nyTimesLogo = IconData(0xe647,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![octagon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/octagon-duotone.svg)
-  static const octagon = PhosphorDuotoneIconData(
-    0xe38f,
-    PhosphorIconData(0xe38e, 'Duotone'),
-  );
+  static const octagon = IconData(0xe38f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![office-chair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/office-chair-duotone.svg)
-  static const officeChair = PhosphorDuotoneIconData(
-    0xea47,
-    PhosphorIconData(0xea46, 'Duotone'),
-  );
+  static const officeChair = IconData(0xea47,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![onigiri-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/onigiri-duotone.svg)
-  static const onigiri = PhosphorDuotoneIconData(
-    0xee2d,
-    PhosphorIconData(0xee2c, 'Duotone'),
-  );
+  static const onigiri = IconData(0xee2d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![open-ai-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/open-ai-logo-duotone.svg)
-  static const openAiLogo = PhosphorDuotoneIconData(
-    0xe7d3,
-    PhosphorIconData(0xe7d2, 'Duotone'),
-  );
+  static const openAiLogo = IconData(0xe7d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![option-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/option-duotone.svg)
-  static const option = PhosphorDuotoneIconData(
-    0xe8a9,
-    PhosphorIconData(0xe8a8, 'Duotone'),
-  );
+  static const option = IconData(0xe8a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/orange-duotone.svg)
-  static const orange = PhosphorDuotoneIconData(
-    0xee41,
-    PhosphorIconData(0xee40, 'Duotone'),
-  );
+  static const orange = IconData(0xee41,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-slice-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/orange-slice-duotone.svg)
-  static const orangeSlice = PhosphorDuotoneIconData(
-    0xed37,
-    PhosphorIconData(0xed36, 'Duotone'),
-  );
+  static const orangeSlice = IconData(0xed37,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![oven-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/oven-duotone.svg)
-  static const oven = PhosphorDuotoneIconData(
-    0xed8d,
-    PhosphorIconData(0xed8c, 'Duotone'),
-  );
+  static const oven = IconData(0xed8d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![package-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/package-duotone.svg)
-  static const package = PhosphorDuotoneIconData(
-    0xe391,
-    PhosphorIconData(0xe390, 'Duotone'),
-  );
+  static const package = IconData(0xe391,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-brush-duotone.svg)
-  static const paintBrush = PhosphorDuotoneIconData(
-    0xe6f1,
-    PhosphorIconData(0xe6f0, 'Duotone'),
-  );
+  static const paintBrush = IconData(0xe6f1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-broad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-brush-broad-duotone.svg)
-  static const paintBrushBroad = PhosphorDuotoneIconData(
-    0xe591,
-    PhosphorIconData(0xe590, 'Duotone'),
-  );
+  static const paintBrushBroad = IconData(0xe591,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-household-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-brush-household-duotone.svg)
-  static const paintBrushHousehold = PhosphorDuotoneIconData(
-    0xe6f3,
-    PhosphorIconData(0xe6f2, 'Duotone'),
-  );
+  static const paintBrushHousehold = IconData(0xe6f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-bucket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-bucket-duotone.svg)
-  static const paintBucket = PhosphorDuotoneIconData(
-    0xe393,
-    PhosphorIconData(0xe392, 'Duotone'),
-  );
+  static const paintBucket = IconData(0xe393,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-roller-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paint-roller-duotone.svg)
-  static const paintRoller = PhosphorDuotoneIconData(
-    0xe6f5,
-    PhosphorIconData(0xe6f4, 'Duotone'),
-  );
+  static const paintRoller = IconData(0xe6f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![palette-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/palette-duotone.svg)
-  static const palette = PhosphorDuotoneIconData(
-    0xe6c9,
-    PhosphorIconData(0xe6c8, 'Duotone'),
-  );
+  static const palette = IconData(0xe6c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![panorama-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/panorama-duotone.svg)
-  static const panorama = PhosphorDuotoneIconData(
-    0xeaa3,
-    PhosphorIconData(0xeaa2, 'Duotone'),
-  );
+  static const panorama = IconData(0xeaa3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pants-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pants-duotone.svg)
-  static const pants = PhosphorDuotoneIconData(
-    0xec89,
-    PhosphorIconData(0xec88, 'Duotone'),
-  );
+  static const pants = IconData(0xec89,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paper-plane-duotone.svg)
-  static const paperPlane = PhosphorDuotoneIconData(
-    0xe395,
-    PhosphorIconData(0xe394, 'Duotone'),
-  );
+  static const paperPlane = IconData(0xe395,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paper-plane-right-duotone.svg)
-  static const paperPlaneRight = PhosphorDuotoneIconData(
-    0xe397,
-    PhosphorIconData(0xe396, 'Duotone'),
-  );
+  static const paperPlaneRight = IconData(0xe397,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-tilt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paper-plane-tilt-duotone.svg)
-  static const paperPlaneTilt = PhosphorDuotoneIconData(
-    0xe399,
-    PhosphorIconData(0xe398, 'Duotone'),
-  );
+  static const paperPlaneTilt = IconData(0xe399,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paperclip-duotone.svg)
-  static const paperclip = PhosphorDuotoneIconData(
-    0xe39b,
-    PhosphorIconData(0xe39a, 'Duotone'),
-  );
+  static const paperclip = IconData(0xe39b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paperclip-horizontal-duotone.svg)
-  static const paperclipHorizontal = PhosphorDuotoneIconData(
-    0xe593,
-    PhosphorIconData(0xe592, 'Duotone'),
-  );
+  static const paperclipHorizontal = IconData(0xe593,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parachute-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/parachute-duotone.svg)
-  static const parachute = PhosphorDuotoneIconData(
-    0xea7d,
-    PhosphorIconData(0xea7c, 'Duotone'),
-  );
+  static const parachute = IconData(0xea7d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paragraph-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paragraph-duotone.svg)
-  static const paragraph = PhosphorDuotoneIconData(
-    0xe961,
-    PhosphorIconData(0xe960, 'Duotone'),
-  );
+  static const paragraph = IconData(0xe961,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parallelogram-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/parallelogram-duotone.svg)
-  static const parallelogram = PhosphorDuotoneIconData(
-    0xecc7,
-    PhosphorIconData(0xecc6, 'Duotone'),
-  );
+  static const parallelogram = IconData(0xecc7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![park-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/park-duotone.svg)
-  static const park = PhosphorDuotoneIconData(
-    0xecb3,
-    PhosphorIconData(0xecb2, 'Duotone'),
-  );
+  static const park = IconData(0xecb3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![password-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/password-duotone.svg)
-  static const password = PhosphorDuotoneIconData(
-    0xe753,
-    PhosphorIconData(0xe752, 'Duotone'),
-  );
+  static const password = IconData(0xe753,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![path-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/path-duotone.svg)
-  static const path = PhosphorDuotoneIconData(
-    0xe39d,
-    PhosphorIconData(0xe39c, 'Duotone'),
-  );
+  static const path = IconData(0xe39d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![patreon-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/patreon-logo-duotone.svg)
-  static const patreonLogo = PhosphorDuotoneIconData(
-    0xe98b,
-    PhosphorIconData(0xe98a, 'Duotone'),
-  );
+  static const patreonLogo = IconData(0xe98b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pause-duotone.svg)
-  static const pause = PhosphorDuotoneIconData(
-    0xe39f,
-    PhosphorIconData(0xe39e, 'Duotone'),
-  );
+  static const pause = IconData(0xe39f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pause-circle-duotone.svg)
-  static const pauseCircle = PhosphorDuotoneIconData(
-    0xe3a1,
-    PhosphorIconData(0xe3a0, 'Duotone'),
-  );
+  static const pauseCircle = IconData(0xe3a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paw-print-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paw-print-duotone.svg)
-  static const pawPrint = PhosphorDuotoneIconData(
-    0xe649,
-    PhosphorIconData(0xe648, 'Duotone'),
-  );
+  static const pawPrint = IconData(0xe649,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paypal-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/paypal-logo-duotone.svg)
-  static const paypalLogo = PhosphorDuotoneIconData(
-    0xe98d,
-    PhosphorIconData(0xe98c, 'Duotone'),
-  );
+  static const paypalLogo = IconData(0xe98d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![peace-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/peace-duotone.svg)
-  static const peace = PhosphorDuotoneIconData(
-    0xe3a3,
-    PhosphorIconData(0xe3a2, 'Duotone'),
-  );
+  static const peace = IconData(0xe3a3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pen-duotone.svg)
-  static const pen = PhosphorDuotoneIconData(
-    0xe3ab,
-    PhosphorIconData(0xe3aa, 'Duotone'),
-  );
+  static const pen = IconData(0xe3ab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pen-nib-duotone.svg)
-  static const penNib = PhosphorDuotoneIconData(
-    0xe3ad,
-    PhosphorIconData(0xe3ac, 'Duotone'),
-  );
+  static const penNib = IconData(0xe3ad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-straight-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pen-nib-straight-duotone.svg)
-  static const penNibStraight = PhosphorDuotoneIconData(
-    0xe64b,
-    PhosphorIconData(0xe64a, 'Duotone'),
-  );
+  static const penNibStraight = IconData(0xe64b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-duotone.svg)
-  static const pencil = PhosphorDuotoneIconData(
-    0xe3af,
-    PhosphorIconData(0xe3ae, 'Duotone'),
-  );
+  static const pencil = IconData(0xe3af,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-circle-duotone.svg)
-  static const pencilCircle = PhosphorDuotoneIconData(
-    0xe3b1,
-    PhosphorIconData(0xe3b0, 'Duotone'),
-  );
+  static const pencilCircle = IconData(0xe3b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-line-duotone.svg)
-  static const pencilLine = PhosphorDuotoneIconData(
-    0xe3b3,
-    PhosphorIconData(0xe3b2, 'Duotone'),
-  );
+  static const pencilLine = IconData(0xe3b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-ruler-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-ruler-duotone.svg)
-  static const pencilRuler = PhosphorDuotoneIconData(
-    0xe907,
-    PhosphorIconData(0xe906, 'Duotone'),
-  );
+  static const pencilRuler = IconData(0xe907,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-simple-duotone.svg)
-  static const pencilSimple = PhosphorDuotoneIconData(
-    0xe3b5,
-    PhosphorIconData(0xe3b4, 'Duotone'),
-  );
+  static const pencilSimple = IconData(0xe3b5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-line-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-simple-line-duotone.svg)
-  static const pencilSimpleLine = PhosphorDuotoneIconData(
-    0xebc7,
-    PhosphorIconData(0xebc6, 'Duotone'),
-  );
+  static const pencilSimpleLine = IconData(0xebc7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-simple-slash-duotone.svg)
-  static const pencilSimpleSlash = PhosphorDuotoneIconData(
-    0xecf7,
-    PhosphorIconData(0xecf6, 'Duotone'),
-  );
+  static const pencilSimpleSlash = IconData(0xecf7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pencil-slash-duotone.svg)
-  static const pencilSlash = PhosphorDuotoneIconData(
-    0xecf9,
-    PhosphorIconData(0xecf8, 'Duotone'),
-  );
+  static const pencilSlash = IconData(0xecf9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pentagon-duotone.svg)
-  static const pentagon = PhosphorDuotoneIconData(
-    0xec7f,
-    PhosphorIconData(0xec7e, 'Duotone'),
-  );
+  static const pentagon = IconData(0xec7f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagram-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pentagram-duotone.svg)
-  static const pentagram = PhosphorDuotoneIconData(
-    0xec5d,
-    PhosphorIconData(0xec5c, 'Duotone'),
-  );
+  static const pentagram = IconData(0xec5d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pepper-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pepper-duotone.svg)
-  static const pepper = PhosphorDuotoneIconData(
-    0xe94b,
-    PhosphorIconData(0xe94a, 'Duotone'),
-  );
+  static const pepper = IconData(0xe94b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![percent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/percent-duotone.svg)
-  static const percent = PhosphorDuotoneIconData(
-    0xe3b7,
-    PhosphorIconData(0xe3b6, 'Duotone'),
-  );
+  static const percent = IconData(0xe3b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-duotone.svg)
-  static const person = PhosphorDuotoneIconData(
-    0xe3a9,
-    PhosphorIconData(0xe3a8, 'Duotone'),
-  );
+  static const person = IconData(0xe3a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-arms-spread-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-arms-spread-duotone.svg)
-  static const personArmsSpread = PhosphorDuotoneIconData(
-    0xecff,
-    PhosphorIconData(0xecfe, 'Duotone'),
-  );
+  static const personArmsSpread = IconData(0xecff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-duotone.svg)
-  static const personSimple = PhosphorDuotoneIconData(
-    0xe72f,
-    PhosphorIconData(0xe72e, 'Duotone'),
-  );
+  static const personSimple = IconData(0xe72f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-bike-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-bike-duotone.svg)
-  static const personSimpleBike = PhosphorDuotoneIconData(
-    0xe735,
-    PhosphorIconData(0xe734, 'Duotone'),
-  );
+  static const personSimpleBike = IconData(0xe735,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-circle-duotone.svg)
-  static const personSimpleCircle = PhosphorDuotoneIconData(
-    0xee59,
-    PhosphorIconData(0xee58, 'Duotone'),
-  );
+  static const personSimpleCircle = IconData(0xee59,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-hike-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-hike-duotone.svg)
-  static const personSimpleHike = PhosphorDuotoneIconData(
-    0xed55,
-    PhosphorIconData(0xed54, 'Duotone'),
-  );
+  static const personSimpleHike = IconData(0xed55,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-run-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-run-duotone.svg)
-  static const personSimpleRun = PhosphorDuotoneIconData(
-    0xe731,
-    PhosphorIconData(0xe730, 'Duotone'),
-  );
+  static const personSimpleRun = IconData(0xe731,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-ski-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-ski-duotone.svg)
-  static const personSimpleSki = PhosphorDuotoneIconData(
-    0xe71d,
-    PhosphorIconData(0xe71c, 'Duotone'),
-  );
+  static const personSimpleSki = IconData(0xe71d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-snowboard-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-snowboard-duotone.svg)
-  static const personSimpleSnowboard = PhosphorDuotoneIconData(
-    0xe71f,
-    PhosphorIconData(0xe71e, 'Duotone'),
-  );
+  static const personSimpleSnowboard = IconData(0xe71f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-swim-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-swim-duotone.svg)
-  static const personSimpleSwim = PhosphorDuotoneIconData(
-    0xe737,
-    PhosphorIconData(0xe736, 'Duotone'),
-  );
+  static const personSimpleSwim = IconData(0xe737,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-tai-chi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-tai-chi-duotone.svg)
-  static const personSimpleTaiChi = PhosphorDuotoneIconData(
-    0xed5d,
-    PhosphorIconData(0xed5c, 'Duotone'),
-  );
+  static const personSimpleTaiChi = IconData(0xed5d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-throw-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-throw-duotone.svg)
-  static const personSimpleThrow = PhosphorDuotoneIconData(
-    0xe733,
-    PhosphorIconData(0xe732, 'Duotone'),
-  );
+  static const personSimpleThrow = IconData(0xe733,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-walk-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/person-simple-walk-duotone.svg)
-  static const personSimpleWalk = PhosphorDuotoneIconData(
-    0xe73b,
-    PhosphorIconData(0xe73a, 'Duotone'),
-  );
+  static const personSimpleWalk = IconData(0xe73b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![perspective-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/perspective-duotone.svg)
-  static const perspective = PhosphorDuotoneIconData(
-    0xebe7,
-    PhosphorIconData(0xebe6, 'Duotone'),
-  );
+  static const perspective = IconData(0xebe7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-duotone.svg)
-  static const phone = PhosphorDuotoneIconData(
-    0xe3b9,
-    PhosphorIconData(0xe3b8, 'Duotone'),
-  );
+  static const phone = IconData(0xe3b9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-call-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-call-duotone.svg)
-  static const phoneCall = PhosphorDuotoneIconData(
-    0xe3bb,
-    PhosphorIconData(0xe3ba, 'Duotone'),
-  );
+  static const phoneCall = IconData(0xe3bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-disconnect-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-disconnect-duotone.svg)
-  static const phoneDisconnect = PhosphorDuotoneIconData(
-    0xe3bd,
-    PhosphorIconData(0xe3bc, 'Duotone'),
-  );
+  static const phoneDisconnect = IconData(0xe3bd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-incoming-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-incoming-duotone.svg)
-  static const phoneIncoming = PhosphorDuotoneIconData(
-    0xe3bf,
-    PhosphorIconData(0xe3be, 'Duotone'),
-  );
+  static const phoneIncoming = IconData(0xe3bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-list-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-list-duotone.svg)
-  static const phoneList = PhosphorDuotoneIconData(
-    0xe3cd,
-    PhosphorIconData(0xe3cc, 'Duotone'),
-  );
+  static const phoneList = IconData(0xe3cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-outgoing-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-outgoing-duotone.svg)
-  static const phoneOutgoing = PhosphorDuotoneIconData(
-    0xe3c1,
-    PhosphorIconData(0xe3c0, 'Duotone'),
-  );
+  static const phoneOutgoing = IconData(0xe3c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-pause-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-pause-duotone.svg)
-  static const phonePause = PhosphorDuotoneIconData(
-    0xe3cb,
-    PhosphorIconData(0xe3ca, 'Duotone'),
-  );
+  static const phonePause = IconData(0xe3cb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-plus-duotone.svg)
-  static const phonePlus = PhosphorDuotoneIconData(
-    0xec57,
-    PhosphorIconData(0xec56, 'Duotone'),
-  );
+  static const phonePlus = IconData(0xec57,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-slash-duotone.svg)
-  static const phoneSlash = PhosphorDuotoneIconData(
-    0xe3c3,
-    PhosphorIconData(0xe3c2, 'Duotone'),
-  );
+  static const phoneSlash = IconData(0xe3c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-transfer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-transfer-duotone.svg)
-  static const phoneTransfer = PhosphorDuotoneIconData(
-    0xe3c7,
-    PhosphorIconData(0xe3c6, 'Duotone'),
-  );
+  static const phoneTransfer = IconData(0xe3c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phone-x-duotone.svg)
-  static const phoneX = PhosphorDuotoneIconData(
-    0xe3c5,
-    PhosphorIconData(0xe3c4, 'Duotone'),
-  );
+  static const phoneX = IconData(0xe3c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phosphor-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/phosphor-logo-duotone.svg)
-  static const phosphorLogo = PhosphorDuotoneIconData(
-    0xe3cf,
-    PhosphorIconData(0xe3ce, 'Duotone'),
-  );
+  static const phosphorLogo = IconData(0xe3cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pi-duotone.svg)
-  static const pi = PhosphorDuotoneIconData(
-    0xec81,
-    PhosphorIconData(0xec80, 'Duotone'),
-  );
+  static const pi = IconData(0xec81,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piano-keys-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/piano-keys-duotone.svg)
-  static const pianoKeys = PhosphorDuotoneIconData(
-    0xe9c9,
-    PhosphorIconData(0xe9c8, 'Duotone'),
-  );
+  static const pianoKeys = IconData(0xe9c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picnic-table-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/picnic-table-duotone.svg)
-  static const picnicTable = PhosphorDuotoneIconData(
-    0xee27,
-    PhosphorIconData(0xee26, 'Duotone'),
-  );
+  static const picnicTable = IconData(0xee27,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picture-in-picture-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/picture-in-picture-duotone.svg)
-  static const pictureInpicture = PhosphorDuotoneIconData(
-    0xe64d,
-    PhosphorIconData(0xe64c, 'Duotone'),
-  );
+  static const pictureInpicture = IconData(0xe64d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piggy-bank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/piggy-bank-duotone.svg)
-  static const piggyBank = PhosphorDuotoneIconData(
-    0xea05,
-    PhosphorIconData(0xea04, 'Duotone'),
-  );
+  static const piggyBank = IconData(0xea05,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pill-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pill-duotone.svg)
-  static const pill = PhosphorDuotoneIconData(
-    0xe701,
-    PhosphorIconData(0xe700, 'Duotone'),
-  );
+  static const pill = IconData(0xe701,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ping-pong-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ping-pong-duotone.svg)
-  static const pingPong = PhosphorDuotoneIconData(
-    0xea43,
-    PhosphorIconData(0xea42, 'Duotone'),
-  );
+  static const pingPong = IconData(0xea43,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pint-glass-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pint-glass-duotone.svg)
-  static const pintGlass = PhosphorDuotoneIconData(
-    0xedd1,
-    PhosphorIconData(0xedd0, 'Duotone'),
-  );
+  static const pintGlass = IconData(0xedd1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinterest-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pinterest-logo-duotone.svg)
-  static const pinterestLogo = PhosphorDuotoneIconData(
-    0xe64f,
-    PhosphorIconData(0xe64e, 'Duotone'),
-  );
+  static const pinterestLogo = IconData(0xe64f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinwheel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pinwheel-duotone.svg)
-  static const pinwheel = PhosphorDuotoneIconData(
-    0xeb9d,
-    PhosphorIconData(0xeb9c, 'Duotone'),
-  );
+  static const pinwheel = IconData(0xeb9d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pipe-duotone.svg)
-  static const pipe = PhosphorDuotoneIconData(
-    0xed87,
-    PhosphorIconData(0xed86, 'Duotone'),
-  );
+  static const pipe = IconData(0xed87,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-wrench-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pipe-wrench-duotone.svg)
-  static const pipeWrench = PhosphorDuotoneIconData(
-    0xed89,
-    PhosphorIconData(0xed88, 'Duotone'),
-  );
+  static const pipeWrench = IconData(0xed89,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pix-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pix-logo-duotone.svg)
-  static const pixLogo = PhosphorDuotoneIconData(
-    0xecc3,
-    PhosphorIconData(0xecc2, 'Duotone'),
-  );
+  static const pixLogo = IconData(0xecc3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pizza-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pizza-duotone.svg)
-  static const pizza = PhosphorDuotoneIconData(
-    0xe797,
-    PhosphorIconData(0xe796, 'Duotone'),
-  );
+  static const pizza = IconData(0xe797,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![placeholder-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/placeholder-duotone.svg)
-  static const placeholder = PhosphorDuotoneIconData(
-    0xe651,
-    PhosphorIconData(0xe650, 'Duotone'),
-  );
+  static const placeholder = IconData(0xe651,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![planet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/planet-duotone.svg)
-  static const planet = PhosphorDuotoneIconData(
-    0xe653,
-    PhosphorIconData(0xe652, 'Duotone'),
-  );
+  static const planet = IconData(0xe653,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plant-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plant-duotone.svg)
-  static const plant = PhosphorDuotoneIconData(
-    0xebaf,
-    PhosphorIconData(0xebae, 'Duotone'),
-  );
+  static const plant = IconData(0xebaf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/play-duotone.svg)
-  static const play = PhosphorDuotoneIconData(
-    0xe3d1,
-    PhosphorIconData(0xe3d0, 'Duotone'),
-  );
+  static const play = IconData(0xe3d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/play-circle-duotone.svg)
-  static const playCircle = PhosphorDuotoneIconData(
-    0xe3d3,
-    PhosphorIconData(0xe3d2, 'Duotone'),
-  );
+  static const playCircle = IconData(0xe3d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-pause-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/play-pause-duotone.svg)
-  static const playPause = PhosphorDuotoneIconData(
-    0xe8bf,
-    PhosphorIconData(0xe8be, 'Duotone'),
-  );
+  static const playPause = IconData(0xe8bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![playlist-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/playlist-duotone.svg)
-  static const playlist = PhosphorDuotoneIconData(
-    0xe6ab,
-    PhosphorIconData(0xe6aa, 'Duotone'),
-  );
+  static const playlist = IconData(0xe6ab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plug-duotone.svg)
-  static const plug = PhosphorDuotoneIconData(
-    0xe947,
-    PhosphorIconData(0xe946, 'Duotone'),
-  );
+  static const plug = IconData(0xe947,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-charging-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plug-charging-duotone.svg)
-  static const plugCharging = PhosphorDuotoneIconData(
-    0xeb5d,
-    PhosphorIconData(0xeb5c, 'Duotone'),
-  );
+  static const plugCharging = IconData(0xeb5d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plugs-duotone.svg)
-  static const plugs = PhosphorDuotoneIconData(
-    0xeb57,
-    PhosphorIconData(0xeb56, 'Duotone'),
-  );
+  static const plugs = IconData(0xeb57,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-connected-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plugs-connected-duotone.svg)
-  static const plugsConnected = PhosphorDuotoneIconData(
-    0xeb5b,
-    PhosphorIconData(0xeb5a, 'Duotone'),
-  );
+  static const plugsConnected = IconData(0xeb5b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plus-duotone.svg)
-  static const plus = PhosphorDuotoneIconData(
-    0xe3d5,
-    PhosphorIconData(0xe3d4, 'Duotone'),
-  );
+  static const plus = IconData(0xe3d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plus-circle-duotone.svg)
-  static const plusCircle = PhosphorDuotoneIconData(
-    0xe3d7,
-    PhosphorIconData(0xe3d6, 'Duotone'),
-  );
+  static const plusCircle = IconData(0xe3d7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plus-minus-duotone.svg)
-  static const plusMinus = PhosphorDuotoneIconData(
-    0xe3d9,
-    PhosphorIconData(0xe3d8, 'Duotone'),
-  );
+  static const plusMinus = IconData(0xe3d9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/plus-square-duotone.svg)
-  static const plusSquare = PhosphorDuotoneIconData(
-    0xed56,
-    PhosphorIconData(0xed4a, 'Duotone'),
-  );
+  static const plusSquare = IconData(0xed56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![poker-chip-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/poker-chip-duotone.svg)
-  static const pokerChip = PhosphorDuotoneIconData(
-    0xe595,
-    PhosphorIconData(0xe594, 'Duotone'),
-  );
+  static const pokerChip = IconData(0xe595,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![police-car-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/police-car-duotone.svg)
-  static const policeCar = PhosphorDuotoneIconData(
-    0xec4b,
-    PhosphorIconData(0xec4a, 'Duotone'),
-  );
+  static const policeCar = IconData(0xec4b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![polygon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/polygon-duotone.svg)
-  static const polygon = PhosphorDuotoneIconData(
-    0xe6d1,
-    PhosphorIconData(0xe6d0, 'Duotone'),
-  );
+  static const polygon = IconData(0xe6d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popcorn-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/popcorn-duotone.svg)
-  static const popcorn = PhosphorDuotoneIconData(
-    0xeb4f,
-    PhosphorIconData(0xeb4e, 'Duotone'),
-  );
+  static const popcorn = IconData(0xeb4f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popsicle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/popsicle-duotone.svg)
-  static const popsicle = PhosphorDuotoneIconData(
-    0xebbf,
-    PhosphorIconData(0xebbe, 'Duotone'),
-  );
+  static const popsicle = IconData(0xebbf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![potted-plant-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/potted-plant-duotone.svg)
-  static const pottedPlant = PhosphorDuotoneIconData(
-    0xec23,
-    PhosphorIconData(0xec22, 'Duotone'),
-  );
+  static const pottedPlant = IconData(0xec23,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![power-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/power-duotone.svg)
-  static const power = PhosphorDuotoneIconData(
-    0xe3db,
-    PhosphorIconData(0xe3da, 'Duotone'),
-  );
+  static const power = IconData(0xe3db,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prescription-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/prescription-duotone.svg)
-  static const prescription = PhosphorDuotoneIconData(
-    0xe7a3,
-    PhosphorIconData(0xe7a2, 'Duotone'),
-  );
+  static const prescription = IconData(0xe7a3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/presentation-duotone.svg)
-  static const presentation = PhosphorDuotoneIconData(
-    0xe655,
-    PhosphorIconData(0xe654, 'Duotone'),
-  );
+  static const presentation = IconData(0xe655,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-chart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/presentation-chart-duotone.svg)
-  static const presentationChart = PhosphorDuotoneIconData(
-    0xe657,
-    PhosphorIconData(0xe656, 'Duotone'),
-  );
+  static const presentationChart = IconData(0xe657,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![printer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/printer-duotone.svg)
-  static const printer = PhosphorDuotoneIconData(
-    0xe3dd,
-    PhosphorIconData(0xe3dc, 'Duotone'),
-  );
+  static const printer = IconData(0xe3dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/prohibit-duotone.svg)
-  static const prohibit = PhosphorDuotoneIconData(
-    0xe3df,
-    PhosphorIconData(0xe3de, 'Duotone'),
-  );
+  static const prohibit = IconData(0xe3df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-inset-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/prohibit-inset-duotone.svg)
-  static const prohibitInset = PhosphorDuotoneIconData(
-    0xe3e1,
-    PhosphorIconData(0xe3e0, 'Duotone'),
-  );
+  static const prohibitInset = IconData(0xe3e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/projector-screen-duotone.svg)
-  static const projectorScreen = PhosphorDuotoneIconData(
-    0xe659,
-    PhosphorIconData(0xe658, 'Duotone'),
-  );
+  static const projectorScreen = IconData(0xe659,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-chart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/projector-screen-chart-duotone.svg)
-  static const projectorScreenChart = PhosphorDuotoneIconData(
-    0xe65b,
-    PhosphorIconData(0xe65a, 'Duotone'),
-  );
+  static const projectorScreenChart = IconData(0xe65b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pulse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/pulse-duotone.svg)
-  static const pulse = PhosphorDuotoneIconData(
-    0xe001,
-    PhosphorIconData(0xe000, 'Duotone'),
-  );
+  static const pulse = IconData(0xe001,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/push-pin-duotone.svg)
-  static const pushPin = PhosphorDuotoneIconData(
-    0xe3e3,
-    PhosphorIconData(0xe3e2, 'Duotone'),
-  );
+  static const pushPin = IconData(0xe3e3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/push-pin-simple-duotone.svg)
-  static const pushPinSimple = PhosphorDuotoneIconData(
-    0xe65d,
-    PhosphorIconData(0xe65c, 'Duotone'),
-  );
+  static const pushPinSimple = IconData(0xe65d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/push-pin-simple-slash-duotone.svg)
-  static const pushPinSimpleSlash = PhosphorDuotoneIconData(
-    0xe65f,
-    PhosphorIconData(0xe65e, 'Duotone'),
-  );
+  static const pushPinSimpleSlash = IconData(0xe65f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/push-pin-slash-duotone.svg)
-  static const pushPinSlash = PhosphorDuotoneIconData(
-    0xe3e5,
-    PhosphorIconData(0xe3e4, 'Duotone'),
-  );
+  static const pushPinSlash = IconData(0xe3e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![puzzle-piece-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/puzzle-piece-duotone.svg)
-  static const puzzlePiece = PhosphorDuotoneIconData(
-    0xe597,
-    PhosphorIconData(0xe596, 'Duotone'),
-  );
+  static const puzzlePiece = IconData(0xe597,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![qr-code-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/qr-code-duotone.svg)
-  static const qrCode = PhosphorDuotoneIconData(
-    0xe3e7,
-    PhosphorIconData(0xe3e6, 'Duotone'),
-  );
+  static const qrCode = IconData(0xe3e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/question-duotone.svg)
-  static const question = PhosphorDuotoneIconData(
-    0xe3eb,
-    PhosphorIconData(0xe3e8, 'Duotone'),
-  );
+  static const question = IconData(0xe3eb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-mark-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/question-mark-duotone.svg)
-  static const questionMark = PhosphorDuotoneIconData(
-    0xe3ed,
-    PhosphorIconData(0xe3e9, 'Duotone'),
-  );
+  static const questionMark = IconData(0xe3ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![queue-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/queue-duotone.svg)
-  static const queue = PhosphorDuotoneIconData(
-    0xe6ad,
-    PhosphorIconData(0xe6ac, 'Duotone'),
-  );
+  static const queue = IconData(0xe6ad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![quotes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/quotes-duotone.svg)
-  static const quotes = PhosphorDuotoneIconData(
-    0xe661,
-    PhosphorIconData(0xe660, 'Duotone'),
-  );
+  static const quotes = IconData(0xe661,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rabbit-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rabbit-duotone.svg)
-  static const rabbit = PhosphorDuotoneIconData(
-    0xeac3,
-    PhosphorIconData(0xeac2, 'Duotone'),
-  );
+  static const rabbit = IconData(0xeac3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![racquet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/racquet-duotone.svg)
-  static const racquet = PhosphorDuotoneIconData(
-    0xee03,
-    PhosphorIconData(0xee02, 'Duotone'),
-  );
+  static const racquet = IconData(0xee03,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/radical-duotone.svg)
-  static const radical = PhosphorDuotoneIconData(
-    0xe3ef,
-    PhosphorIconData(0xe3ea, 'Duotone'),
-  );
+  static const radical = IconData(0xe3ef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/radio-duotone.svg)
-  static const radio = PhosphorDuotoneIconData(
-    0xe77f,
-    PhosphorIconData(0xe77e, 'Duotone'),
-  );
+  static const radio = IconData(0xe77f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-button-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/radio-button-duotone.svg)
-  static const radioButton = PhosphorDuotoneIconData(
-    0xeb09,
-    PhosphorIconData(0xeb08, 'Duotone'),
-  );
+  static const radioButton = IconData(0xeb09,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radioactive-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/radioactive-duotone.svg)
-  static const radioactive = PhosphorDuotoneIconData(
-    0xe9dd,
-    PhosphorIconData(0xe9dc, 'Duotone'),
-  );
+  static const radioactive = IconData(0xe9dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rainbow-duotone.svg)
-  static const rainbow = PhosphorDuotoneIconData(
-    0xe599,
-    PhosphorIconData(0xe598, 'Duotone'),
-  );
+  static const rainbow = IconData(0xe599,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-cloud-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rainbow-cloud-duotone.svg)
-  static const rainbowCloud = PhosphorDuotoneIconData(
-    0xe59b,
-    PhosphorIconData(0xe59a, 'Duotone'),
-  );
+  static const rainbowCloud = IconData(0xe59b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ranking-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ranking-duotone.svg)
-  static const ranking = PhosphorDuotoneIconData(
-    0xed63,
-    PhosphorIconData(0xed62, 'Duotone'),
-  );
+  static const ranking = IconData(0xed63,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![read-cv-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/read-cv-logo-duotone.svg)
-  static const readCvLogo = PhosphorDuotoneIconData(
-    0xed0d,
-    PhosphorIconData(0xed0c, 'Duotone'),
-  );
+  static const readCvLogo = IconData(0xed0d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/receipt-duotone.svg)
-  static const receipt = PhosphorDuotoneIconData(
-    0xe3f1,
-    PhosphorIconData(0xe3ec, 'Duotone'),
-  );
+  static const receipt = IconData(0xe3f1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/receipt-x-duotone.svg)
-  static const receiptX = PhosphorDuotoneIconData(
-    0xed41,
-    PhosphorIconData(0xed40, 'Duotone'),
-  );
+  static const receiptX = IconData(0xed41,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![record-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/record-duotone.svg)
-  static const record = PhosphorDuotoneIconData(
-    0xe3f3,
-    PhosphorIconData(0xe3ee, 'Duotone'),
-  );
+  static const record = IconData(0xe3f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rectangle-duotone.svg)
-  static const rectangle = PhosphorDuotoneIconData(
-    0xe3f5,
-    PhosphorIconData(0xe3f0, 'Duotone'),
-  );
+  static const rectangle = IconData(0xe3f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rectangle-dashed-duotone.svg)
-  static const rectangleDashed = PhosphorDuotoneIconData(
-    0xe3f7,
-    PhosphorIconData(0xe3f2, 'Duotone'),
-  );
+  static const rectangleDashed = IconData(0xe3f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![recycle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/recycle-duotone.svg)
-  static const recycle = PhosphorDuotoneIconData(
-    0xe75b,
-    PhosphorIconData(0xe75a, 'Duotone'),
-  );
+  static const recycle = IconData(0xe75b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![reddit-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/reddit-logo-duotone.svg)
-  static const redditLogo = PhosphorDuotoneIconData(
-    0xe59d,
-    PhosphorIconData(0xe59c, 'Duotone'),
-  );
+  static const redditLogo = IconData(0xe59d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/repeat-duotone.svg)
-  static const repeat = PhosphorDuotoneIconData(
-    0xe3f9,
-    PhosphorIconData(0xe3f6, 'Duotone'),
-  );
+  static const repeat = IconData(0xe3f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-once-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/repeat-once-duotone.svg)
-  static const repeatOnce = PhosphorDuotoneIconData(
-    0xe3fb,
-    PhosphorIconData(0xe3f8, 'Duotone'),
-  );
+  static const repeatOnce = IconData(0xe3fb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![replit-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/replit-logo-duotone.svg)
-  static const replitLogo = PhosphorDuotoneIconData(
-    0xeb8b,
-    PhosphorIconData(0xeb8a, 'Duotone'),
-  );
+  static const replitLogo = IconData(0xeb8b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![resize-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/resize-duotone.svg)
-  static const resize = PhosphorDuotoneIconData(
-    0xed6f,
-    PhosphorIconData(0xed6e, 'Duotone'),
-  );
+  static const resize = IconData(0xed6f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rewind-duotone.svg)
-  static const rewind = PhosphorDuotoneIconData(
-    0xe6a9,
-    PhosphorIconData(0xe6a8, 'Duotone'),
-  );
+  static const rewind = IconData(0xe6a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rewind-circle-duotone.svg)
-  static const rewindCircle = PhosphorDuotoneIconData(
-    0xe3fd,
-    PhosphorIconData(0xe3fa, 'Duotone'),
-  );
+  static const rewindCircle = IconData(0xe3fd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![road-horizon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/road-horizon-duotone.svg)
-  static const roadHorizon = PhosphorDuotoneIconData(
-    0xe839,
-    PhosphorIconData(0xe838, 'Duotone'),
-  );
+  static const roadHorizon = IconData(0xe839,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![robot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/robot-duotone.svg)
-  static const robot = PhosphorDuotoneIconData(
-    0xe763,
-    PhosphorIconData(0xe762, 'Duotone'),
-  );
+  static const robot = IconData(0xe763,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rocket-duotone.svg)
-  static const rocket = PhosphorDuotoneIconData(
-    0xe3ff,
-    PhosphorIconData(0xe3fc, 'Duotone'),
-  );
+  static const rocket = IconData(0xe3ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-launch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rocket-launch-duotone.svg)
-  static const rocketLaunch = PhosphorDuotoneIconData(
-    0xe401,
-    PhosphorIconData(0xe3fe, 'Duotone'),
-  );
+  static const rocketLaunch = IconData(0xe401,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rows-duotone.svg)
-  static const rows = PhosphorDuotoneIconData(
-    0xe5a3,
-    PhosphorIconData(0xe5a2, 'Duotone'),
-  );
+  static const rows = IconData(0xe5a3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-bottom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rows-plus-bottom-duotone.svg)
-  static const rowsPlusBottom = PhosphorDuotoneIconData(
-    0xe59f,
-    PhosphorIconData(0xe59e, 'Duotone'),
-  );
+  static const rowsPlusBottom = IconData(0xe59f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-top-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rows-plus-top-duotone.svg)
-  static const rowsPlusTop = PhosphorDuotoneIconData(
-    0xe5a1,
-    PhosphorIconData(0xe5a0, 'Duotone'),
-  );
+  static const rowsPlusTop = IconData(0xe5a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rss-duotone.svg)
-  static const rss = PhosphorDuotoneIconData(
-    0xe403,
-    PhosphorIconData(0xe400, 'Duotone'),
-  );
+  static const rss = IconData(0xe403,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rss-simple-duotone.svg)
-  static const rssSimple = PhosphorDuotoneIconData(
-    0xe405,
-    PhosphorIconData(0xe402, 'Duotone'),
-  );
+  static const rssSimple = IconData(0xe405,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rug-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/rug-duotone.svg)
-  static const rug = PhosphorDuotoneIconData(
-    0xea1b,
-    PhosphorIconData(0xea1a, 'Duotone'),
-  );
+  static const rug = IconData(0xea1b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ruler-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ruler-duotone.svg)
-  static const ruler = PhosphorDuotoneIconData(
-    0xe6b9,
-    PhosphorIconData(0xe6b8, 'Duotone'),
-  );
+  static const ruler = IconData(0xe6b9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sailboat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sailboat-duotone.svg)
-  static const sailboat = PhosphorDuotoneIconData(
-    0xe78b,
-    PhosphorIconData(0xe78a, 'Duotone'),
-  );
+  static const sailboat = IconData(0xe78b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scales-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scales-duotone.svg)
-  static const scales = PhosphorDuotoneIconData(
-    0xe751,
-    PhosphorIconData(0xe750, 'Duotone'),
-  );
+  static const scales = IconData(0xe751,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scan-duotone.svg)
-  static const scan = PhosphorDuotoneIconData(
-    0xebb7,
-    PhosphorIconData(0xebb6, 'Duotone'),
-  );
+  static const scan = IconData(0xebb7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-smiley-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scan-smiley-duotone.svg)
-  static const scanSmiley = PhosphorDuotoneIconData(
-    0xebb5,
-    PhosphorIconData(0xebb4, 'Duotone'),
-  );
+  static const scanSmiley = IconData(0xebb5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scissors-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scissors-duotone.svg)
-  static const scissors = PhosphorDuotoneIconData(
-    0xeae1,
-    PhosphorIconData(0xeae0, 'Duotone'),
-  );
+  static const scissors = IconData(0xeae1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scooter-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scooter-duotone.svg)
-  static const scooter = PhosphorDuotoneIconData(
-    0xe821,
-    PhosphorIconData(0xe820, 'Duotone'),
-  );
+  static const scooter = IconData(0xe821,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screencast-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/screencast-duotone.svg)
-  static const screencast = PhosphorDuotoneIconData(
-    0xe407,
-    PhosphorIconData(0xe404, 'Duotone'),
-  );
+  static const screencast = IconData(0xe407,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screwdriver-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/screwdriver-duotone.svg)
-  static const screwdriver = PhosphorDuotoneIconData(
-    0xe86f,
-    PhosphorIconData(0xe86e, 'Duotone'),
-  );
+  static const screwdriver = IconData(0xe86f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scribble-duotone.svg)
-  static const scribble = PhosphorDuotoneIconData(
-    0xe807,
-    PhosphorIconData(0xe806, 'Duotone'),
-  );
+  static const scribble = IconData(0xe807,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-loop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scribble-loop-duotone.svg)
-  static const scribbleLoop = PhosphorDuotoneIconData(
-    0xe663,
-    PhosphorIconData(0xe662, 'Duotone'),
-  );
+  static const scribbleLoop = IconData(0xe663,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scroll-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/scroll-duotone.svg)
-  static const scroll = PhosphorDuotoneIconData(
-    0xeb7b,
-    PhosphorIconData(0xeb7a, 'Duotone'),
-  );
+  static const scroll = IconData(0xeb7b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-duotone.svg)
-  static const seal = PhosphorDuotoneIconData(
-    0xe605,
-    PhosphorIconData(0xe604, 'Duotone'),
-  );
+  static const seal = IconData(0xe605,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-check-duotone.svg)
-  static const sealCheck = PhosphorDuotoneIconData(
-    0xe607,
-    PhosphorIconData(0xe606, 'Duotone'),
-  );
+  static const sealCheck = IconData(0xe607,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-percent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-percent-duotone.svg)
-  static const sealPercent = PhosphorDuotoneIconData(
-    0xe60b,
-    PhosphorIconData(0xe60a, 'Duotone'),
-  );
+  static const sealPercent = IconData(0xe60b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-question-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-question-duotone.svg)
-  static const sealQuestion = PhosphorDuotoneIconData(
-    0xe609,
-    PhosphorIconData(0xe608, 'Duotone'),
-  );
+  static const sealQuestion = IconData(0xe609,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seal-warning-duotone.svg)
-  static const sealWarning = PhosphorDuotoneIconData(
-    0xe60d,
-    PhosphorIconData(0xe60c, 'Duotone'),
-  );
+  static const sealWarning = IconData(0xe60d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seat-duotone.svg)
-  static const seat = PhosphorDuotoneIconData(
-    0xeb8f,
-    PhosphorIconData(0xeb8e, 'Duotone'),
-  );
+  static const seat = IconData(0xeb8f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seatbelt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/seatbelt-duotone.svg)
-  static const seatbelt = PhosphorDuotoneIconData(
-    0xedff,
-    PhosphorIconData(0xedfe, 'Duotone'),
-  );
+  static const seatbelt = IconData(0xedff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![security-camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/security-camera-duotone.svg)
-  static const securityCamera = PhosphorDuotoneIconData(
-    0xeca5,
-    PhosphorIconData(0xeca4, 'Duotone'),
-  );
+  static const securityCamera = IconData(0xeca5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-duotone.svg)
-  static const selection = PhosphorDuotoneIconData(
-    0xe69b,
-    PhosphorIconData(0xe69a, 'Duotone'),
-  );
+  static const selection = IconData(0xe69b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-all-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-all-duotone.svg)
-  static const selectionAll = PhosphorDuotoneIconData(
-    0xe747,
-    PhosphorIconData(0xe746, 'Duotone'),
-  );
+  static const selectionAll = IconData(0xe747,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-background-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-background-duotone.svg)
-  static const selectionBackground = PhosphorDuotoneIconData(
-    0xeaf9,
-    PhosphorIconData(0xeaf8, 'Duotone'),
-  );
+  static const selectionBackground = IconData(0xeaf9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-foreground-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-foreground-duotone.svg)
-  static const selectionForeground = PhosphorDuotoneIconData(
-    0xeaf7,
-    PhosphorIconData(0xeaf6, 'Duotone'),
-  );
+  static const selectionForeground = IconData(0xeaf7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-inverse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-inverse-duotone.svg)
-  static const selectionInverse = PhosphorDuotoneIconData(
-    0xe745,
-    PhosphorIconData(0xe744, 'Duotone'),
-  );
+  static const selectionInverse = IconData(0xe745,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-plus-duotone.svg)
-  static const selectionPlus = PhosphorDuotoneIconData(
-    0xe69d,
-    PhosphorIconData(0xe69c, 'Duotone'),
-  );
+  static const selectionPlus = IconData(0xe69d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/selection-slash-duotone.svg)
-  static const selectionSlash = PhosphorDuotoneIconData(
-    0xe69f,
-    PhosphorIconData(0xe69e, 'Duotone'),
-  );
+  static const selectionSlash = IconData(0xe69f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shapes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shapes-duotone.svg)
-  static const shapes = PhosphorDuotoneIconData(
-    0xec5f,
-    PhosphorIconData(0xec5e, 'Duotone'),
-  );
+  static const shapes = IconData(0xec5f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/share-duotone.svg)
-  static const share = PhosphorDuotoneIconData(
-    0xe409,
-    PhosphorIconData(0xe406, 'Duotone'),
-  );
+  static const share = IconData(0xe409,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-fat-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/share-fat-duotone.svg)
-  static const shareFat = PhosphorDuotoneIconData(
-    0xed57,
-    PhosphorIconData(0xed52, 'Duotone'),
-  );
+  static const shareFat = IconData(0xed57,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-network-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/share-network-duotone.svg)
-  static const shareNetwork = PhosphorDuotoneIconData(
-    0xe40b,
-    PhosphorIconData(0xe408, 'Duotone'),
-  );
+  static const shareNetwork = IconData(0xe40b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-duotone.svg)
-  static const shield = PhosphorDuotoneIconData(
-    0xe40d,
-    PhosphorIconData(0xe40a, 'Duotone'),
-  );
+  static const shield = IconData(0xe40d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-check-duotone.svg)
-  static const shieldCheck = PhosphorDuotoneIconData(
-    0xe40f,
-    PhosphorIconData(0xe40c, 'Duotone'),
-  );
+  static const shieldCheck = IconData(0xe40f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-checkered-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-checkered-duotone.svg)
-  static const shieldCheckered = PhosphorDuotoneIconData(
-    0xe709,
-    PhosphorIconData(0xe708, 'Duotone'),
-  );
+  static const shieldCheckered = IconData(0xe709,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-chevron-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-chevron-duotone.svg)
-  static const shieldChevron = PhosphorDuotoneIconData(
-    0xe411,
-    PhosphorIconData(0xe40e, 'Duotone'),
-  );
+  static const shieldChevron = IconData(0xe411,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-plus-duotone.svg)
-  static const shieldPlus = PhosphorDuotoneIconData(
-    0xe707,
-    PhosphorIconData(0xe706, 'Duotone'),
-  );
+  static const shieldPlus = IconData(0xe707,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-slash-duotone.svg)
-  static const shieldSlash = PhosphorDuotoneIconData(
-    0xe413,
-    PhosphorIconData(0xe410, 'Duotone'),
-  );
+  static const shieldSlash = IconData(0xe413,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-star-duotone.svg)
-  static const shieldStar = PhosphorDuotoneIconData(
-    0xec35,
-    PhosphorIconData(0xec34, 'Duotone'),
-  );
+  static const shieldStar = IconData(0xec35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shield-warning-duotone.svg)
-  static const shieldWarning = PhosphorDuotoneIconData(
-    0xe414,
-    PhosphorIconData(0xe412, 'Duotone'),
-  );
+  static const shieldWarning = IconData(0xe414,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shipping-container-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shipping-container-duotone.svg)
-  static const shippingContainer = PhosphorDuotoneIconData(
-    0xe78d,
-    PhosphorIconData(0xe78c, 'Duotone'),
-  );
+  static const shippingContainer = IconData(0xe78d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shirt-folded-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shirt-folded-duotone.svg)
-  static const shirtFolded = PhosphorDuotoneIconData(
-    0xea93,
-    PhosphorIconData(0xea92, 'Duotone'),
-  );
+  static const shirtFolded = IconData(0xea93,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shooting-star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shooting-star-duotone.svg)
-  static const shootingStar = PhosphorDuotoneIconData(
-    0xecfb,
-    PhosphorIconData(0xecfa, 'Duotone'),
-  );
+  static const shootingStar = IconData(0xecfb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shopping-bag-duotone.svg)
-  static const shoppingBag = PhosphorDuotoneIconData(
-    0xe417,
-    PhosphorIconData(0xe416, 'Duotone'),
-  );
+  static const shoppingBag = IconData(0xe417,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-open-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shopping-bag-open-duotone.svg)
-  static const shoppingBagOpen = PhosphorDuotoneIconData(
-    0xe419,
-    PhosphorIconData(0xe418, 'Duotone'),
-  );
+  static const shoppingBagOpen = IconData(0xe419,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shopping-cart-duotone.svg)
-  static const shoppingCart = PhosphorDuotoneIconData(
-    0xe41f,
-    PhosphorIconData(0xe41e, 'Duotone'),
-  );
+  static const shoppingCart = IconData(0xe41f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shopping-cart-simple-duotone.svg)
-  static const shoppingCartSimple = PhosphorDuotoneIconData(
-    0xe421,
-    PhosphorIconData(0xe420, 'Duotone'),
-  );
+  static const shoppingCartSimple = IconData(0xe421,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shovel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shovel-duotone.svg)
-  static const shovel = PhosphorDuotoneIconData(
-    0xe9e7,
-    PhosphorIconData(0xe9e6, 'Duotone'),
-  );
+  static const shovel = IconData(0xe9e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shower-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shower-duotone.svg)
-  static const shower = PhosphorDuotoneIconData(
-    0xe777,
-    PhosphorIconData(0xe776, 'Duotone'),
-  );
+  static const shower = IconData(0xe777,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shrimp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shrimp-duotone.svg)
-  static const shrimp = PhosphorDuotoneIconData(
-    0xeab5,
-    PhosphorIconData(0xeab4, 'Duotone'),
-  );
+  static const shrimp = IconData(0xeab5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shuffle-duotone.svg)
-  static const shuffle = PhosphorDuotoneIconData(
-    0xe423,
-    PhosphorIconData(0xe422, 'Duotone'),
-  );
+  static const shuffle = IconData(0xe423,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-angular-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shuffle-angular-duotone.svg)
-  static const shuffleAngular = PhosphorDuotoneIconData(
-    0xe425,
-    PhosphorIconData(0xe424, 'Duotone'),
-  );
+  static const shuffleAngular = IconData(0xe425,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/shuffle-simple-duotone.svg)
-  static const shuffleSimple = PhosphorDuotoneIconData(
-    0xe427,
-    PhosphorIconData(0xe426, 'Duotone'),
-  );
+  static const shuffleSimple = IconData(0xe427,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sidebar-duotone.svg)
-  static const sidebar = PhosphorDuotoneIconData(
-    0xeab7,
-    PhosphorIconData(0xeab6, 'Duotone'),
-  );
+  static const sidebar = IconData(0xeab7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sidebar-simple-duotone.svg)
-  static const sidebarSimple = PhosphorDuotoneIconData(
-    0xec25,
-    PhosphorIconData(0xec24, 'Duotone'),
-  );
+  static const sidebarSimple = IconData(0xec25,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sigma-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sigma-duotone.svg)
-  static const sigma = PhosphorDuotoneIconData(
-    0xeab9,
-    PhosphorIconData(0xeab8, 'Duotone'),
-  );
+  static const sigma = IconData(0xeab9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-in-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sign-in-duotone.svg)
-  static const signIn = PhosphorDuotoneIconData(
-    0xe429,
-    PhosphorIconData(0xe428, 'Duotone'),
-  );
+  static const signIn = IconData(0xe429,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-out-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sign-out-duotone.svg)
-  static const signOut = PhosphorDuotoneIconData(
-    0xe42b,
-    PhosphorIconData(0xe42a, 'Duotone'),
-  );
+  static const signOut = IconData(0xe42b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signature-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/signature-duotone.svg)
-  static const signature = PhosphorDuotoneIconData(
-    0xebad,
-    PhosphorIconData(0xebac, 'Duotone'),
-  );
+  static const signature = IconData(0xebad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signpost-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/signpost-duotone.svg)
-  static const signpost = PhosphorDuotoneIconData(
-    0xe89d,
-    PhosphorIconData(0xe89c, 'Duotone'),
-  );
+  static const signpost = IconData(0xe89d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sim-card-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sim-card-duotone.svg)
-  static const simCard = PhosphorDuotoneIconData(
-    0xe665,
-    PhosphorIconData(0xe664, 'Duotone'),
-  );
+  static const simCard = IconData(0xe665,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![siren-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/siren-duotone.svg)
-  static const siren = PhosphorDuotoneIconData(
-    0xe9b9,
-    PhosphorIconData(0xe9b8, 'Duotone'),
-  );
+  static const siren = IconData(0xe9b9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sketch-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sketch-logo-duotone.svg)
-  static const sketchLogo = PhosphorDuotoneIconData(
-    0xe42d,
-    PhosphorIconData(0xe42c, 'Duotone'),
-  );
+  static const sketchLogo = IconData(0xe42d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skip-back-duotone.svg)
-  static const skipBack = PhosphorDuotoneIconData(
-    0xe5a5,
-    PhosphorIconData(0xe5a4, 'Duotone'),
-  );
+  static const skipBack = IconData(0xe5a5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skip-back-circle-duotone.svg)
-  static const skipBackCircle = PhosphorDuotoneIconData(
-    0xe42f,
-    PhosphorIconData(0xe42e, 'Duotone'),
-  );
+  static const skipBackCircle = IconData(0xe42f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skip-forward-duotone.svg)
-  static const skipForward = PhosphorDuotoneIconData(
-    0xe5a7,
-    PhosphorIconData(0xe5a6, 'Duotone'),
-  );
+  static const skipForward = IconData(0xe5a7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skip-forward-circle-duotone.svg)
-  static const skipForwardCircle = PhosphorDuotoneIconData(
-    0xe431,
-    PhosphorIconData(0xe430, 'Duotone'),
-  );
+  static const skipForwardCircle = IconData(0xe431,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skull-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skull-duotone.svg)
-  static const skull = PhosphorDuotoneIconData(
-    0xe917,
-    PhosphorIconData(0xe916, 'Duotone'),
-  );
+  static const skull = IconData(0xe917,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skype-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/skype-logo-duotone.svg)
-  static const skypeLogo = PhosphorDuotoneIconData(
-    0xe8dd,
-    PhosphorIconData(0xe8dc, 'Duotone'),
-  );
+  static const skypeLogo = IconData(0xe8dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slack-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/slack-logo-duotone.svg)
-  static const slackLogo = PhosphorDuotoneIconData(
-    0xe5a9,
-    PhosphorIconData(0xe5a8, 'Duotone'),
-  );
+  static const slackLogo = IconData(0xe5a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sliders-duotone.svg)
-  static const sliders = PhosphorDuotoneIconData(
-    0xe433,
-    PhosphorIconData(0xe432, 'Duotone'),
-  );
+  static const sliders = IconData(0xe433,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sliders-horizontal-duotone.svg)
-  static const slidersHorizontal = PhosphorDuotoneIconData(
-    0xe435,
-    PhosphorIconData(0xe434, 'Duotone'),
-  );
+  static const slidersHorizontal = IconData(0xe435,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slideshow-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/slideshow-duotone.svg)
-  static const slideshow = PhosphorDuotoneIconData(
-    0xed33,
-    PhosphorIconData(0xed32, 'Duotone'),
-  );
+  static const slideshow = IconData(0xed33,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-duotone.svg)
-  static const smiley = PhosphorDuotoneIconData(
-    0xe437,
-    PhosphorIconData(0xe436, 'Duotone'),
-  );
+  static const smiley = IconData(0xe437,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-angry-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-angry-duotone.svg)
-  static const smileyAngry = PhosphorDuotoneIconData(
-    0xec63,
-    PhosphorIconData(0xec62, 'Duotone'),
-  );
+  static const smileyAngry = IconData(0xec63,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-blank-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-blank-duotone.svg)
-  static const smileyBlank = PhosphorDuotoneIconData(
-    0xe439,
-    PhosphorIconData(0xe438, 'Duotone'),
-  );
+  static const smileyBlank = IconData(0xe439,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-meh-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-meh-duotone.svg)
-  static const smileyMeh = PhosphorDuotoneIconData(
-    0xe43b,
-    PhosphorIconData(0xe43a, 'Duotone'),
-  );
+  static const smileyMeh = IconData(0xe43b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-melting-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-melting-duotone.svg)
-  static const smileyMelting = PhosphorDuotoneIconData(
-    0xee57,
-    PhosphorIconData(0xee56, 'Duotone'),
-  );
+  static const smileyMelting = IconData(0xee57,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-nervous-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-nervous-duotone.svg)
-  static const smileyNervous = PhosphorDuotoneIconData(
-    0xe43d,
-    PhosphorIconData(0xe43c, 'Duotone'),
-  );
+  static const smileyNervous = IconData(0xe43d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sad-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-sad-duotone.svg)
-  static const smileySad = PhosphorDuotoneIconData(
-    0xe43f,
-    PhosphorIconData(0xe43e, 'Duotone'),
-  );
+  static const smileySad = IconData(0xe43f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sticker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-sticker-duotone.svg)
-  static const smileySticker = PhosphorDuotoneIconData(
-    0xe441,
-    PhosphorIconData(0xe440, 'Duotone'),
-  );
+  static const smileySticker = IconData(0xe441,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-wink-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-wink-duotone.svg)
-  static const smileyWink = PhosphorDuotoneIconData(
-    0xe667,
-    PhosphorIconData(0xe666, 'Duotone'),
-  );
+  static const smileyWink = IconData(0xe667,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-x-eyes-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/smiley-x-eyes-duotone.svg)
-  static const smileyXEyes = PhosphorDuotoneIconData(
-    0xe443,
-    PhosphorIconData(0xe442, 'Duotone'),
-  );
+  static const smileyXEyes = IconData(0xe443,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snapchat-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/snapchat-logo-duotone.svg)
-  static const snapchatLogo = PhosphorDuotoneIconData(
-    0xe669,
-    PhosphorIconData(0xe668, 'Duotone'),
-  );
+  static const snapchatLogo = IconData(0xe669,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sneaker-duotone.svg)
-  static const sneaker = PhosphorDuotoneIconData(
-    0xe80d,
-    PhosphorIconData(0xe80c, 'Duotone'),
-  );
+  static const sneaker = IconData(0xe80d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-move-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sneaker-move-duotone.svg)
-  static const sneakerMove = PhosphorDuotoneIconData(
-    0xed61,
-    PhosphorIconData(0xed60, 'Duotone'),
-  );
+  static const sneakerMove = IconData(0xed61,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snowflake-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/snowflake-duotone.svg)
-  static const snowflake = PhosphorDuotoneIconData(
-    0xe5ab,
-    PhosphorIconData(0xe5aa, 'Duotone'),
-  );
+  static const snowflake = IconData(0xe5ab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soccer-ball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/soccer-ball-duotone.svg)
-  static const soccerBall = PhosphorDuotoneIconData(
-    0xe717,
-    PhosphorIconData(0xe716, 'Duotone'),
-  );
+  static const soccerBall = IconData(0xe717,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sock-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sock-duotone.svg)
-  static const sock = PhosphorDuotoneIconData(
-    0xeccf,
-    PhosphorIconData(0xecce, 'Duotone'),
-  );
+  static const sock = IconData(0xeccf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-panel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/solar-panel-duotone.svg)
-  static const solarPanel = PhosphorDuotoneIconData(
-    0xed7e,
-    PhosphorIconData(0xed7a, 'Duotone'),
-  );
+  static const solarPanel = IconData(0xed7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-roof-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/solar-roof-duotone.svg)
-  static const solarRoof = PhosphorDuotoneIconData(
-    0xed7f,
-    PhosphorIconData(0xed7b, 'Duotone'),
-  );
+  static const solarRoof = IconData(0xed7f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-ascending-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sort-ascending-duotone.svg)
-  static const sortAscending = PhosphorDuotoneIconData(
-    0xe445,
-    PhosphorIconData(0xe444, 'Duotone'),
-  );
+  static const sortAscending = IconData(0xe445,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-descending-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sort-descending-duotone.svg)
-  static const sortDescending = PhosphorDuotoneIconData(
-    0xe447,
-    PhosphorIconData(0xe446, 'Duotone'),
-  );
+  static const sortDescending = IconData(0xe447,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soundcloud-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/soundcloud-logo-duotone.svg)
-  static const soundcloudLogo = PhosphorDuotoneIconData(
-    0xe8df,
-    PhosphorIconData(0xe8de, 'Duotone'),
-  );
+  static const soundcloudLogo = IconData(0xe8df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spade-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spade-duotone.svg)
-  static const spade = PhosphorDuotoneIconData(
-    0xe449,
-    PhosphorIconData(0xe448, 'Duotone'),
-  );
+  static const spade = IconData(0xe449,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sparkle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sparkle-duotone.svg)
-  static const sparkle = PhosphorDuotoneIconData(
-    0xe6a3,
-    PhosphorIconData(0xe6a2, 'Duotone'),
-  );
+  static const sparkle = IconData(0xe6a3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-hifi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-hifi-duotone.svg)
-  static const speakerHifi = PhosphorDuotoneIconData(
-    0xea09,
-    PhosphorIconData(0xea08, 'Duotone'),
-  );
+  static const speakerHifi = IconData(0xea09,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-high-duotone.svg)
-  static const speakerHigh = PhosphorDuotoneIconData(
-    0xe44b,
-    PhosphorIconData(0xe44a, 'Duotone'),
-  );
+  static const speakerHigh = IconData(0xe44b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-low-duotone.svg)
-  static const speakerLow = PhosphorDuotoneIconData(
-    0xe44d,
-    PhosphorIconData(0xe44c, 'Duotone'),
-  );
+  static const speakerLow = IconData(0xe44d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-none-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-none-duotone.svg)
-  static const speakerNone = PhosphorDuotoneIconData(
-    0xe44f,
-    PhosphorIconData(0xe44e, 'Duotone'),
-  );
+  static const speakerNone = IconData(0xe44f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-high-duotone.svg)
-  static const speakerSimpleHigh = PhosphorDuotoneIconData(
-    0xe451,
-    PhosphorIconData(0xe450, 'Duotone'),
-  );
+  static const speakerSimpleHigh = IconData(0xe451,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-low-duotone.svg)
-  static const speakerSimpleLow = PhosphorDuotoneIconData(
-    0xe453,
-    PhosphorIconData(0xe452, 'Duotone'),
-  );
+  static const speakerSimpleLow = IconData(0xe453,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-none-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-none-duotone.svg)
-  static const speakerSimpleNone = PhosphorDuotoneIconData(
-    0xe455,
-    PhosphorIconData(0xe454, 'Duotone'),
-  );
+  static const speakerSimpleNone = IconData(0xe455,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-slash-duotone.svg)
-  static const speakerSimpleSlash = PhosphorDuotoneIconData(
-    0xe457,
-    PhosphorIconData(0xe456, 'Duotone'),
-  );
+  static const speakerSimpleSlash = IconData(0xe457,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-simple-x-duotone.svg)
-  static const speakerSimpleX = PhosphorDuotoneIconData(
-    0xe459,
-    PhosphorIconData(0xe458, 'Duotone'),
-  );
+  static const speakerSimpleX = IconData(0xe459,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-slash-duotone.svg)
-  static const speakerSlash = PhosphorDuotoneIconData(
-    0xe45b,
-    PhosphorIconData(0xe45a, 'Duotone'),
-  );
+  static const speakerSlash = IconData(0xe45b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speaker-x-duotone.svg)
-  static const speakerX = PhosphorDuotoneIconData(
-    0xe45d,
-    PhosphorIconData(0xe45c, 'Duotone'),
-  );
+  static const speakerX = IconData(0xe45d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speedometer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/speedometer-duotone.svg)
-  static const speedometer = PhosphorDuotoneIconData(
-    0xee75,
-    PhosphorIconData(0xee74, 'Duotone'),
-  );
+  static const speedometer = IconData(0xee75,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sphere-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sphere-duotone.svg)
-  static const sphere = PhosphorDuotoneIconData(
-    0xee67,
-    PhosphorIconData(0xee66, 'Duotone'),
-  );
+  static const sphere = IconData(0xee67,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spinner-duotone.svg)
-  static const spinner = PhosphorDuotoneIconData(
-    0xe66b,
-    PhosphorIconData(0xe66a, 'Duotone'),
-  );
+  static const spinner = IconData(0xe66b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-ball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spinner-ball-duotone.svg)
-  static const spinnerBall = PhosphorDuotoneIconData(
-    0xee29,
-    PhosphorIconData(0xee28, 'Duotone'),
-  );
+  static const spinnerBall = IconData(0xee29,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-gap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spinner-gap-duotone.svg)
-  static const spinnerGap = PhosphorDuotoneIconData(
-    0xe66d,
-    PhosphorIconData(0xe66c, 'Duotone'),
-  );
+  static const spinnerGap = IconData(0xe66d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spiral-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spiral-duotone.svg)
-  static const spiral = PhosphorDuotoneIconData(
-    0xe9fb,
-    PhosphorIconData(0xe9fa, 'Duotone'),
-  );
+  static const spiral = IconData(0xe9fb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/split-horizontal-duotone.svg)
-  static const splitHorizontal = PhosphorDuotoneIconData(
-    0xe873,
-    PhosphorIconData(0xe872, 'Duotone'),
-  );
+  static const splitHorizontal = IconData(0xe873,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/split-vertical-duotone.svg)
-  static const splitVertical = PhosphorDuotoneIconData(
-    0xe877,
-    PhosphorIconData(0xe876, 'Duotone'),
-  );
+  static const splitVertical = IconData(0xe877,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spotify-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spotify-logo-duotone.svg)
-  static const spotifyLogo = PhosphorDuotoneIconData(
-    0xe66f,
-    PhosphorIconData(0xe66e, 'Duotone'),
-  );
+  static const spotifyLogo = IconData(0xe66f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spray-bottle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/spray-bottle-duotone.svg)
-  static const sprayBottle = PhosphorDuotoneIconData(
-    0xe7e8,
-    PhosphorIconData(0xe7e4, 'Duotone'),
-  );
+  static const sprayBottle = IconData(0xe7e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-duotone.svg)
-  static const square = PhosphorDuotoneIconData(
-    0xe45f,
-    PhosphorIconData(0xe45e, 'Duotone'),
-  );
+  static const square = IconData(0xe45f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-half-duotone.svg)
-  static const squareHalf = PhosphorDuotoneIconData(
-    0xe463,
-    PhosphorIconData(0xe462, 'Duotone'),
-  );
+  static const squareHalf = IconData(0xe463,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-bottom-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-half-bottom-duotone.svg)
-  static const squareHalfBottom = PhosphorDuotoneIconData(
-    0xeb17,
-    PhosphorIconData(0xeb16, 'Duotone'),
-  );
+  static const squareHalfBottom = IconData(0xeb17,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-logo-duotone.svg)
-  static const squareLogo = PhosphorDuotoneIconData(
-    0xe691,
-    PhosphorIconData(0xe690, 'Duotone'),
-  );
+  static const squareLogo = IconData(0xe691,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-horizontal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-split-horizontal-duotone.svg)
-  static const squareSplitHorizontal = PhosphorDuotoneIconData(
-    0xe871,
-    PhosphorIconData(0xe870, 'Duotone'),
-  );
+  static const squareSplitHorizontal = IconData(0xe871,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-vertical-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/square-split-vertical-duotone.svg)
-  static const squareSplitVertical = PhosphorDuotoneIconData(
-    0xe875,
-    PhosphorIconData(0xe874, 'Duotone'),
-  );
+  static const squareSplitVertical = IconData(0xe875,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![squares-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/squares-four-duotone.svg)
-  static const squaresFour = PhosphorDuotoneIconData(
-    0xe465,
-    PhosphorIconData(0xe464, 'Duotone'),
-  );
+  static const squaresFour = IconData(0xe465,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stack-duotone.svg)
-  static const stack = PhosphorDuotoneIconData(
-    0xe467,
-    PhosphorIconData(0xe466, 'Duotone'),
-  );
+  static const stack = IconData(0xe467,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stack-minus-duotone.svg)
-  static const stackMinus = PhosphorDuotoneIconData(
-    0xedf5,
-    PhosphorIconData(0xedf4, 'Duotone'),
-  );
+  static const stackMinus = IconData(0xedf5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-overflow-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stack-overflow-logo-duotone.svg)
-  static const stackOverflowLogo = PhosphorDuotoneIconData(
-    0xeb79,
-    PhosphorIconData(0xeb78, 'Duotone'),
-  );
+  static const stackOverflowLogo = IconData(0xeb79,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stack-plus-duotone.svg)
-  static const stackPlus = PhosphorDuotoneIconData(
-    0xedf7,
-    PhosphorIconData(0xedf6, 'Duotone'),
-  );
+  static const stackPlus = IconData(0xedf7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stack-simple-duotone.svg)
-  static const stackSimple = PhosphorDuotoneIconData(
-    0xe469,
-    PhosphorIconData(0xe468, 'Duotone'),
-  );
+  static const stackSimple = IconData(0xe469,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stairs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stairs-duotone.svg)
-  static const stairs = PhosphorDuotoneIconData(
-    0xe8ed,
-    PhosphorIconData(0xe8ec, 'Duotone'),
-  );
+  static const stairs = IconData(0xe8ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stamp-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stamp-duotone.svg)
-  static const stamp = PhosphorDuotoneIconData(
-    0xea49,
-    PhosphorIconData(0xea48, 'Duotone'),
-  );
+  static const stamp = IconData(0xea49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![standard-definition-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/standard-definition-duotone.svg)
-  static const standardDefinition = PhosphorDuotoneIconData(
-    0xea91,
-    PhosphorIconData(0xea90, 'Duotone'),
-  );
+  static const standardDefinition = IconData(0xea91,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-duotone.svg)
-  static const star = PhosphorDuotoneIconData(
-    0xe46b,
-    PhosphorIconData(0xe46a, 'Duotone'),
-  );
+  static const star = IconData(0xe46b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-and-crescent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-and-crescent-duotone.svg)
-  static const starAndCrescent = PhosphorDuotoneIconData(
-    0xecf5,
-    PhosphorIconData(0xecf4, 'Duotone'),
-  );
+  static const starAndCrescent = IconData(0xecf5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-four-duotone.svg)
-  static const starFour = PhosphorDuotoneIconData(
-    0xe6a5,
-    PhosphorIconData(0xe6a4, 'Duotone'),
-  );
+  static const starFour = IconData(0xe6a5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-half-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-half-duotone.svg)
-  static const starHalf = PhosphorDuotoneIconData(
-    0xe70b,
-    PhosphorIconData(0xe70a, 'Duotone'),
-  );
+  static const starHalf = IconData(0xe70b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-of-david-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/star-of-david-duotone.svg)
-  static const starOfDavid = PhosphorDuotoneIconData(
-    0xe89f,
-    PhosphorIconData(0xe89e, 'Duotone'),
-  );
+  static const starOfDavid = IconData(0xe89f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steam-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/steam-logo-duotone.svg)
-  static const steamLogo = PhosphorDuotoneIconData(
-    0xead5,
-    PhosphorIconData(0xead4, 'Duotone'),
-  );
+  static const steamLogo = IconData(0xead5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steering-wheel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/steering-wheel-duotone.svg)
-  static const steeringWheel = PhosphorDuotoneIconData(
-    0xe9ad,
-    PhosphorIconData(0xe9ac, 'Duotone'),
-  );
+  static const steeringWheel = IconData(0xe9ad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steps-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/steps-duotone.svg)
-  static const steps = PhosphorDuotoneIconData(
-    0xecbf,
-    PhosphorIconData(0xecbe, 'Duotone'),
-  );
+  static const steps = IconData(0xecbf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stethoscope-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stethoscope-duotone.svg)
-  static const stethoscope = PhosphorDuotoneIconData(
-    0xe7eb,
-    PhosphorIconData(0xe7ea, 'Duotone'),
-  );
+  static const stethoscope = IconData(0xe7eb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sticker-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sticker-duotone.svg)
-  static const sticker = PhosphorDuotoneIconData(
-    0xe5ad,
-    PhosphorIconData(0xe5ac, 'Duotone'),
-  );
+  static const sticker = IconData(0xe5ad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stool-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stool-duotone.svg)
-  static const stool = PhosphorDuotoneIconData(
-    0xea45,
-    PhosphorIconData(0xea44, 'Duotone'),
-  );
+  static const stool = IconData(0xea45,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stop-duotone.svg)
-  static const stop = PhosphorDuotoneIconData(
-    0xe46d,
-    PhosphorIconData(0xe46c, 'Duotone'),
-  );
+  static const stop = IconData(0xe46d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stop-circle-duotone.svg)
-  static const stopCircle = PhosphorDuotoneIconData(
-    0xe46f,
-    PhosphorIconData(0xe46e, 'Duotone'),
-  );
+  static const stopCircle = IconData(0xe46f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![storefront-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/storefront-duotone.svg)
-  static const storefront = PhosphorDuotoneIconData(
-    0xe471,
-    PhosphorIconData(0xe470, 'Duotone'),
-  );
+  static const storefront = IconData(0xe471,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![strategy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/strategy-duotone.svg)
-  static const strategy = PhosphorDuotoneIconData(
-    0xea3b,
-    PhosphorIconData(0xea3a, 'Duotone'),
-  );
+  static const strategy = IconData(0xea3b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stripe-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/stripe-logo-duotone.svg)
-  static const stripeLogo = PhosphorDuotoneIconData(
-    0xe699,
-    PhosphorIconData(0xe698, 'Duotone'),
-  );
+  static const stripeLogo = IconData(0xe699,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![student-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/student-duotone.svg)
-  static const student = PhosphorDuotoneIconData(
-    0xe73f,
-    PhosphorIconData(0xe73e, 'Duotone'),
-  );
+  static const student = IconData(0xe73f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-of-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subset-of-duotone.svg)
-  static const subsetOf = PhosphorDuotoneIconData(
-    0xedc1,
-    PhosphorIconData(0xedc0, 'Duotone'),
-  );
+  static const subsetOf = IconData(0xedc1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-proper-of-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subset-proper-of-duotone.svg)
-  static const subsetProperOf = PhosphorDuotoneIconData(
-    0xedb7,
-    PhosphorIconData(0xedb6, 'Duotone'),
-  );
+  static const subsetProperOf = IconData(0xedb7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subtitles-duotone.svg)
-  static const subtitles = PhosphorDuotoneIconData(
-    0xe1a9,
-    PhosphorIconData(0xe1a8, 'Duotone'),
-  );
+  static const subtitles = IconData(0xe1a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subtitles-slash-duotone.svg)
-  static const subtitlesSlash = PhosphorDuotoneIconData(
-    0xe1a7,
-    PhosphorIconData(0xe1a6, 'Duotone'),
-  );
+  static const subtitlesSlash = IconData(0xe1a7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subtract-duotone.svg)
-  static const subtract = PhosphorDuotoneIconData(
-    0xebd7,
-    PhosphorIconData(0xebd6, 'Duotone'),
-  );
+  static const subtract = IconData(0xebd7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subtract-square-duotone.svg)
-  static const subtractSquare = PhosphorDuotoneIconData(
-    0xebd5,
-    PhosphorIconData(0xebd4, 'Duotone'),
-  );
+  static const subtractSquare = IconData(0xebd5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subway-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/subway-duotone.svg)
-  static const subway = PhosphorDuotoneIconData(
-    0xe499,
-    PhosphorIconData(0xe498, 'Duotone'),
-  );
+  static const subway = IconData(0xe499,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/suitcase-duotone.svg)
-  static const suitcase = PhosphorDuotoneIconData(
-    0xe5af,
-    PhosphorIconData(0xe5ae, 'Duotone'),
-  );
+  static const suitcase = IconData(0xe5af,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-rolling-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/suitcase-rolling-duotone.svg)
-  static const suitcaseRolling = PhosphorDuotoneIconData(
-    0xe9b1,
-    PhosphorIconData(0xe9b0, 'Duotone'),
-  );
+  static const suitcaseRolling = IconData(0xe9b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/suitcase-simple-duotone.svg)
-  static const suitcaseSimple = PhosphorDuotoneIconData(
-    0xe5b1,
-    PhosphorIconData(0xe5b0, 'Duotone'),
-  );
+  static const suitcaseSimple = IconData(0xe5b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sun-duotone.svg)
-  static const sun = PhosphorDuotoneIconData(
-    0xe473,
-    PhosphorIconData(0xe472, 'Duotone'),
-  );
+  static const sun = IconData(0xe473,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-dim-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sun-dim-duotone.svg)
-  static const sunDim = PhosphorDuotoneIconData(
-    0xe475,
-    PhosphorIconData(0xe474, 'Duotone'),
-  );
+  static const sunDim = IconData(0xe475,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-horizon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sun-horizon-duotone.svg)
-  static const sunHorizon = PhosphorDuotoneIconData(
-    0xe5b7,
-    PhosphorIconData(0xe5b6, 'Duotone'),
-  );
+  static const sunHorizon = IconData(0xe5b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sunglasses-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sunglasses-duotone.svg)
-  static const sunglasses = PhosphorDuotoneIconData(
-    0xe817,
-    PhosphorIconData(0xe816, 'Duotone'),
-  );
+  static const sunglasses = IconData(0xe817,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-of-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/superset-of-duotone.svg)
-  static const supersetOf = PhosphorDuotoneIconData(
-    0xedb9,
-    PhosphorIconData(0xedb8, 'Duotone'),
-  );
+  static const supersetOf = IconData(0xedb9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-proper-of-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/superset-proper-of-duotone.svg)
-  static const supersetProperOf = PhosphorDuotoneIconData(
-    0xedb5,
-    PhosphorIconData(0xedb4, 'Duotone'),
-  );
+  static const supersetProperOf = IconData(0xedb5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swap-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/swap-duotone.svg)
-  static const swap = PhosphorDuotoneIconData(
-    0xe83d,
-    PhosphorIconData(0xe83c, 'Duotone'),
-  );
+  static const swap = IconData(0xe83d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swatches-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/swatches-duotone.svg)
-  static const swatches = PhosphorDuotoneIconData(
-    0xe5b9,
-    PhosphorIconData(0xe5b8, 'Duotone'),
-  );
+  static const swatches = IconData(0xe5b9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swimming-pool-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/swimming-pool-duotone.svg)
-  static const swimmingPool = PhosphorDuotoneIconData(
-    0xecb7,
-    PhosphorIconData(0xecb6, 'Duotone'),
-  );
+  static const swimmingPool = IconData(0xecb7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sword-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/sword-duotone.svg)
-  static const sword = PhosphorDuotoneIconData(
-    0xe5bb,
-    PhosphorIconData(0xe5ba, 'Duotone'),
-  );
+  static const sword = IconData(0xe5bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![synagogue-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/synagogue-duotone.svg)
-  static const synagogue = PhosphorDuotoneIconData(
-    0xeced,
-    PhosphorIconData(0xecec, 'Duotone'),
-  );
+  static const synagogue = IconData(0xeced,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![syringe-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/syringe-duotone.svg)
-  static const syringe = PhosphorDuotoneIconData(
-    0xe969,
-    PhosphorIconData(0xe968, 'Duotone'),
-  );
+  static const syringe = IconData(0xe969,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![t-shirt-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/t-shirt-duotone.svg)
-  static const tShirt = PhosphorDuotoneIconData(
-    0xe671,
-    PhosphorIconData(0xe670, 'Duotone'),
-  );
+  static const tShirt = IconData(0xe671,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![table-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/table-duotone.svg)
-  static const table = PhosphorDuotoneIconData(
-    0xe477,
-    PhosphorIconData(0xe476, 'Duotone'),
-  );
+  static const table = IconData(0xe477,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tabs-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tabs-duotone.svg)
-  static const tabs = PhosphorDuotoneIconData(
-    0xe779,
-    PhosphorIconData(0xe778, 'Duotone'),
-  );
+  static const tabs = IconData(0xe779,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tag-duotone.svg)
-  static const tag = PhosphorDuotoneIconData(
-    0xe479,
-    PhosphorIconData(0xe478, 'Duotone'),
-  );
+  static const tag = IconData(0xe479,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-chevron-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tag-chevron-duotone.svg)
-  static const tagChevron = PhosphorDuotoneIconData(
-    0xe673,
-    PhosphorIconData(0xe672, 'Duotone'),
-  );
+  static const tagChevron = IconData(0xe673,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tag-simple-duotone.svg)
-  static const tagSimple = PhosphorDuotoneIconData(
-    0xe47b,
-    PhosphorIconData(0xe47a, 'Duotone'),
-  );
+  static const tagSimple = IconData(0xe47b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![target-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/target-duotone.svg)
-  static const target = PhosphorDuotoneIconData(
-    0xe47d,
-    PhosphorIconData(0xe47c, 'Duotone'),
-  );
+  static const target = IconData(0xe47d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![taxi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/taxi-duotone.svg)
-  static const taxi = PhosphorDuotoneIconData(
-    0xe903,
-    PhosphorIconData(0xe902, 'Duotone'),
-  );
+  static const taxi = IconData(0xe903,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tea-bag-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tea-bag-duotone.svg)
-  static const teaBag = PhosphorDuotoneIconData(
-    0xe8e7,
-    PhosphorIconData(0xe8e6, 'Duotone'),
-  );
+  static const teaBag = IconData(0xe8e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![telegram-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/telegram-logo-duotone.svg)
-  static const telegramLogo = PhosphorDuotoneIconData(
-    0xe5bd,
-    PhosphorIconData(0xe5bc, 'Duotone'),
-  );
+  static const telegramLogo = IconData(0xe5bd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/television-duotone.svg)
-  static const television = PhosphorDuotoneIconData(
-    0xe755,
-    PhosphorIconData(0xe754, 'Duotone'),
-  );
+  static const television = IconData(0xe755,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/television-simple-duotone.svg)
-  static const televisionSimple = PhosphorDuotoneIconData(
-    0xeae7,
-    PhosphorIconData(0xeae6, 'Duotone'),
-  );
+  static const televisionSimple = IconData(0xeae7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tennis-ball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tennis-ball-duotone.svg)
-  static const tennisBall = PhosphorDuotoneIconData(
-    0xe721,
-    PhosphorIconData(0xe720, 'Duotone'),
-  );
+  static const tennisBall = IconData(0xe721,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tent-duotone.svg)
-  static const tent = PhosphorDuotoneIconData(
-    0xe8bb,
-    PhosphorIconData(0xe8ba, 'Duotone'),
-  );
+  static const tent = IconData(0xe8bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/terminal-duotone.svg)
-  static const terminal = PhosphorDuotoneIconData(
-    0xe47f,
-    PhosphorIconData(0xe47e, 'Duotone'),
-  );
+  static const terminal = IconData(0xe47f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-window-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/terminal-window-duotone.svg)
-  static const terminalWindow = PhosphorDuotoneIconData(
-    0xeae9,
-    PhosphorIconData(0xeae8, 'Duotone'),
-  );
+  static const terminalWindow = IconData(0xeae9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![test-tube-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/test-tube-duotone.svg)
-  static const testTube = PhosphorDuotoneIconData(
-    0xe7a1,
-    PhosphorIconData(0xe7a0, 'Duotone'),
-  );
+  static const testTube = IconData(0xe7a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-a-underline-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-a-underline-duotone.svg)
-  static const textAUnderline = PhosphorDuotoneIconData(
-    0xed35,
-    PhosphorIconData(0xed34, 'Duotone'),
-  );
+  static const textAUnderline = IconData(0xed35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-aa-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-aa-duotone.svg)
-  static const textAa = PhosphorDuotoneIconData(
-    0xe6ef,
-    PhosphorIconData(0xe6ee, 'Duotone'),
-  );
+  static const textAa = IconData(0xe6ef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-center-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-align-center-duotone.svg)
-  static const textAlignCenter = PhosphorDuotoneIconData(
-    0xe481,
-    PhosphorIconData(0xe480, 'Duotone'),
-  );
+  static const textAlignCenter = IconData(0xe481,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-justify-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-align-justify-duotone.svg)
-  static const textAlignJustify = PhosphorDuotoneIconData(
-    0xe483,
-    PhosphorIconData(0xe482, 'Duotone'),
-  );
+  static const textAlignJustify = IconData(0xe483,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-align-left-duotone.svg)
-  static const textAlignLeft = PhosphorDuotoneIconData(
-    0xe485,
-    PhosphorIconData(0xe484, 'Duotone'),
-  );
+  static const textAlignLeft = IconData(0xe485,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-align-right-duotone.svg)
-  static const textAlignRight = PhosphorDuotoneIconData(
-    0xe487,
-    PhosphorIconData(0xe486, 'Duotone'),
-  );
+  static const textAlignRight = IconData(0xe487,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-b-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-b-duotone.svg)
-  static const textB = PhosphorDuotoneIconData(
-    0xe5bf,
-    PhosphorIconData(0xe5be, 'Duotone'),
-  );
+  static const textB = IconData(0xe5bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-columns-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-columns-duotone.svg)
-  static const textColumns = PhosphorDuotoneIconData(
-    0xec97,
-    PhosphorIconData(0xec96, 'Duotone'),
-  );
+  static const textColumns = IconData(0xec97,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-duotone.svg)
-  static const textH = PhosphorDuotoneIconData(
-    0xe6bb,
-    PhosphorIconData(0xe6ba, 'Duotone'),
-  );
+  static const textH = IconData(0xe6bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-five-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-five-duotone.svg)
-  static const textHFive = PhosphorDuotoneIconData(
-    0xe6c5,
-    PhosphorIconData(0xe6c4, 'Duotone'),
-  );
+  static const textHFive = IconData(0xe6c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-four-duotone.svg)
-  static const textHFour = PhosphorDuotoneIconData(
-    0xe6c3,
-    PhosphorIconData(0xe6c2, 'Duotone'),
-  );
+  static const textHFour = IconData(0xe6c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-one-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-one-duotone.svg)
-  static const textHOne = PhosphorDuotoneIconData(
-    0xe6bd,
-    PhosphorIconData(0xe6bc, 'Duotone'),
-  );
+  static const textHOne = IconData(0xe6bd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-six-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-six-duotone.svg)
-  static const textHSix = PhosphorDuotoneIconData(
-    0xe6c7,
-    PhosphorIconData(0xe6c6, 'Duotone'),
-  );
+  static const textHSix = IconData(0xe6c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-three-duotone.svg)
-  static const textHThree = PhosphorDuotoneIconData(
-    0xe6c1,
-    PhosphorIconData(0xe6c0, 'Duotone'),
-  );
+  static const textHThree = IconData(0xe6c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-h-two-duotone.svg)
-  static const textHTwo = PhosphorDuotoneIconData(
-    0xe6bf,
-    PhosphorIconData(0xe6be, 'Duotone'),
-  );
+  static const textHTwo = IconData(0xe6bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-indent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-indent-duotone.svg)
-  static const textIndent = PhosphorDuotoneIconData(
-    0xea1f,
-    PhosphorIconData(0xea1e, 'Duotone'),
-  );
+  static const textIndent = IconData(0xea1f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-italic-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-italic-duotone.svg)
-  static const textItalic = PhosphorDuotoneIconData(
-    0xe5c1,
-    PhosphorIconData(0xe5c0, 'Duotone'),
-  );
+  static const textItalic = IconData(0xe5c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-outdent-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-outdent-duotone.svg)
-  static const textOutdent = PhosphorDuotoneIconData(
-    0xea1d,
-    PhosphorIconData(0xea1c, 'Duotone'),
-  );
+  static const textOutdent = IconData(0xea1d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-strikethrough-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-strikethrough-duotone.svg)
-  static const textStrikethrough = PhosphorDuotoneIconData(
-    0xe5c3,
-    PhosphorIconData(0xe5c2, 'Duotone'),
-  );
+  static const textStrikethrough = IconData(0xe5c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-subscript-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-subscript-duotone.svg)
-  static const textSubscript = PhosphorDuotoneIconData(
-    0xec99,
-    PhosphorIconData(0xec98, 'Duotone'),
-  );
+  static const textSubscript = IconData(0xec99,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-superscript-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-superscript-duotone.svg)
-  static const textSuperscript = PhosphorDuotoneIconData(
-    0xec9b,
-    PhosphorIconData(0xec9a, 'Duotone'),
-  );
+  static const textSuperscript = IconData(0xec9b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-t-duotone.svg)
-  static const textT = PhosphorDuotoneIconData(
-    0xe48b,
-    PhosphorIconData(0xe48a, 'Duotone'),
-  );
+  static const textT = IconData(0xe48b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-t-slash-duotone.svg)
-  static const textTSlash = PhosphorDuotoneIconData(
-    0xe489,
-    PhosphorIconData(0xe488, 'Duotone'),
-  );
+  static const textTSlash = IconData(0xe489,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-underline-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/text-underline-duotone.svg)
-  static const textUnderline = PhosphorDuotoneIconData(
-    0xe5c5,
-    PhosphorIconData(0xe5c4, 'Duotone'),
-  );
+  static const textUnderline = IconData(0xe5c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![textbox-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/textbox-duotone.svg)
-  static const textbox = PhosphorDuotoneIconData(
-    0xeb0b,
-    PhosphorIconData(0xeb0a, 'Duotone'),
-  );
+  static const textbox = IconData(0xeb0b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thermometer-duotone.svg)
-  static const thermometer = PhosphorDuotoneIconData(
-    0xe5c7,
-    PhosphorIconData(0xe5c6, 'Duotone'),
-  );
+  static const thermometer = IconData(0xe5c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-cold-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thermometer-cold-duotone.svg)
-  static const thermometerCold = PhosphorDuotoneIconData(
-    0xe5c9,
-    PhosphorIconData(0xe5c8, 'Duotone'),
-  );
+  static const thermometerCold = IconData(0xe5c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-hot-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thermometer-hot-duotone.svg)
-  static const thermometerHot = PhosphorDuotoneIconData(
-    0xe5cb,
-    PhosphorIconData(0xe5ca, 'Duotone'),
-  );
+  static const thermometerHot = IconData(0xe5cb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thermometer-simple-duotone.svg)
-  static const thermometerSimple = PhosphorDuotoneIconData(
-    0xe5cd,
-    PhosphorIconData(0xe5cc, 'Duotone'),
-  );
+  static const thermometerSimple = IconData(0xe5cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![threads-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/threads-logo-duotone.svg)
-  static const threadsLogo = PhosphorDuotoneIconData(
-    0xed9f,
-    PhosphorIconData(0xed9e, 'Duotone'),
-  );
+  static const threadsLogo = IconData(0xed9f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![three-d-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/three-d-duotone.svg)
-  static const threeD = PhosphorDuotoneIconData(
-    0xea5b,
-    PhosphorIconData(0xea5a, 'Duotone'),
-  );
+  static const threeD = IconData(0xea5b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thumbs-down-duotone.svg)
-  static const thumbsDown = PhosphorDuotoneIconData(
-    0xe48d,
-    PhosphorIconData(0xe48c, 'Duotone'),
-  );
+  static const thumbsDown = IconData(0xe48d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/thumbs-up-duotone.svg)
-  static const thumbsUp = PhosphorDuotoneIconData(
-    0xe48f,
-    PhosphorIconData(0xe48e, 'Duotone'),
-  );
+  static const thumbsUp = IconData(0xe48f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ticket-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/ticket-duotone.svg)
-  static const ticket = PhosphorDuotoneIconData(
-    0xe491,
-    PhosphorIconData(0xe490, 'Duotone'),
-  );
+  static const ticket = IconData(0xe491,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tidal-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tidal-logo-duotone.svg)
-  static const tidalLogo = PhosphorDuotoneIconData(
-    0xed1d,
-    PhosphorIconData(0xed1c, 'Duotone'),
-  );
+  static const tidalLogo = IconData(0xed1d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tiktok-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tiktok-logo-duotone.svg)
-  static const tiktokLogo = PhosphorDuotoneIconData(
-    0xeaf3,
-    PhosphorIconData(0xeaf2, 'Duotone'),
-  );
+  static const tiktokLogo = IconData(0xeaf3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tilde-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tilde-duotone.svg)
-  static const tilde = PhosphorDuotoneIconData(
-    0xeda9,
-    PhosphorIconData(0xeda8, 'Duotone'),
-  );
+  static const tilde = IconData(0xeda9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![timer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/timer-duotone.svg)
-  static const timer = PhosphorDuotoneIconData(
-    0xe493,
-    PhosphorIconData(0xe492, 'Duotone'),
-  );
+  static const timer = IconData(0xe493,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tip-jar-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tip-jar-duotone.svg)
-  static const tipJar = PhosphorDuotoneIconData(
-    0xe7e9,
-    PhosphorIconData(0xe7e2, 'Duotone'),
-  );
+  static const tipJar = IconData(0xe7e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tipi-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tipi-duotone.svg)
-  static const tipi = PhosphorDuotoneIconData(
-    0xed31,
-    PhosphorIconData(0xed30, 'Duotone'),
-  );
+  static const tipi = IconData(0xed31,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tire-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tire-duotone.svg)
-  static const tire = PhosphorDuotoneIconData(
-    0xedd3,
-    PhosphorIconData(0xedd2, 'Duotone'),
-  );
+  static const tire = IconData(0xedd3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-left-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toggle-left-duotone.svg)
-  static const toggleLeft = PhosphorDuotoneIconData(
-    0xe675,
-    PhosphorIconData(0xe674, 'Duotone'),
-  );
+  static const toggleLeft = IconData(0xe675,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-right-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toggle-right-duotone.svg)
-  static const toggleRight = PhosphorDuotoneIconData(
-    0xe677,
-    PhosphorIconData(0xe676, 'Duotone'),
-  );
+  static const toggleRight = IconData(0xe677,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toilet-duotone.svg)
-  static const toilet = PhosphorDuotoneIconData(
-    0xe79b,
-    PhosphorIconData(0xe79a, 'Duotone'),
-  );
+  static const toilet = IconData(0xe79b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-paper-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toilet-paper-duotone.svg)
-  static const toiletPaper = PhosphorDuotoneIconData(
-    0xe79d,
-    PhosphorIconData(0xe79c, 'Duotone'),
-  );
+  static const toiletPaper = IconData(0xe79d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toolbox-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/toolbox-duotone.svg)
-  static const toolbox = PhosphorDuotoneIconData(
-    0xeca1,
-    PhosphorIconData(0xeca0, 'Duotone'),
-  );
+  static const toolbox = IconData(0xeca1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tooth-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tooth-duotone.svg)
-  static const tooth = PhosphorDuotoneIconData(
-    0xe9cd,
-    PhosphorIconData(0xe9cc, 'Duotone'),
-  );
+  static const tooth = IconData(0xe9cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tornado-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tornado-duotone.svg)
-  static const tornado = PhosphorDuotoneIconData(
-    0xe88d,
-    PhosphorIconData(0xe88c, 'Duotone'),
-  );
+  static const tornado = IconData(0xe88d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tote-duotone.svg)
-  static const tote = PhosphorDuotoneIconData(
-    0xe495,
-    PhosphorIconData(0xe494, 'Duotone'),
-  );
+  static const tote = IconData(0xe495,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tote-simple-duotone.svg)
-  static const toteSimple = PhosphorDuotoneIconData(
-    0xe679,
-    PhosphorIconData(0xe678, 'Duotone'),
-  );
+  static const toteSimple = IconData(0xe679,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![towel-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/towel-duotone.svg)
-  static const towel = PhosphorDuotoneIconData(
-    0xede7,
-    PhosphorIconData(0xede6, 'Duotone'),
-  );
+  static const towel = IconData(0xede7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tractor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tractor-duotone.svg)
-  static const tractor = PhosphorDuotoneIconData(
-    0xec6f,
-    PhosphorIconData(0xec6e, 'Duotone'),
-  );
+  static const tractor = IconData(0xec6f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trademark-duotone.svg)
-  static const trademark = PhosphorDuotoneIconData(
-    0xe9f1,
-    PhosphorIconData(0xe9f0, 'Duotone'),
-  );
+  static const trademark = IconData(0xe9f1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-registered-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trademark-registered-duotone.svg)
-  static const trademarkRegistered = PhosphorDuotoneIconData(
-    0xe415,
-    PhosphorIconData(0xe3f4, 'Duotone'),
-  );
+  static const trademarkRegistered = IconData(0xe415,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-cone-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/traffic-cone-duotone.svg)
-  static const trafficCone = PhosphorDuotoneIconData(
-    0xe9a9,
-    PhosphorIconData(0xe9a8, 'Duotone'),
-  );
+  static const trafficCone = IconData(0xe9a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-sign-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/traffic-sign-duotone.svg)
-  static const trafficSign = PhosphorDuotoneIconData(
-    0xe67b,
-    PhosphorIconData(0xe67a, 'Duotone'),
-  );
+  static const trafficSign = IconData(0xe67b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-signal-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/traffic-signal-duotone.svg)
-  static const trafficSignal = PhosphorDuotoneIconData(
-    0xe9ab,
-    PhosphorIconData(0xe9aa, 'Duotone'),
-  );
+  static const trafficSignal = IconData(0xe9ab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/train-duotone.svg)
-  static const train = PhosphorDuotoneIconData(
-    0xe497,
-    PhosphorIconData(0xe496, 'Duotone'),
-  );
+  static const train = IconData(0xe497,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-regional-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/train-regional-duotone.svg)
-  static const trainRegional = PhosphorDuotoneIconData(
-    0xe49f,
-    PhosphorIconData(0xe49e, 'Duotone'),
-  );
+  static const trainRegional = IconData(0xe49f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/train-simple-duotone.svg)
-  static const trainSimple = PhosphorDuotoneIconData(
-    0xe4a1,
-    PhosphorIconData(0xe4a0, 'Duotone'),
-  );
+  static const trainSimple = IconData(0xe4a1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tram-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tram-duotone.svg)
-  static const tram = PhosphorDuotoneIconData(
-    0xe9ed,
-    PhosphorIconData(0xe9ec, 'Duotone'),
-  );
+  static const tram = IconData(0xe9ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![translate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/translate-duotone.svg)
-  static const translate = PhosphorDuotoneIconData(
-    0xe4a3,
-    PhosphorIconData(0xe4a2, 'Duotone'),
-  );
+  static const translate = IconData(0xe4a3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trash-duotone.svg)
-  static const trash = PhosphorDuotoneIconData(
-    0xe4a7,
-    PhosphorIconData(0xe4a6, 'Duotone'),
-  );
+  static const trash = IconData(0xe4a7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trash-simple-duotone.svg)
-  static const trashSimple = PhosphorDuotoneIconData(
-    0xe4a9,
-    PhosphorIconData(0xe4a8, 'Duotone'),
-  );
+  static const trashSimple = IconData(0xe4a9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tray-duotone.svg)
-  static const tray = PhosphorDuotoneIconData(
-    0xe4ab,
-    PhosphorIconData(0xe4aa, 'Duotone'),
-  );
+  static const tray = IconData(0xe4ab,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tray-arrow-down-duotone.svg)
-  static const trayArrowDown = PhosphorDuotoneIconData(
-    0xe011,
-    PhosphorIconData(0xe010, 'Duotone'),
-  );
+  static const trayArrowDown = IconData(0xe011,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tray-arrow-up-duotone.svg)
-  static const trayArrowUp = PhosphorDuotoneIconData(
-    0xee53,
-    PhosphorIconData(0xee52, 'Duotone'),
-  );
+  static const trayArrowUp = IconData(0xee53,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![treasure-chest-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/treasure-chest-duotone.svg)
-  static const treasureChest = PhosphorDuotoneIconData(
-    0xede3,
-    PhosphorIconData(0xede2, 'Duotone'),
-  );
+  static const treasureChest = IconData(0xede3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-duotone.svg)
-  static const tree = PhosphorDuotoneIconData(
-    0xe6db,
-    PhosphorIconData(0xe6da, 'Duotone'),
-  );
+  static const tree = IconData(0xe6db,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-evergreen-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-evergreen-duotone.svg)
-  static const treeEvergreen = PhosphorDuotoneIconData(
-    0xe6dd,
-    PhosphorIconData(0xe6dc, 'Duotone'),
-  );
+  static const treeEvergreen = IconData(0xe6dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-palm-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-palm-duotone.svg)
-  static const treePalm = PhosphorDuotoneIconData(
-    0xe91b,
-    PhosphorIconData(0xe91a, 'Duotone'),
-  );
+  static const treePalm = IconData(0xe91b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-structure-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-structure-duotone.svg)
-  static const treeStructure = PhosphorDuotoneIconData(
-    0xe67d,
-    PhosphorIconData(0xe67c, 'Duotone'),
-  );
+  static const treeStructure = IconData(0xe67d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-view-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tree-view-duotone.svg)
-  static const treeView = PhosphorDuotoneIconData(
-    0xee49,
-    PhosphorIconData(0xee48, 'Duotone'),
-  );
+  static const treeView = IconData(0xee49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-down-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trend-down-duotone.svg)
-  static const trendDown = PhosphorDuotoneIconData(
-    0xe4ad,
-    PhosphorIconData(0xe4ac, 'Duotone'),
-  );
+  static const trendDown = IconData(0xe4ad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-up-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trend-up-duotone.svg)
-  static const trendUp = PhosphorDuotoneIconData(
-    0xe4af,
-    PhosphorIconData(0xe4ae, 'Duotone'),
-  );
+  static const trendUp = IconData(0xe4af,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/triangle-duotone.svg)
-  static const triangle = PhosphorDuotoneIconData(
-    0xe4b1,
-    PhosphorIconData(0xe4b0, 'Duotone'),
-  );
+  static const triangle = IconData(0xe4b1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/triangle-dashed-duotone.svg)
-  static const triangleDashed = PhosphorDuotoneIconData(
-    0xe4b3,
-    PhosphorIconData(0xe4b2, 'Duotone'),
-  );
+  static const triangleDashed = IconData(0xe4b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trolley-duotone.svg)
-  static const trolley = PhosphorDuotoneIconData(
-    0xe5b3,
-    PhosphorIconData(0xe5b2, 'Duotone'),
-  );
+  static const trolley = IconData(0xe5b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-suitcase-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trolley-suitcase-duotone.svg)
-  static const trolleySuitcase = PhosphorDuotoneIconData(
-    0xe5b5,
-    PhosphorIconData(0xe5b4, 'Duotone'),
-  );
+  static const trolleySuitcase = IconData(0xe5b5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trophy-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/trophy-duotone.svg)
-  static const trophy = PhosphorDuotoneIconData(
-    0xe67f,
-    PhosphorIconData(0xe67e, 'Duotone'),
-  );
+  static const trophy = IconData(0xe67f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/truck-duotone.svg)
-  static const truck = PhosphorDuotoneIconData(
-    0xe4b5,
-    PhosphorIconData(0xe4b4, 'Duotone'),
-  );
+  static const truck = IconData(0xe4b5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-trailer-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/truck-trailer-duotone.svg)
-  static const truckTrailer = PhosphorDuotoneIconData(
-    0xe4b7,
-    PhosphorIconData(0xe4b6, 'Duotone'),
-  );
+  static const truckTrailer = IconData(0xe4b7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tumblr-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/tumblr-logo-duotone.svg)
-  static const tumblrLogo = PhosphorDuotoneIconData(
-    0xe8d5,
-    PhosphorIconData(0xe8d4, 'Duotone'),
-  );
+  static const tumblrLogo = IconData(0xe8d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitch-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/twitch-logo-duotone.svg)
-  static const twitchLogo = PhosphorDuotoneIconData(
-    0xe5cf,
-    PhosphorIconData(0xe5ce, 'Duotone'),
-  );
+  static const twitchLogo = IconData(0xe5cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitter-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/twitter-logo-duotone.svg)
-  static const twitterLogo = PhosphorDuotoneIconData(
-    0xe4bb,
-    PhosphorIconData(0xe4ba, 'Duotone'),
-  );
+  static const twitterLogo = IconData(0xe4bb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/umbrella-duotone.svg)
-  static const umbrella = PhosphorDuotoneIconData(
-    0xe685,
-    PhosphorIconData(0xe684, 'Duotone'),
-  );
+  static const umbrella = IconData(0xe685,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/umbrella-simple-duotone.svg)
-  static const umbrellaSimple = PhosphorDuotoneIconData(
-    0xe687,
-    PhosphorIconData(0xe686, 'Duotone'),
-  );
+  static const umbrellaSimple = IconData(0xe687,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![union-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/union-duotone.svg)
-  static const union = PhosphorDuotoneIconData(
-    0xedbf,
-    PhosphorIconData(0xedbe, 'Duotone'),
-  );
+  static const union = IconData(0xedbf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/unite-duotone.svg)
-  static const unite = PhosphorDuotoneIconData(
-    0xe87f,
-    PhosphorIconData(0xe87e, 'Duotone'),
-  );
+  static const unite = IconData(0xe87f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/unite-square-duotone.svg)
-  static const uniteSquare = PhosphorDuotoneIconData(
-    0xe879,
-    PhosphorIconData(0xe878, 'Duotone'),
-  );
+  static const uniteSquare = IconData(0xe879,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/upload-duotone.svg)
-  static const upload = PhosphorDuotoneIconData(
-    0xe4bf,
-    PhosphorIconData(0xe4be, 'Duotone'),
-  );
+  static const upload = IconData(0xe4bf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-simple-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/upload-simple-duotone.svg)
-  static const uploadSimple = PhosphorDuotoneIconData(
-    0xe4c1,
-    PhosphorIconData(0xe4c0, 'Duotone'),
-  );
+  static const uploadSimple = IconData(0xe4c1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![usb-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/usb-duotone.svg)
-  static const usb = PhosphorDuotoneIconData(
-    0xe957,
-    PhosphorIconData(0xe956, 'Duotone'),
-  );
+  static const usb = IconData(0xe957,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-duotone.svg)
-  static const user = PhosphorDuotoneIconData(
-    0xe4c3,
-    PhosphorIconData(0xe4c2, 'Duotone'),
-  );
+  static const user = IconData(0xe4c3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-check-duotone.svg)
-  static const userCheck = PhosphorDuotoneIconData(
-    0xeafb,
-    PhosphorIconData(0xeafa, 'Duotone'),
-  );
+  static const userCheck = IconData(0xeafb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-duotone.svg)
-  static const userCircle = PhosphorDuotoneIconData(
-    0xe4c5,
-    PhosphorIconData(0xe4c4, 'Duotone'),
-  );
+  static const userCircle = IconData(0xe4c5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-check-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-check-duotone.svg)
-  static const userCircleCheck = PhosphorDuotoneIconData(
-    0xec39,
-    PhosphorIconData(0xec38, 'Duotone'),
-  );
+  static const userCircleCheck = IconData(0xec39,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-dashed-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-dashed-duotone.svg)
-  static const userCircleDashed = PhosphorDuotoneIconData(
-    0xec37,
-    PhosphorIconData(0xec36, 'Duotone'),
-  );
+  static const userCircleDashed = IconData(0xec37,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-gear-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-gear-duotone.svg)
-  static const userCircleGear = PhosphorDuotoneIconData(
-    0xe4c7,
-    PhosphorIconData(0xe4c6, 'Duotone'),
-  );
+  static const userCircleGear = IconData(0xe4c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-minus-duotone.svg)
-  static const userCircleMinus = PhosphorDuotoneIconData(
-    0xe4c9,
-    PhosphorIconData(0xe4c8, 'Duotone'),
-  );
+  static const userCircleMinus = IconData(0xe4c9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-circle-plus-duotone.svg)
-  static const userCirclePlus = PhosphorDuotoneIconData(
-    0xe4cb,
-    PhosphorIconData(0xe4ca, 'Duotone'),
-  );
+  static const userCirclePlus = IconData(0xe4cb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-focus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-focus-duotone.svg)
-  static const userFocus = PhosphorDuotoneIconData(
-    0xe6fd,
-    PhosphorIconData(0xe6fc, 'Duotone'),
-  );
+  static const userFocus = IconData(0xe6fd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-gear-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-gear-duotone.svg)
-  static const userGear = PhosphorDuotoneIconData(
-    0xe4cd,
-    PhosphorIconData(0xe4cc, 'Duotone'),
-  );
+  static const userGear = IconData(0xe4cd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-list-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-list-duotone.svg)
-  static const userList = PhosphorDuotoneIconData(
-    0xe73d,
-    PhosphorIconData(0xe73c, 'Duotone'),
-  );
+  static const userList = IconData(0xe73d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-minus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-minus-duotone.svg)
-  static const userMinus = PhosphorDuotoneIconData(
-    0xe4cf,
-    PhosphorIconData(0xe4ce, 'Duotone'),
-  );
+  static const userMinus = IconData(0xe4cf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-plus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-plus-duotone.svg)
-  static const userPlus = PhosphorDuotoneIconData(
-    0xe4d1,
-    PhosphorIconData(0xe4d0, 'Duotone'),
-  );
+  static const userPlus = IconData(0xe4d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-rectangle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-rectangle-duotone.svg)
-  static const userRectangle = PhosphorDuotoneIconData(
-    0xe4d3,
-    PhosphorIconData(0xe4d2, 'Duotone'),
-  );
+  static const userRectangle = IconData(0xe4d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-sound-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-sound-duotone.svg)
-  static const userSound = PhosphorDuotoneIconData(
-    0xeca9,
-    PhosphorIconData(0xeca8, 'Duotone'),
-  );
+  static const userSound = IconData(0xeca9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-square-duotone.svg)
-  static const userSquare = PhosphorDuotoneIconData(
-    0xe4d5,
-    PhosphorIconData(0xe4d4, 'Duotone'),
-  );
+  static const userSquare = IconData(0xe4d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-switch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/user-switch-duotone.svg)
-  static const userSwitch = PhosphorDuotoneIconData(
-    0xe757,
-    PhosphorIconData(0xe756, 'Duotone'),
-  );
+  static const userSwitch = IconData(0xe757,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/users-duotone.svg)
-  static const users = PhosphorDuotoneIconData(
-    0xe4d7,
-    PhosphorIconData(0xe4d6, 'Duotone'),
-  );
+  static const users = IconData(0xe4d7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-four-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/users-four-duotone.svg)
-  static const usersFour = PhosphorDuotoneIconData(
-    0xe68d,
-    PhosphorIconData(0xe68c, 'Duotone'),
-  );
+  static const usersFour = IconData(0xe68d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/users-three-duotone.svg)
-  static const usersThree = PhosphorDuotoneIconData(
-    0xe68f,
-    PhosphorIconData(0xe68e, 'Duotone'),
-  );
+  static const usersThree = IconData(0xe68f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![van-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/van-duotone.svg)
-  static const van = PhosphorDuotoneIconData(
-    0xe827,
-    PhosphorIconData(0xe826, 'Duotone'),
-  );
+  static const van = IconData(0xe827,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vault-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vault-duotone.svg)
-  static const vault = PhosphorDuotoneIconData(
-    0xe76f,
-    PhosphorIconData(0xe76e, 'Duotone'),
-  );
+  static const vault = IconData(0xe76f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-three-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vector-three-duotone.svg)
-  static const vectorThree = PhosphorDuotoneIconData(
-    0xee63,
-    PhosphorIconData(0xee62, 'Duotone'),
-  );
+  static const vectorThree = IconData(0xee63,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-two-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vector-two-duotone.svg)
-  static const vectorTwo = PhosphorDuotoneIconData(
-    0xee65,
-    PhosphorIconData(0xee64, 'Duotone'),
-  );
+  static const vectorTwo = IconData(0xee65,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vibrate-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vibrate-duotone.svg)
-  static const vibrate = PhosphorDuotoneIconData(
-    0xe4d9,
-    PhosphorIconData(0xe4d8, 'Duotone'),
-  );
+  static const vibrate = IconData(0xe4d9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/video-duotone.svg)
-  static const video = PhosphorDuotoneIconData(
-    0xe741,
-    PhosphorIconData(0xe740, 'Duotone'),
-  );
+  static const video = IconData(0xe741,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/video-camera-duotone.svg)
-  static const videoCamera = PhosphorDuotoneIconData(
-    0xe4db,
-    PhosphorIconData(0xe4da, 'Duotone'),
-  );
+  static const videoCamera = IconData(0xe4db,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/video-camera-slash-duotone.svg)
-  static const videoCameraSlash = PhosphorDuotoneIconData(
-    0xe4dd,
-    PhosphorIconData(0xe4dc, 'Duotone'),
-  );
+  static const videoCameraSlash = IconData(0xe4dd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-conference-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/video-conference-duotone.svg)
-  static const videoConference = PhosphorDuotoneIconData(
-    0xedcf,
-    PhosphorIconData(0xedce, 'Duotone'),
-  );
+  static const videoConference = IconData(0xedcf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vignette-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vignette-duotone.svg)
-  static const vignette = PhosphorDuotoneIconData(
-    0xeba3,
-    PhosphorIconData(0xeba2, 'Duotone'),
-  );
+  static const vignette = IconData(0xeba3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vinyl-record-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/vinyl-record-duotone.svg)
-  static const vinylRecord = PhosphorDuotoneIconData(
-    0xecad,
-    PhosphorIconData(0xecac, 'Duotone'),
-  );
+  static const vinylRecord = IconData(0xecad,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virtual-reality-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/virtual-reality-duotone.svg)
-  static const virtualReality = PhosphorDuotoneIconData(
-    0xe7b9,
-    PhosphorIconData(0xe7b8, 'Duotone'),
-  );
+  static const virtualReality = IconData(0xe7b9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virus-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/virus-duotone.svg)
-  static const virus = PhosphorDuotoneIconData(
-    0xe7d7,
-    PhosphorIconData(0xe7d6, 'Duotone'),
-  );
+  static const virus = IconData(0xe7d7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![visor-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/visor-duotone.svg)
-  static const visor = PhosphorDuotoneIconData(
-    0xee2b,
-    PhosphorIconData(0xee2a, 'Duotone'),
-  );
+  static const visor = IconData(0xee2b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![voicemail-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/voicemail-duotone.svg)
-  static const voicemail = PhosphorDuotoneIconData(
-    0xe4df,
-    PhosphorIconData(0xe4de, 'Duotone'),
-  );
+  static const voicemail = IconData(0xe4df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![volleyball-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/volleyball-duotone.svg)
-  static const volleyball = PhosphorDuotoneIconData(
-    0xe727,
-    PhosphorIconData(0xe726, 'Duotone'),
-  );
+  static const volleyball = IconData(0xe727,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wall-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wall-duotone.svg)
-  static const wall = PhosphorDuotoneIconData(
-    0xe689,
-    PhosphorIconData(0xe688, 'Duotone'),
-  );
+  static const wall = IconData(0xe689,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wallet-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wallet-duotone.svg)
-  static const wallet = PhosphorDuotoneIconData(
-    0xe68b,
-    PhosphorIconData(0xe68a, 'Duotone'),
-  );
+  static const wallet = IconData(0xe68b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warehouse-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warehouse-duotone.svg)
-  static const warehouse = PhosphorDuotoneIconData(
-    0xecd5,
-    PhosphorIconData(0xecd4, 'Duotone'),
-  );
+  static const warehouse = IconData(0xecd5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warning-duotone.svg)
-  static const warning = PhosphorDuotoneIconData(
-    0xe4e1,
-    PhosphorIconData(0xe4e0, 'Duotone'),
-  );
+  static const warning = IconData(0xe4e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warning-circle-duotone.svg)
-  static const warningCircle = PhosphorDuotoneIconData(
-    0xe4e3,
-    PhosphorIconData(0xe4e2, 'Duotone'),
-  );
+  static const warningCircle = IconData(0xe4e3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-diamond-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warning-diamond-duotone.svg)
-  static const warningDiamond = PhosphorDuotoneIconData(
-    0xe7fd,
-    PhosphorIconData(0xe7fc, 'Duotone'),
-  );
+  static const warningDiamond = IconData(0xe7fd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-octagon-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/warning-octagon-duotone.svg)
-  static const warningOctagon = PhosphorDuotoneIconData(
-    0xe4e5,
-    PhosphorIconData(0xe4e4, 'Duotone'),
-  );
+  static const warningOctagon = IconData(0xe4e5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![washing-machine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/washing-machine-duotone.svg)
-  static const washingMachine = PhosphorDuotoneIconData(
-    0xede9,
-    PhosphorIconData(0xede8, 'Duotone'),
-  );
+  static const washingMachine = IconData(0xede9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![watch-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/watch-duotone.svg)
-  static const watch = PhosphorDuotoneIconData(
-    0xe4e7,
-    PhosphorIconData(0xe4e6, 'Duotone'),
-  );
+  static const watch = IconData(0xe4e7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sawtooth-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wave-sawtooth-duotone.svg)
-  static const waveSawtooth = PhosphorDuotoneIconData(
-    0xea9d,
-    PhosphorIconData(0xea9c, 'Duotone'),
-  );
+  static const waveSawtooth = IconData(0xea9d,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wave-sine-duotone.svg)
-  static const waveSine = PhosphorDuotoneIconData(
-    0xea9b,
-    PhosphorIconData(0xea9a, 'Duotone'),
-  );
+  static const waveSine = IconData(0xea9b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wave-square-duotone.svg)
-  static const waveSquare = PhosphorDuotoneIconData(
-    0xea9f,
-    PhosphorIconData(0xea9e, 'Duotone'),
-  );
+  static const waveSquare = IconData(0xea9f,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-triangle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wave-triangle-duotone.svg)
-  static const waveTriangle = PhosphorDuotoneIconData(
-    0xeaa1,
-    PhosphorIconData(0xeaa0, 'Duotone'),
-  );
+  static const waveTriangle = IconData(0xeaa1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/waveform-duotone.svg)
-  static const waveform = PhosphorDuotoneIconData(
-    0xe803,
-    PhosphorIconData(0xe802, 'Duotone'),
-  );
+  static const waveform = IconData(0xe803,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/waveform-slash-duotone.svg)
-  static const waveformSlash = PhosphorDuotoneIconData(
-    0xe801,
-    PhosphorIconData(0xe800, 'Duotone'),
-  );
+  static const waveformSlash = IconData(0xe801,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waves-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/waves-duotone.svg)
-  static const waves = PhosphorDuotoneIconData(
-    0xe6df,
-    PhosphorIconData(0xe6de, 'Duotone'),
-  );
+  static const waves = IconData(0xe6df,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/webcam-duotone.svg)
-  static const webcam = PhosphorDuotoneIconData(
-    0xe9b3,
-    PhosphorIconData(0xe9b2, 'Duotone'),
-  );
+  static const webcam = IconData(0xe9b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/webcam-slash-duotone.svg)
-  static const webcamSlash = PhosphorDuotoneIconData(
-    0xecdd,
-    PhosphorIconData(0xecdc, 'Duotone'),
-  );
+  static const webcamSlash = IconData(0xecdd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webhooks-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/webhooks-logo-duotone.svg)
-  static const webhooksLogo = PhosphorDuotoneIconData(
-    0xecaf,
-    PhosphorIconData(0xecae, 'Duotone'),
-  );
+  static const webhooksLogo = IconData(0xecaf,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wechat-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wechat-logo-duotone.svg)
-  static const wechatLogo = PhosphorDuotoneIconData(
-    0xe8d3,
-    PhosphorIconData(0xe8d2, 'Duotone'),
-  );
+  static const wechatLogo = IconData(0xe8d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![whatsapp-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/whatsapp-logo-duotone.svg)
-  static const whatsappLogo = PhosphorDuotoneIconData(
-    0xe5d1,
-    PhosphorIconData(0xe5d0, 'Duotone'),
-  );
+  static const whatsappLogo = IconData(0xe5d1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wheelchair-duotone.svg)
-  static const wheelchair = PhosphorDuotoneIconData(
-    0xe4e9,
-    PhosphorIconData(0xe4e8, 'Duotone'),
-  );
+  static const wheelchair = IconData(0xe4e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-motion-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wheelchair-motion-duotone.svg)
-  static const wheelchairMotion = PhosphorDuotoneIconData(
-    0xe89b,
-    PhosphorIconData(0xe89a, 'Duotone'),
-  );
+  static const wheelchairMotion = IconData(0xe89b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-high-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-high-duotone.svg)
-  static const wifiHigh = PhosphorDuotoneIconData(
-    0xe4eb,
-    PhosphorIconData(0xe4ea, 'Duotone'),
-  );
+  static const wifiHigh = IconData(0xe4eb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-low-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-low-duotone.svg)
-  static const wifiLow = PhosphorDuotoneIconData(
-    0xe4ed,
-    PhosphorIconData(0xe4ec, 'Duotone'),
-  );
+  static const wifiLow = IconData(0xe4ed,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-medium-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-medium-duotone.svg)
-  static const wifiMedium = PhosphorDuotoneIconData(
-    0xe4ef,
-    PhosphorIconData(0xe4ee, 'Duotone'),
-  );
+  static const wifiMedium = IconData(0xe4ef,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-none-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-none-duotone.svg)
-  static const wifiNone = PhosphorFlatIconData(0xe4f0, 'Duotone');
+  static const wifiNone = IconData(0xe4f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-slash-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-slash-duotone.svg)
-  static const wifiSlash = PhosphorDuotoneIconData(
-    0xe4f3,
-    PhosphorIconData(0xe4f2, 'Duotone'),
-  );
+  static const wifiSlash = IconData(0xe4f3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wifi-x-duotone.svg)
-  static const wifiX = PhosphorDuotoneIconData(
-    0xe4f5,
-    PhosphorIconData(0xe4f4, 'Duotone'),
-  );
+  static const wifiX = IconData(0xe4f5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wind-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wind-duotone.svg)
-  static const wind = PhosphorDuotoneIconData(
-    0xe5d3,
-    PhosphorIconData(0xe5d2, 'Duotone'),
-  );
+  static const wind = IconData(0xe5d3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windmill-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/windmill-duotone.svg)
-  static const windmill = PhosphorDuotoneIconData(
-    0xe9f9,
-    PhosphorIconData(0xe9f8, 'Duotone'),
-  );
+  static const windmill = IconData(0xe9f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windows-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/windows-logo-duotone.svg)
-  static const windowsLogo = PhosphorDuotoneIconData(
-    0xe693,
-    PhosphorIconData(0xe692, 'Duotone'),
-  );
+  static const windowsLogo = IconData(0xe693,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wine-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wine-duotone.svg)
-  static const wine = PhosphorDuotoneIconData(
-    0xe6b3,
-    PhosphorIconData(0xe6b2, 'Duotone'),
-  );
+  static const wine = IconData(0xe6b3,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wrench-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/wrench-duotone.svg)
-  static const wrench = PhosphorDuotoneIconData(
-    0xe5d5,
-    PhosphorIconData(0xe5d4, 'Duotone'),
-  );
+  static const wrench = IconData(0xe5d5,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/x-duotone.svg)
-  static const x = PhosphorDuotoneIconData(
-    0xe4f7,
-    PhosphorIconData(0xe4f6, 'Duotone'),
-  );
+  static const x = IconData(0xe4f7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-circle-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/x-circle-duotone.svg)
-  static const xCircle = PhosphorDuotoneIconData(
-    0xe4f9,
-    PhosphorIconData(0xe4f8, 'Duotone'),
-  );
+  static const xCircle = IconData(0xe4f9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/x-logo-duotone.svg)
-  static const xLogo = PhosphorDuotoneIconData(
-    0xe4bd,
-    PhosphorIconData(0xe4bc, 'Duotone'),
-  );
+  static const xLogo = IconData(0xe4bd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-square-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/x-square-duotone.svg)
-  static const xSquare = PhosphorDuotoneIconData(
-    0xe4fb,
-    PhosphorIconData(0xe4fa, 'Duotone'),
-  );
+  static const xSquare = IconData(0xe4fb,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yarn-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/yarn-duotone.svg)
-  static const yarn = PhosphorDuotoneIconData(
-    0xed9b,
-    PhosphorIconData(0xed9a, 'Duotone'),
-  );
+  static const yarn = IconData(0xed9b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yin-yang-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/yin-yang-duotone.svg)
-  static const yinYang = PhosphorDuotoneIconData(
-    0xe92b,
-    PhosphorIconData(0xe92a, 'Duotone'),
-  );
+  static const yinYang = IconData(0xe92b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![youtube-logo-duotone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/duotone/youtube-logo-duotone.svg)
-  static const youtubeLogo = PhosphorDuotoneIconData(
-    0xe4fd,
-    PhosphorIconData(0xe4fc, 'Duotone'),
-  );
+  static const youtubeLogo = IconData(0xe4fd,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
+
+  /// A map that contains the secondary IconData for each primary IconData of the duotone style.
+  /// The key is the `codePoint` of the primary IconData and the value is the secondary IconData.
+  /// `PhosphorIcon` reads this map to stack the secondary glyph beneath the primary, producing the duotone effect.
+  static const Map<int, IconData> secondaryFor = {
+    0xeb9b: IconData(0xeb9a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6f9: IconData(0xe6f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee4f: IconData(0xee4e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecd9: IconData(0xecd8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe003: IconData(0xe002,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4ff: IconData(0xe4fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe503: IconData(0xe502,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe505: IconData(0xe504,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe501: IconData(0xe500,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5d7: IconData(0xe5d6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe005: IconData(0xe004,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe007: IconData(0xe006,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8a7: IconData(0xe8a6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe507: IconData(0xe506,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb0d: IconData(0xeb0c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe50b: IconData(0xe50a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb0f: IconData(0xeb0e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe50d: IconData(0xe50c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb11: IconData(0xeb10,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe50f: IconData(0xe50e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaef: IconData(0xeaee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe511: IconData(0xe510,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb13: IconData(0xeb12,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe513: IconData(0xe512,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb15: IconData(0xeb14,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe96d: IconData(0xe96c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe573: IconData(0xe572,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe515: IconData(0xe514,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5d9: IconData(0xe5d8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe009: IconData(0xe008,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7bd: IconData(0xe7bc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb81: IconData(0xeb80,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe00b: IconData(0xe00a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe975: IconData(0xe974,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5db: IconData(0xe5da,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe517: IconData(0xe516,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb97: IconData(0xeb96,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedab: IconData(0xedaa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe00d: IconData(0xe00c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe013: IconData(0xe012,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe015: IconData(0xe014,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe017: IconData(0xe016,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe03b: IconData(0xe03a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe03d: IconData(0xe03c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe019: IconData(0xe018,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe01b: IconData(0xe01a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe01d: IconData(0xe01c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe01f: IconData(0xe01e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe021: IconData(0xe020,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe023: IconData(0xe022,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe025: IconData(0xe024,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe027: IconData(0xe026,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe029: IconData(0xe028,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe02b: IconData(0xe02a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe02d: IconData(0xe02c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe05b: IconData(0xe05a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe02f: IconData(0xe02e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe031: IconData(0xe030,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe033: IconData(0xe032,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe035: IconData(0xe034,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe037: IconData(0xe036,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe039: IconData(0xe038,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe03f: IconData(0xe03e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe041: IconData(0xe040,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe043: IconData(0xe042,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe045: IconData(0xe044,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe047: IconData(0xe046,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe049: IconData(0xe048,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe04b: IconData(0xe04a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe04d: IconData(0xe04c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe04f: IconData(0xe04e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe051: IconData(0xe050,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe053: IconData(0xe052,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe055: IconData(0xe054,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe057: IconData(0xe056,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe519: IconData(0xe518,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe51b: IconData(0xe51a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe51d: IconData(0xe51c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe51f: IconData(0xe51e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe521: IconData(0xe520,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe523: IconData(0xe522,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe525: IconData(0xe524,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe527: IconData(0xe526,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe529: IconData(0xe528,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe52b: IconData(0xe52a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe52d: IconData(0xe52c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe52f: IconData(0xe52e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe059: IconData(0xe058,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe05d: IconData(0xe05c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe05f: IconData(0xe05e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe061: IconData(0xe060,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe063: IconData(0xe062,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe065: IconData(0xe064,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe067: IconData(0xe066,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe069: IconData(0xe068,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe06b: IconData(0xe06a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe06d: IconData(0xe06c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe06f: IconData(0xe06e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe071: IconData(0xe070,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe073: IconData(0xe072,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5dd: IconData(0xe5dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe075: IconData(0xe074,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5df: IconData(0xe5de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe077: IconData(0xe076,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe079: IconData(0xe078,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe07b: IconData(0xe07a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe07d: IconData(0xe07c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe07f: IconData(0xe07e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe081: IconData(0xe080,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe083: IconData(0xe082,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe085: IconData(0xe084,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe087: IconData(0xe086,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe089: IconData(0xe088,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe08b: IconData(0xe08a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe08d: IconData(0xe08c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe08f: IconData(0xe08e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe091: IconData(0xe090,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe093: IconData(0xe092,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe095: IconData(0xe094,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe097: IconData(0xe096,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe099: IconData(0xe098,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb07: IconData(0xeb06,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe09b: IconData(0xe09a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe09d: IconData(0xe09c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe531: IconData(0xe530,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe533: IconData(0xe532,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe09f: IconData(0xe09e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0a1: IconData(0xe0a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed3f: IconData(0xed3e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0a3: IconData(0xe0a2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0a5: IconData(0xe0a4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe535: IconData(0xe534,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe537: IconData(0xe536,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0a7: IconData(0xe0a6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed3d: IconData(0xed3c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb05: IconData(0xeb04,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0a9: IconData(0xe0a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5e1: IconData(0xe5e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5e3: IconData(0xe5e2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee35: IconData(0xee34,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0ab: IconData(0xe0aa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe833: IconData(0xe832,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0ad: IconData(0xe0ac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5e5: IconData(0xe5e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee05: IconData(0xee04,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9fd: IconData(0xe9fc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe775: IconData(0xe774,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe819: IconData(0xe818,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe923: IconData(0xe922,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0af: IconData(0xe0ae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0b1: IconData(0xe0b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5e7: IconData(0xe5e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe76d: IconData(0xe76c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0b3: IconData(0xe0b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0b5: IconData(0xe0b4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0b7: IconData(0xe0b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0b9: IconData(0xe0b8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec73: IconData(0xec72,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe949: IconData(0xe948,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe71b: IconData(0xe71a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea29: IconData(0xea28,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee4b: IconData(0xee4a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe965: IconData(0xe964,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe725: IconData(0xe724,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe81f: IconData(0xe81e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0bb: IconData(0xe0ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0bd: IconData(0xe0bc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0bf: IconData(0xe0be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0c1: IconData(0xe0c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0c3: IconData(0xe0c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0c5: IconData(0xe0c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0c7: IconData(0xe0c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe809: IconData(0xe808,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec51: IconData(0xec50,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7c7: IconData(0xe7c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7c5: IconData(0xe7c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7c3: IconData(0xe7c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7bf: IconData(0xe7be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7c1: IconData(0xe7c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0c9: IconData(0xe0c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0cb: IconData(0xe0ca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed25: IconData(0xed24,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea2b: IconData(0xea2a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0cd: IconData(0xe0cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7b1: IconData(0xe7b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb63: IconData(0xeb62,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7f5: IconData(0xe7f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0cf: IconData(0xe0ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5e9: IconData(0xe5e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0d1: IconData(0xe0d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5eb: IconData(0xe5ea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0d3: IconData(0xe0d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5ed: IconData(0xe5ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0d5: IconData(0xe0d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5ef: IconData(0xe5ee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea2d: IconData(0xea2c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb01: IconData(0xeb00,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0d7: IconData(0xe0d6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee61: IconData(0xee60,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea65: IconData(0xea64,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9e1: IconData(0xe9e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe72d: IconData(0xe72c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeda1: IconData(0xeda0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0db: IconData(0xe0da,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0dd: IconData(0xe0dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0df: IconData(0xe0de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0e1: IconData(0xe0e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe787: IconData(0xe786,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee0b: IconData(0xee0a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7f3: IconData(0xe7f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0e3: IconData(0xe0e2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0e5: IconData(0xe0e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0e7: IconData(0xe0e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8f3: IconData(0xe8f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xede1: IconData(0xede0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0e9: IconData(0xe0e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0eb: IconData(0xe0ea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0ed: IconData(0xe0ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5f1: IconData(0xe5f0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe759: IconData(0xe758,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeccb: IconData(0xecca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe723: IconData(0xe722,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6cf: IconData(0xe6ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaa5: IconData(0xeaa4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8e5: IconData(0xe8e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea35: IconData(0xea34,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe00f: IconData(0xe00e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee55: IconData(0xee54,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea37: IconData(0xea36,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe863: IconData(0xe862,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe861: IconData(0xe860,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe865: IconData(0xe864,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe85f: IconData(0xe85e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe74f: IconData(0xe74e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6b5: IconData(0xe6b4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe81d: IconData(0xe81c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea69: IconData(0xea68,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0ef: IconData(0xe0ee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5f3: IconData(0xe5f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0f3: IconData(0xe0f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec55: IconData(0xec54,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0f5: IconData(0xe0f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0f7: IconData(0xe0f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5f5: IconData(0xe5f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5f7: IconData(0xe5f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5f9: IconData(0xe5f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe101: IconData(0xe100,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe103: IconData(0xe0fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe104: IconData(0xe0ff,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe105: IconData(0xe102,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec6d: IconData(0xec6c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe107: IconData(0xe106,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea6f: IconData(0xea6e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe49d: IconData(0xe49c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe919: IconData(0xe918,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe781: IconData(0xe780,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe539: IconData(0xe538,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe109: IconData(0xe108,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe10b: IconData(0xe10a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe713: IconData(0xe712,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7b3: IconData(0xe7b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7b5: IconData(0xe7b4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8b1: IconData(0xe8b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea15: IconData(0xea14,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe715: IconData(0xe714,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea13: IconData(0xea12,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8b3: IconData(0xe8b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe10d: IconData(0xe10c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7df: IconData(0xe7de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe10f: IconData(0xe10e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec59: IconData(0xec58,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7a5: IconData(0xe7a4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe111: IconData(0xe110,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9d9: IconData(0xe9d8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe113: IconData(0xe112,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee31: IconData(0xee30,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8cd: IconData(0xe8cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe115: IconData(0xe114,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5fb: IconData(0xe5fa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe0f9: IconData(0xe0f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee51: IconData(0xee50,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe117: IconData(0xe116,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe119: IconData(0xe118,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe11b: IconData(0xe11a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe11d: IconData(0xe11c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe11f: IconData(0xe11e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe121: IconData(0xe120,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe123: IconData(0xe122,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe125: IconData(0xe124,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe13f: IconData(0xe13e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe127: IconData(0xe126,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe129: IconData(0xe128,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe12b: IconData(0xe12a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe12d: IconData(0xe12c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe137: IconData(0xe136,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe139: IconData(0xe138,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe135: IconData(0xe134,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe133: IconData(0xe132,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe131: IconData(0xe130,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe12f: IconData(0xe12e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe13b: IconData(0xe13a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe13d: IconData(0xe13c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe141: IconData(0xe140,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed39: IconData(0xed38,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed81: IconData(0xed80,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed2f: IconData(0xed2e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9d1: IconData(0xe9d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe749: IconData(0xe748,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe143: IconData(0xe142,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe145: IconData(0xe144,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe147: IconData(0xe146,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe149: IconData(0xe148,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe14d: IconData(0xe14c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe14f: IconData(0xe14e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebab: IconData(0xebaa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe767: IconData(0xe766,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe951: IconData(0xe950,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5fd: IconData(0xe5fc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5ff: IconData(0xe5fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe601: IconData(0xe600,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeacb: IconData(0xeaca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8d1: IconData(0xe8d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe151: IconData(0xe150,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe153: IconData(0xe152,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaa7: IconData(0xeaa6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe155: IconData(0xe154,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8b7: IconData(0xe8b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe157: IconData(0xe156,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe159: IconData(0xe158,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe15b: IconData(0xe15a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaa9: IconData(0xeaa8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaad: IconData(0xeaac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe15d: IconData(0xe15c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe161: IconData(0xe160,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe165: IconData(0xe164,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe163: IconData(0xe162,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe167: IconData(0xe166,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe169: IconData(0xe168,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe16d: IconData(0xe16c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe16b: IconData(0xe16a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe16f: IconData(0xe16e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe171: IconData(0xe170,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe15f: IconData(0xe15e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe173: IconData(0xe172,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe177: IconData(0xe176,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe175: IconData(0xe174,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe179: IconData(0xe178,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe17b: IconData(0xe17a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe17d: IconData(0xe17c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe17f: IconData(0xe17e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe181: IconData(0xe180,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe183: IconData(0xe182,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe185: IconData(0xe184,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeba7: IconData(0xeba6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe187: IconData(0xe186,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe189: IconData(0xe188,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8c5: IconData(0xe8c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe53b: IconData(0xe53a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea4b: IconData(0xea4a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9ff: IconData(0xe9fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed8f: IconData(0xed8e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe831: IconData(0xe830,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeceb: IconData(0xecea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed91: IconData(0xed90,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed93: IconData(0xed92,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe18b: IconData(0xe18a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe603: IconData(0xe602,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe18d: IconData(0xe18c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe18f: IconData(0xe18e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb45: IconData(0xeb44,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe191: IconData(0xe190,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe193: IconData(0xe192,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe195: IconData(0xe194,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9c3: IconData(0xe9c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea6b: IconData(0xea6a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe197: IconData(0xe196,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe199: IconData(0xe198,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe19b: IconData(0xe19a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe19d: IconData(0xe19c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe19f: IconData(0xe19e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed2d: IconData(0xed2c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1a1: IconData(0xe1a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeded: IconData(0xedec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1a5: IconData(0xe1a4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1ab: IconData(0xe1aa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1ad: IconData(0xe1ac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1af: IconData(0xe1ae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1b1: IconData(0xe1b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe53d: IconData(0xe53c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1b3: IconData(0xe1b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe53f: IconData(0xe53e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1b5: IconData(0xe1b4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1b7: IconData(0xe1b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1b9: IconData(0xe1b8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe541: IconData(0xe540,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea99: IconData(0xea98,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea97: IconData(0xea96,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedc9: IconData(0xedc8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1bb: IconData(0xe1ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7ff: IconData(0xe7fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7cf: IconData(0xe7ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1bd: IconData(0xe1bc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaff: IconData(0xeafe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1bf: IconData(0xe1be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe979: IconData(0xe978,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea07: IconData(0xea06,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1c3: IconData(0xe1c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1c1: IconData(0xe1c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe60f: IconData(0xe60e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb49: IconData(0xeb48,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe78f: IconData(0xe78e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe547: IconData(0xe546,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe545: IconData(0xe544,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe543: IconData(0xe542,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1c5: IconData(0xe1c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1c9: IconData(0xe1c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1c7: IconData(0xe1c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea0f: IconData(0xea0e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe549: IconData(0xe548,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe81b: IconData(0xe81a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed43: IconData(0xed42,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeca7: IconData(0xeca6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6cb: IconData(0xe6ca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe765: IconData(0xe764,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1cb: IconData(0xe1ca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1cd: IconData(0xe1cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe86b: IconData(0xe86a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe54b: IconData(0xe54a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1cf: IconData(0xe1ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1d1: IconData(0xe1d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7f7: IconData(0xe7f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee37: IconData(0xee36,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeabf: IconData(0xeabe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed13: IconData(0xed12,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe611: IconData(0xe610,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed4b: IconData(0xed48,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed4d: IconData(0xed49,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1d3: IconData(0xe1d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee13: IconData(0xee12,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1d5: IconData(0xe1d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8a1: IconData(0xe8a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1d7: IconData(0xe1d6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1d9: IconData(0xe1d8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe615: IconData(0xe614,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee5f: IconData(0xee5e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe617: IconData(0xe616,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1db: IconData(0xe1da,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed0b: IconData(0xed0a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec7d: IconData(0xec7c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe619: IconData(0xe618,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe54d: IconData(0xe54c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe54f: IconData(0xe54e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe551: IconData(0xe550,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe553: IconData(0xe552,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeadb: IconData(0xeada,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe555: IconData(0xe554,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe557: IconData(0xe556,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe559: IconData(0xe558,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe55b: IconData(0xe55a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe55d: IconData(0xe55c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec4d: IconData(0xec4c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb53: IconData(0xeb52,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe55f: IconData(0xe55e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1dd: IconData(0xe1dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7c9: IconData(0xe7c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7d9: IconData(0xe7d8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8fd: IconData(0xe8fc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1df: IconData(0xe1de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed17: IconData(0xed16,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe561: IconData(0xe560,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe563: IconData(0xe562,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe83f: IconData(0xe83e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed0f: IconData(0xed0e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1e1: IconData(0xe1e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1e3: IconData(0xe1e2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee47: IconData(0xee46,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1e5: IconData(0xe1e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedf3: IconData(0xedf2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1e7: IconData(0xe1e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1e9: IconData(0xe1e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1eb: IconData(0xe1ea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeba5: IconData(0xeba4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1ed: IconData(0xe1ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8f5: IconData(0xe8f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1ef: IconData(0xe1ee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1f1: IconData(0xe1f0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1f3: IconData(0xe1f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1f5: IconData(0xe1f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1f7: IconData(0xe1f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1f9: IconData(0xe1f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe565: IconData(0xe564,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed99: IconData(0xed98,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe61b: IconData(0xe61a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1fb: IconData(0xe1fa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe925: IconData(0xe924,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe74b: IconData(0xe74a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe61d: IconData(0xe61c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7e7: IconData(0xe7e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecdf: IconData(0xecde,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xece1: IconData(0xece0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1fd: IconData(0xe1fc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe795: IconData(0xe794,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeae3: IconData(0xeae2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1ff: IconData(0xe1fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe201: IconData(0xe200,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe203: IconData(0xe202,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe205: IconData(0xe204,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe207: IconData(0xe206,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe209: IconData(0xe208,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe20b: IconData(0xe20a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe20d: IconData(0xe20c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea7f: IconData(0xea7e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe94f: IconData(0xe94e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe20f: IconData(0xe20e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed75: IconData(0xed74,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe211: IconData(0xe210,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe567: IconData(0xe566,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb41: IconData(0xeb40,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee33: IconData(0xee32,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe955: IconData(0xe954,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7d1: IconData(0xe7d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe70d: IconData(0xe70c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe70f: IconData(0xe70e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe813: IconData(0xe812,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb65: IconData(0xeb64,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe213: IconData(0xe212,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6af: IconData(0xe6ae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecc1: IconData(0xecc0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedbd: IconData(0xedbc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea81: IconData(0xea80,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe215: IconData(0xe214,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe217: IconData(0xe216,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe219: IconData(0xe218,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe21b: IconData(0xe21a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebbd: IconData(0xebbc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe21d: IconData(0xe21c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe21f: IconData(0xe21e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecbb: IconData(0xecba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecbd: IconData(0xecbc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe743: IconData(0xe742,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee45: IconData(0xee44,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe883: IconData(0xe882,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe881: IconData(0xe880,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaf1: IconData(0xeaf0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe221: IconData(0xe220,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe223: IconData(0xe222,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe225: IconData(0xe224,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe569: IconData(0xe568,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeac5: IconData(0xeac4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7bb: IconData(0xe7ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee5d: IconData(0xee5c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe56b: IconData(0xe56a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe227: IconData(0xe226,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe761: IconData(0xe760,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe229: IconData(0xe228,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe22b: IconData(0xe22a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9df: IconData(0xe9de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9f3: IconData(0xe9f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec71: IconData(0xec70,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6a7: IconData(0xe6a6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe22d: IconData(0xe22c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9c1: IconData(0xe9c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed67: IconData(0xed66,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe22f: IconData(0xe22e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe231: IconData(0xe230,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb2b: IconData(0xeb2a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe233: IconData(0xe232,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe61f: IconData(0xe61e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea21: IconData(0xea20,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb36: IconData(0xeb32,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb31: IconData(0xeb30,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe95f: IconData(0xe95e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe915: IconData(0xe914,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb2f: IconData(0xeb2e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb37: IconData(0xeb34,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb1d: IconData(0xeb1c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe705: IconData(0xe704,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb1f: IconData(0xeb1e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb39: IconData(0xeb38,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea25: IconData(0xea24,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb3b: IconData(0xeb33,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb1b: IconData(0xeb1a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb25: IconData(0xeb24,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb3d: IconData(0xeb3a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe95d: IconData(0xe95c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe239: IconData(0xe238,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed51: IconData(0xed50,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe235: IconData(0xe234,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe703: IconData(0xe702,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe237: IconData(0xe236,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb19: IconData(0xeb18,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb21: IconData(0xeb20,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb2d: IconData(0xeb2c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb29: IconData(0xeb28,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed4f: IconData(0xed4e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed09: IconData(0xed08,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe23b: IconData(0xe23a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb27: IconData(0xeb26,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb3f: IconData(0xeb3c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb43: IconData(0xeb35,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea23: IconData(0xea22,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb47: IconData(0xeb3e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe23d: IconData(0xe23c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb23: IconData(0xeb22,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe959: IconData(0xe958,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe711: IconData(0xe710,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8c1: IconData(0xe8c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb51: IconData(0xeb50,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8c3: IconData(0xe8c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe793: IconData(0xe792,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe23f: IconData(0xe23e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe241: IconData(0xe240,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe56d: IconData(0xe56c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe243: IconData(0xe242,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9e9: IconData(0xe9e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe621: IconData(0xe620,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe575: IconData(0xe574,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe56f: IconData(0xe56e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe571: IconData(0xe570,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe729: IconData(0xe728,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe72b: IconData(0xe72a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe245: IconData(0xe244,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe623: IconData(0xe622,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecf3: IconData(0xecf2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea39: IconData(0xea38,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecf1: IconData(0xecf0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe625: IconData(0xe624,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe247: IconData(0xe246,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe79f: IconData(0xe79e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed6b: IconData(0xed6a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed6d: IconData(0xed6c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe249: IconData(0xe248,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaf5: IconData(0xeaf4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6ed: IconData(0xe6ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe75f: IconData(0xe75e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6cd: IconData(0xe6cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeacd: IconData(0xeacc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb4b: IconData(0xeb4a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe24b: IconData(0xe24a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8f9: IconData(0xe8f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea3d: IconData(0xea3c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe255: IconData(0xe254,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe257: IconData(0xe256,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe259: IconData(0xe258,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe25b: IconData(0xe25a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec2b: IconData(0xec2a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb5f: IconData(0xeb5e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe25d: IconData(0xe25c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe25f: IconData(0xe25e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec2f: IconData(0xec2e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb61: IconData(0xeb60,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea87: IconData(0xea86,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb4c: IconData(0xeb46,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe261: IconData(0xe260,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe719: IconData(0xe718,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee4d: IconData(0xee4c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea89: IconData(0xea88,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe263: IconData(0xe262,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea5d: IconData(0xea5c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe627: IconData(0xe626,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe265: IconData(0xe264,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebe5: IconData(0xebe4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe267: IconData(0xe266,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe269: IconData(0xe268,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe26b: IconData(0xe26a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe26d: IconData(0xe26c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe26f: IconData(0xe26e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecd7: IconData(0xecd6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8cf: IconData(0xe8ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe769: IconData(0xe768,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe629: IconData(0xe628,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea33: IconData(0xea32,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe271: IconData(0xe270,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe87d: IconData(0xe87c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe273: IconData(0xe272,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6e1: IconData(0xe6e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6e7: IconData(0xe6e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6e3: IconData(0xe6e2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6eb: IconData(0xe6ea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6e5: IconData(0xe6e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6e9: IconData(0xe6e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe62b: IconData(0xe62a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe275: IconData(0xe274,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe277: IconData(0xe276,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe279: IconData(0xe278,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe27b: IconData(0xe27a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe27d: IconData(0xe27c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe27f: IconData(0xe27e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe281: IconData(0xe280,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe283: IconData(0xe282,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe577: IconData(0xe576,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe695: IconData(0xe694,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe697: IconData(0xe696,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe289: IconData(0xe288,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe28b: IconData(0xe28a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe28d: IconData(0xe28c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe28f: IconData(0xe28e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe285: IconData(0xe284,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe291: IconData(0xe290,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe287: IconData(0xe286,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecb5: IconData(0xecb4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea3f: IconData(0xea3e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed11: IconData(0xed10,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7b7: IconData(0xe7b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe977: IconData(0xe976,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8f7: IconData(0xe8f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe293: IconData(0xe292,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb93: IconData(0xeb92,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe295: IconData(0xe294,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb95: IconData(0xeb94,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedd9: IconData(0xedd8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedd7: IconData(0xedd6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedd5: IconData(0xedd4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb4d: IconData(0xeb42,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe62d: IconData(0xe62c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec69: IconData(0xec68,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec6b: IconData(0xec6a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb59: IconData(0xeb58,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe613: IconData(0xe612,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedc5: IconData(0xedc4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeda3: IconData(0xeda2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe297: IconData(0xe296,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec8d: IconData(0xec8c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea8b: IconData(0xea8a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea67: IconData(0xea66,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe791: IconData(0xe790,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe80f: IconData(0xe80e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe299: IconData(0xe298,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea4f: IconData(0xea4e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee5b: IconData(0xee5a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea8d: IconData(0xea8c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee83: IconData(0xee82,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea4d: IconData(0xea4c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe57b: IconData(0xe57a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe57d: IconData(0xe57c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe811: IconData(0xe810,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe57f: IconData(0xe57e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7cd: IconData(0xe7cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe29b: IconData(0xe29a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe631: IconData(0xe630,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec95: IconData(0xec94,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec93: IconData(0xec92,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec91: IconData(0xec90,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe581: IconData(0xe580,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee81: IconData(0xee80,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe29d: IconData(0xe29c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe62f: IconData(0xe62e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6a1: IconData(0xe6a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecc9: IconData(0xecc8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe583: IconData(0xe582,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe29f: IconData(0xe29e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2a1: IconData(0xe2a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed47: IconData(0xed46,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2a3: IconData(0xe2a2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2a5: IconData(0xe2a4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7d5: IconData(0xe7d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6ff: IconData(0xe6fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2a7: IconData(0xe2a6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe585: IconData(0xe584,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2a9: IconData(0xe2a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebe9: IconData(0xebe8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec49: IconData(0xec48,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2ab: IconData(0xe2aa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb99: IconData(0xeb98,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2ad: IconData(0xe2ac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2af: IconData(0xe2ae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea8f: IconData(0xea8e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8e9: IconData(0xe8e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec77: IconData(0xec76,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe633: IconData(0xe632,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec87: IconData(0xec86,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecd1: IconData(0xecd0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2b1: IconData(0xe2b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe845: IconData(0xe844,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2b3: IconData(0xe2b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2b5: IconData(0xe2b4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2b7: IconData(0xe2b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2b9: IconData(0xe2b8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2bb: IconData(0xe2ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2bd: IconData(0xe2bc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2bf: IconData(0xe2be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2c1: IconData(0xe2c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2c3: IconData(0xe2c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2c5: IconData(0xe2c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2c7: IconData(0xe2c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe88f: IconData(0xe88e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe805: IconData(0xe804,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6f7: IconData(0xe6f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2c9: IconData(0xe2c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2cb: IconData(0xe2ca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7a9: IconData(0xe7a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2cd: IconData(0xe2cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe837: IconData(0xe836,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe835: IconData(0xe834,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe635: IconData(0xe634,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2cf: IconData(0xe2ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2d1: IconData(0xe2d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2d3: IconData(0xe2d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe87b: IconData(0xe87a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecc5: IconData(0xecc4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedbb: IconData(0xedba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee43: IconData(0xee42,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee07: IconData(0xee06,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7e3: IconData(0xe7e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7e5: IconData(0xe7e1,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2d5: IconData(0xe2d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea5f: IconData(0xea5e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb55: IconData(0xeb54,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2d7: IconData(0xe2d6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe783: IconData(0xe782,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2d9: IconData(0xe2d8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea79: IconData(0xea78,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe637: IconData(0xe636,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9e5: IconData(0xe9e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec27: IconData(0xec26,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe639: IconData(0xe638,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee2f: IconData(0xee2e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe587: IconData(0xe586,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedc7: IconData(0xedc6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe843: IconData(0xe842,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6d7: IconData(0xe6d6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2db: IconData(0xe2da,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe95b: IconData(0xe95a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8c8: IconData(0xe8c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8c9: IconData(0xe8c7,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedad: IconData(0xedac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeda5: IconData(0xeda4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebf9: IconData(0xebf8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec09: IconData(0xec08,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec15: IconData(0xec14,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe63b: IconData(0xe63a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2dd: IconData(0xe2dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe63d: IconData(0xe63c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9f7: IconData(0xe9f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2df: IconData(0xe2de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea85: IconData(0xea84,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2e1: IconData(0xe2e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6d3: IconData(0xe6d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6d5: IconData(0xe6d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed71: IconData(0xed70,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2e3: IconData(0xe2e2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2e5: IconData(0xe2e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2e7: IconData(0xe2e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2e9: IconData(0xe2e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2eb: IconData(0xe2ea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2ed: IconData(0xe2ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2ef: IconData(0xe2ee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedef: IconData(0xedee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb03: IconData(0xeb02,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2f1: IconData(0xe2f0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2f3: IconData(0xe2f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeadd: IconData(0xeadc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2f5: IconData(0xe2f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebdf: IconData(0xebde,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebe1: IconData(0xebe0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2f7: IconData(0xe2f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2f9: IconData(0xe2f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebdd: IconData(0xebdc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2fb: IconData(0xe2fa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe2ff: IconData(0xe2fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe301: IconData(0xe300,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe303: IconData(0xe302,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe305: IconData(0xe304,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe307: IconData(0xe306,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe309: IconData(0xe308,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe30b: IconData(0xe30a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecb9: IconData(0xecb8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed83: IconData(0xed82,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6b7: IconData(0xe6b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe681: IconData(0xe680,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe683: IconData(0xe682,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe30d: IconData(0xe30c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe30f: IconData(0xe30e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe311: IconData(0xe310,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec1f: IconData(0xec1e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe317: IconData(0xe316,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee3b: IconData(0xee3a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe319: IconData(0xe318,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe315: IconData(0xe314,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee3f: IconData(0xee3e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee3d: IconData(0xee3c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee39: IconData(0xee38,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe31b: IconData(0xe31a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe509: IconData(0xe508,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe641: IconData(0xe640,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe31d: IconData(0xe31c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9f5: IconData(0xe9f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb9f: IconData(0xeb9e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed69: IconData(0xed68,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe31f: IconData(0xe31e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed65: IconData(0xed64,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe321: IconData(0xe320,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecfd: IconData(0xecfc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe323: IconData(0xe322,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe325: IconData(0xe324,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe643: IconData(0xe642,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedc3: IconData(0xedc2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9c5: IconData(0xe9c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6d9: IconData(0xe6d8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed03: IconData(0xed02,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9bb: IconData(0xe9ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec8f: IconData(0xec8e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe327: IconData(0xe326,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe329: IconData(0xe328,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe75d: IconData(0xe75c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec7b: IconData(0xec7a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb6d: IconData(0xeb6c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb71: IconData(0xeb70,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeacf: IconData(0xeace,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb67: IconData(0xeb66,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb6b: IconData(0xeb6a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe32b: IconData(0xe32a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe32d: IconData(0xe32c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed53: IconData(0xed4c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe589: IconData(0xe588,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee69: IconData(0xee68,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe32f: IconData(0xe32e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe58b: IconData(0xe58a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe58d: IconData(0xe58c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe331: IconData(0xe330,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe58f: IconData(0xe58e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe825: IconData(0xe824,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe823: IconData(0xe822,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecef: IconData(0xecee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe80b: IconData(0xe80a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7af: IconData(0xe7ae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe33b: IconData(0xe33a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe335: IconData(0xe334,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe339: IconData(0xe338,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe337: IconData(0xe336,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe333: IconData(0xe332,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe645: IconData(0xe644,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe33d: IconData(0xe33c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe33f: IconData(0xe33e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe341: IconData(0xe340,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee0d: IconData(0xee0c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb7d: IconData(0xeb7c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe343: IconData(0xe342,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeadf: IconData(0xeade,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe82f: IconData(0xe82e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeddf: IconData(0xedde,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeddd: IconData(0xeddc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeddb: IconData(0xedda,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe345: IconData(0xe344,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe347: IconData(0xe346,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeda7: IconData(0xeda6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedaf: IconData(0xedae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedb1: IconData(0xedb0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedb3: IconData(0xedb2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed3b: IconData(0xed3a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe349: IconData(0xe348,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe34b: IconData(0xe34a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe34d: IconData(0xe34c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe34f: IconData(0xe34e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe63f: IconData(0xe63e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6fb: IconData(0xe6fa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9a1: IconData(0xe9a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed7d: IconData(0xed7c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe353: IconData(0xe352,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe359: IconData(0xe358,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe35f: IconData(0xe35e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe365: IconData(0xe364,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe36b: IconData(0xe36a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe371: IconData(0xe370,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe377: IconData(0xe376,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe37d: IconData(0xe37c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe383: IconData(0xe382,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe389: IconData(0xe388,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe351: IconData(0xe350,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe357: IconData(0xe356,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe35d: IconData(0xe35c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe363: IconData(0xe362,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe369: IconData(0xe368,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe36f: IconData(0xe36e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe375: IconData(0xe374,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe355: IconData(0xe354,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe35b: IconData(0xe35a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe361: IconData(0xe360,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe367: IconData(0xe366,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe36d: IconData(0xe36c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe373: IconData(0xe372,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe379: IconData(0xe378,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe37f: IconData(0xe37e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe385: IconData(0xe384,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe38b: IconData(0xe38a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe37b: IconData(0xe37a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe381: IconData(0xe380,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe387: IconData(0xe386,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3c9: IconData(0xe3c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe38d: IconData(0xe38c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe647: IconData(0xe646,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe38f: IconData(0xe38e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea47: IconData(0xea46,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee2d: IconData(0xee2c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7d3: IconData(0xe7d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8a9: IconData(0xe8a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee41: IconData(0xee40,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed37: IconData(0xed36,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed8d: IconData(0xed8c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe391: IconData(0xe390,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6f1: IconData(0xe6f0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe591: IconData(0xe590,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6f3: IconData(0xe6f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe393: IconData(0xe392,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6f5: IconData(0xe6f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6c9: IconData(0xe6c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaa3: IconData(0xeaa2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec89: IconData(0xec88,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe395: IconData(0xe394,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe397: IconData(0xe396,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe399: IconData(0xe398,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe39b: IconData(0xe39a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe593: IconData(0xe592,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea7d: IconData(0xea7c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe961: IconData(0xe960,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecc7: IconData(0xecc6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecb3: IconData(0xecb2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe753: IconData(0xe752,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe39d: IconData(0xe39c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe98b: IconData(0xe98a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe39f: IconData(0xe39e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3a1: IconData(0xe3a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe649: IconData(0xe648,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe98d: IconData(0xe98c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3a3: IconData(0xe3a2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3ab: IconData(0xe3aa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3ad: IconData(0xe3ac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe64b: IconData(0xe64a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3af: IconData(0xe3ae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3b1: IconData(0xe3b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3b3: IconData(0xe3b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe907: IconData(0xe906,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3b5: IconData(0xe3b4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebc7: IconData(0xebc6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecf7: IconData(0xecf6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecf9: IconData(0xecf8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec7f: IconData(0xec7e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec5d: IconData(0xec5c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe94b: IconData(0xe94a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3b7: IconData(0xe3b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3a9: IconData(0xe3a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecff: IconData(0xecfe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe72f: IconData(0xe72e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe735: IconData(0xe734,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee59: IconData(0xee58,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed55: IconData(0xed54,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe731: IconData(0xe730,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe71d: IconData(0xe71c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe71f: IconData(0xe71e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe737: IconData(0xe736,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed5d: IconData(0xed5c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe733: IconData(0xe732,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe73b: IconData(0xe73a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebe7: IconData(0xebe6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3b9: IconData(0xe3b8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3bb: IconData(0xe3ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3bd: IconData(0xe3bc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3bf: IconData(0xe3be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3cd: IconData(0xe3cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3c1: IconData(0xe3c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3cb: IconData(0xe3ca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec57: IconData(0xec56,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3c3: IconData(0xe3c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3c7: IconData(0xe3c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3c5: IconData(0xe3c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3cf: IconData(0xe3ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec81: IconData(0xec80,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9c9: IconData(0xe9c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee27: IconData(0xee26,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe64d: IconData(0xe64c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea05: IconData(0xea04,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe701: IconData(0xe700,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea43: IconData(0xea42,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedd1: IconData(0xedd0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe64f: IconData(0xe64e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb9d: IconData(0xeb9c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed87: IconData(0xed86,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed89: IconData(0xed88,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecc3: IconData(0xecc2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe797: IconData(0xe796,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe651: IconData(0xe650,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe653: IconData(0xe652,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebaf: IconData(0xebae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3d1: IconData(0xe3d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3d3: IconData(0xe3d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8bf: IconData(0xe8be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6ab: IconData(0xe6aa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe947: IconData(0xe946,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb5d: IconData(0xeb5c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb57: IconData(0xeb56,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb5b: IconData(0xeb5a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3d5: IconData(0xe3d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3d7: IconData(0xe3d6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3d9: IconData(0xe3d8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed56: IconData(0xed4a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe595: IconData(0xe594,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec4b: IconData(0xec4a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6d1: IconData(0xe6d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb4f: IconData(0xeb4e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebbf: IconData(0xebbe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec23: IconData(0xec22,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3db: IconData(0xe3da,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7a3: IconData(0xe7a2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe655: IconData(0xe654,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe657: IconData(0xe656,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3dd: IconData(0xe3dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3df: IconData(0xe3de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3e1: IconData(0xe3e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe659: IconData(0xe658,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe65b: IconData(0xe65a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe001: IconData(0xe000,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3e3: IconData(0xe3e2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe65d: IconData(0xe65c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe65f: IconData(0xe65e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3e5: IconData(0xe3e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe597: IconData(0xe596,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3e7: IconData(0xe3e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3eb: IconData(0xe3e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3ed: IconData(0xe3e9,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6ad: IconData(0xe6ac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe661: IconData(0xe660,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeac3: IconData(0xeac2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee03: IconData(0xee02,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3ef: IconData(0xe3ea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe77f: IconData(0xe77e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb09: IconData(0xeb08,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9dd: IconData(0xe9dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe599: IconData(0xe598,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe59b: IconData(0xe59a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed63: IconData(0xed62,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed0d: IconData(0xed0c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3f1: IconData(0xe3ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed41: IconData(0xed40,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3f3: IconData(0xe3ee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3f5: IconData(0xe3f0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3f7: IconData(0xe3f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe75b: IconData(0xe75a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe59d: IconData(0xe59c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3f9: IconData(0xe3f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3fb: IconData(0xe3f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb8b: IconData(0xeb8a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed6f: IconData(0xed6e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6a9: IconData(0xe6a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3fd: IconData(0xe3fa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe839: IconData(0xe838,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe763: IconData(0xe762,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe3ff: IconData(0xe3fc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe401: IconData(0xe3fe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5a3: IconData(0xe5a2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe59f: IconData(0xe59e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5a1: IconData(0xe5a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe403: IconData(0xe400,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe405: IconData(0xe402,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea1b: IconData(0xea1a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6b9: IconData(0xe6b8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe78b: IconData(0xe78a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe751: IconData(0xe750,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebb7: IconData(0xebb6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebb5: IconData(0xebb4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeae1: IconData(0xeae0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe821: IconData(0xe820,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe407: IconData(0xe404,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe86f: IconData(0xe86e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe807: IconData(0xe806,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe663: IconData(0xe662,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb7b: IconData(0xeb7a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe605: IconData(0xe604,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe607: IconData(0xe606,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe60b: IconData(0xe60a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe609: IconData(0xe608,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe60d: IconData(0xe60c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb8f: IconData(0xeb8e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedff: IconData(0xedfe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeca5: IconData(0xeca4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe69b: IconData(0xe69a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe747: IconData(0xe746,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaf9: IconData(0xeaf8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaf7: IconData(0xeaf6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe745: IconData(0xe744,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe69d: IconData(0xe69c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe69f: IconData(0xe69e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec5f: IconData(0xec5e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe409: IconData(0xe406,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed57: IconData(0xed52,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe40b: IconData(0xe408,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe40d: IconData(0xe40a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe40f: IconData(0xe40c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe709: IconData(0xe708,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe411: IconData(0xe40e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe707: IconData(0xe706,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe413: IconData(0xe410,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec35: IconData(0xec34,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe414: IconData(0xe412,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe78d: IconData(0xe78c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea93: IconData(0xea92,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecfb: IconData(0xecfa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe417: IconData(0xe416,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe419: IconData(0xe418,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe41f: IconData(0xe41e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe421: IconData(0xe420,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9e7: IconData(0xe9e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe777: IconData(0xe776,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeab5: IconData(0xeab4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe423: IconData(0xe422,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe425: IconData(0xe424,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe427: IconData(0xe426,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeab7: IconData(0xeab6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec25: IconData(0xec24,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeab9: IconData(0xeab8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe429: IconData(0xe428,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe42b: IconData(0xe42a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebad: IconData(0xebac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe89d: IconData(0xe89c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe665: IconData(0xe664,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9b9: IconData(0xe9b8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe42d: IconData(0xe42c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5a5: IconData(0xe5a4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe42f: IconData(0xe42e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5a7: IconData(0xe5a6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe431: IconData(0xe430,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe917: IconData(0xe916,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8dd: IconData(0xe8dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5a9: IconData(0xe5a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe433: IconData(0xe432,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe435: IconData(0xe434,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed33: IconData(0xed32,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe437: IconData(0xe436,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec63: IconData(0xec62,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe439: IconData(0xe438,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe43b: IconData(0xe43a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee57: IconData(0xee56,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe43d: IconData(0xe43c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe43f: IconData(0xe43e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe441: IconData(0xe440,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe667: IconData(0xe666,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe443: IconData(0xe442,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe669: IconData(0xe668,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe80d: IconData(0xe80c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed61: IconData(0xed60,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5ab: IconData(0xe5aa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe717: IconData(0xe716,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeccf: IconData(0xecce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed7e: IconData(0xed7a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed7f: IconData(0xed7b,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe445: IconData(0xe444,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe447: IconData(0xe446,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8df: IconData(0xe8de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe449: IconData(0xe448,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6a3: IconData(0xe6a2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea09: IconData(0xea08,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe44b: IconData(0xe44a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe44d: IconData(0xe44c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe44f: IconData(0xe44e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe451: IconData(0xe450,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe453: IconData(0xe452,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe455: IconData(0xe454,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe457: IconData(0xe456,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe459: IconData(0xe458,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe45b: IconData(0xe45a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe45d: IconData(0xe45c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee75: IconData(0xee74,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee67: IconData(0xee66,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe66b: IconData(0xe66a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee29: IconData(0xee28,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe66d: IconData(0xe66c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9fb: IconData(0xe9fa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe873: IconData(0xe872,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe877: IconData(0xe876,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe66f: IconData(0xe66e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7e8: IconData(0xe7e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe45f: IconData(0xe45e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe463: IconData(0xe462,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb17: IconData(0xeb16,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe691: IconData(0xe690,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe871: IconData(0xe870,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe875: IconData(0xe874,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe465: IconData(0xe464,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe467: IconData(0xe466,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedf5: IconData(0xedf4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb79: IconData(0xeb78,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedf7: IconData(0xedf6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe469: IconData(0xe468,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8ed: IconData(0xe8ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea49: IconData(0xea48,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea91: IconData(0xea90,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe46b: IconData(0xe46a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecf5: IconData(0xecf4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6a5: IconData(0xe6a4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe70b: IconData(0xe70a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe89f: IconData(0xe89e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xead5: IconData(0xead4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9ad: IconData(0xe9ac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecbf: IconData(0xecbe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7eb: IconData(0xe7ea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5ad: IconData(0xe5ac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea45: IconData(0xea44,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe46d: IconData(0xe46c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe46f: IconData(0xe46e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe471: IconData(0xe470,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea3b: IconData(0xea3a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe699: IconData(0xe698,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe73f: IconData(0xe73e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedc1: IconData(0xedc0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedb7: IconData(0xedb6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1a9: IconData(0xe1a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe1a7: IconData(0xe1a6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebd7: IconData(0xebd6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xebd5: IconData(0xebd4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe499: IconData(0xe498,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5af: IconData(0xe5ae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9b1: IconData(0xe9b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5b1: IconData(0xe5b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe473: IconData(0xe472,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe475: IconData(0xe474,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5b7: IconData(0xe5b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe817: IconData(0xe816,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedb9: IconData(0xedb8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedb5: IconData(0xedb4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe83d: IconData(0xe83c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5b9: IconData(0xe5b8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecb7: IconData(0xecb6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5bb: IconData(0xe5ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeced: IconData(0xecec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe969: IconData(0xe968,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe671: IconData(0xe670,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe477: IconData(0xe476,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe779: IconData(0xe778,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe479: IconData(0xe478,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe673: IconData(0xe672,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe47b: IconData(0xe47a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe47d: IconData(0xe47c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe903: IconData(0xe902,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8e7: IconData(0xe8e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5bd: IconData(0xe5bc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe755: IconData(0xe754,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeae7: IconData(0xeae6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe721: IconData(0xe720,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8bb: IconData(0xe8ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe47f: IconData(0xe47e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeae9: IconData(0xeae8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7a1: IconData(0xe7a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed35: IconData(0xed34,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6ef: IconData(0xe6ee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe481: IconData(0xe480,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe483: IconData(0xe482,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe485: IconData(0xe484,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe487: IconData(0xe486,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5bf: IconData(0xe5be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec97: IconData(0xec96,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6bb: IconData(0xe6ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6c5: IconData(0xe6c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6c3: IconData(0xe6c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6bd: IconData(0xe6bc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6c7: IconData(0xe6c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6c1: IconData(0xe6c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6bf: IconData(0xe6be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea1f: IconData(0xea1e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5c1: IconData(0xe5c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea1d: IconData(0xea1c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5c3: IconData(0xe5c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec99: IconData(0xec98,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec9b: IconData(0xec9a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe48b: IconData(0xe48a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe489: IconData(0xe488,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5c5: IconData(0xe5c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeb0b: IconData(0xeb0a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5c7: IconData(0xe5c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5c9: IconData(0xe5c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5cb: IconData(0xe5ca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5cd: IconData(0xe5cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed9f: IconData(0xed9e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea5b: IconData(0xea5a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe48d: IconData(0xe48c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe48f: IconData(0xe48e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe491: IconData(0xe490,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed1d: IconData(0xed1c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaf3: IconData(0xeaf2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeda9: IconData(0xeda8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe493: IconData(0xe492,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7e9: IconData(0xe7e2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed31: IconData(0xed30,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedd3: IconData(0xedd2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe675: IconData(0xe674,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe677: IconData(0xe676,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe79b: IconData(0xe79a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe79d: IconData(0xe79c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeca1: IconData(0xeca0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9cd: IconData(0xe9cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe88d: IconData(0xe88c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe495: IconData(0xe494,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe679: IconData(0xe678,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xede7: IconData(0xede6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec6f: IconData(0xec6e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9f1: IconData(0xe9f0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe415: IconData(0xe3f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9a9: IconData(0xe9a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe67b: IconData(0xe67a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9ab: IconData(0xe9aa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe497: IconData(0xe496,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe49f: IconData(0xe49e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4a1: IconData(0xe4a0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9ed: IconData(0xe9ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4a3: IconData(0xe4a2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4a7: IconData(0xe4a6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4a9: IconData(0xe4a8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4ab: IconData(0xe4aa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe011: IconData(0xe010,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee53: IconData(0xee52,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xede3: IconData(0xede2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6db: IconData(0xe6da,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6dd: IconData(0xe6dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe91b: IconData(0xe91a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe67d: IconData(0xe67c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee49: IconData(0xee48,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4ad: IconData(0xe4ac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4af: IconData(0xe4ae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4b1: IconData(0xe4b0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4b3: IconData(0xe4b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5b3: IconData(0xe5b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5b5: IconData(0xe5b4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe67f: IconData(0xe67e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4b5: IconData(0xe4b4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4b7: IconData(0xe4b6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8d5: IconData(0xe8d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5cf: IconData(0xe5ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4bb: IconData(0xe4ba,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe685: IconData(0xe684,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe687: IconData(0xe686,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedbf: IconData(0xedbe,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe87f: IconData(0xe87e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe879: IconData(0xe878,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4bf: IconData(0xe4be,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4c1: IconData(0xe4c0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe957: IconData(0xe956,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4c3: IconData(0xe4c2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeafb: IconData(0xeafa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4c5: IconData(0xe4c4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec39: IconData(0xec38,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xec37: IconData(0xec36,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4c7: IconData(0xe4c6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4c9: IconData(0xe4c8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4cb: IconData(0xe4ca,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6fd: IconData(0xe6fc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4cd: IconData(0xe4cc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe73d: IconData(0xe73c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4cf: IconData(0xe4ce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4d1: IconData(0xe4d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4d3: IconData(0xe4d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeca9: IconData(0xeca8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4d5: IconData(0xe4d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe757: IconData(0xe756,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4d7: IconData(0xe4d6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe68d: IconData(0xe68c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe68f: IconData(0xe68e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe827: IconData(0xe826,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe76f: IconData(0xe76e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee63: IconData(0xee62,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee65: IconData(0xee64,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4d9: IconData(0xe4d8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe741: IconData(0xe740,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4db: IconData(0xe4da,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4dd: IconData(0xe4dc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xedcf: IconData(0xedce,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeba3: IconData(0xeba2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecad: IconData(0xecac,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7b9: IconData(0xe7b8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7d7: IconData(0xe7d6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xee2b: IconData(0xee2a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4df: IconData(0xe4de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe727: IconData(0xe726,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe689: IconData(0xe688,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe68b: IconData(0xe68a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecd5: IconData(0xecd4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4e1: IconData(0xe4e0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4e3: IconData(0xe4e2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe7fd: IconData(0xe7fc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4e5: IconData(0xe4e4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xede9: IconData(0xede8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4e7: IconData(0xe4e6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea9d: IconData(0xea9c,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea9b: IconData(0xea9a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xea9f: IconData(0xea9e,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xeaa1: IconData(0xeaa0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe803: IconData(0xe802,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe801: IconData(0xe800,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6df: IconData(0xe6de,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9b3: IconData(0xe9b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecdd: IconData(0xecdc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xecaf: IconData(0xecae,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe8d3: IconData(0xe8d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5d1: IconData(0xe5d0,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4e9: IconData(0xe4e8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe89b: IconData(0xe89a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4eb: IconData(0xe4ea,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4ed: IconData(0xe4ec,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4ef: IconData(0xe4ee,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4f3: IconData(0xe4f2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4f5: IconData(0xe4f4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5d3: IconData(0xe5d2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe9f9: IconData(0xe9f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe693: IconData(0xe692,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe6b3: IconData(0xe6b2,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe5d5: IconData(0xe5d4,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4f7: IconData(0xe4f6,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4f9: IconData(0xe4f8,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4bd: IconData(0xe4bc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4fb: IconData(0xe4fa,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xed9b: IconData(0xed9a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe92b: IconData(0xe92a,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+    0xe4fd: IconData(0xe4fc,
+        fontFamily: _f, fontPackage: _p, matchTextDirection: true),
+  };
 }

--- a/lib/src/phosphor_icons_fill.dart
+++ b/lib/src/phosphor_icons_fill.dart
@@ -1,4547 +1,6060 @@
 // Auto generated File
 // DON'T EDIT BY HAND
 
-import 'package:phosphor_flutter/src/phosphor_icon_data.dart';
 import 'package:flutter/widgets.dart';
+
+const String _f = 'PhosphorFill';
+const String _p = 'phosphor_flutter';
 
 @staticIconProvider
 class PhosphorIconsFill {
   const PhosphorIconsFill();
 
   /// ![acorn-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/acorn-fill.svg)
-  static const acorn = PhosphorFlatIconData(0xeb9a, 'Fill');
+  static const acorn = IconData(0xeb9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/address-book-fill.svg)
-  static const addressBook = PhosphorFlatIconData(0xe6f8, 'Fill');
+  static const addressBook = IconData(0xe6f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-tabs-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/address-book-tabs-fill.svg)
-  static const addressBookTabs = PhosphorFlatIconData(0xee4e, 'Fill');
+  static const addressBookTabs = IconData(0xee4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![air-traffic-control-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/air-traffic-control-fill.svg)
-  static const airTrafficControl = PhosphorFlatIconData(0xecd8, 'Fill');
+  static const airTrafficControl = IconData(0xecd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/airplane-fill.svg)
-  static const airplane = PhosphorFlatIconData(0xe002, 'Fill');
+  static const airplane = IconData(0xe002,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-in-flight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/airplane-in-flight-fill.svg)
-  static const airplaneInFlight = PhosphorFlatIconData(0xe4fe, 'Fill');
+  static const airplaneInFlight = IconData(0xe4fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-landing-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/airplane-landing-fill.svg)
-  static const airplaneLanding = PhosphorFlatIconData(0xe502, 'Fill');
+  static const airplaneLanding = IconData(0xe502,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-takeoff-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/airplane-takeoff-fill.svg)
-  static const airplaneTakeoff = PhosphorFlatIconData(0xe504, 'Fill');
+  static const airplaneTakeoff = IconData(0xe504,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-taxiing-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/airplane-taxiing-fill.svg)
-  static const airplaneTaxiing = PhosphorFlatIconData(0xe500, 'Fill');
+  static const airplaneTaxiing = IconData(0xe500,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-tilt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/airplane-tilt-fill.svg)
-  static const airplaneTilt = PhosphorFlatIconData(0xe5d6, 'Fill');
+  static const airplaneTilt = IconData(0xe5d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplay-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/airplay-fill.svg)
-  static const airplay = PhosphorFlatIconData(0xe004, 'Fill');
+  static const airplay = IconData(0xe004,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alarm-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/alarm-fill.svg)
-  static const alarm = PhosphorFlatIconData(0xe006, 'Fill');
+  static const alarm = IconData(0xe006,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alien-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/alien-fill.svg)
-  static const alien = PhosphorFlatIconData(0xe8a6, 'Fill');
+  static const alien = IconData(0xe8a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-bottom-fill.svg)
-  static const alignBottom = PhosphorFlatIconData(0xe506, 'Fill');
+  static const alignBottom = IconData(0xe506,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-bottom-simple-fill.svg)
-  static const alignBottomSimple = PhosphorFlatIconData(0xeb0c, 'Fill');
+  static const alignBottomSimple = IconData(0xeb0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-center-horizontal-fill.svg)
-  static const alignCenterHorizontal = PhosphorFlatIconData(0xe50a, 'Fill');
+  static const alignCenterHorizontal = IconData(0xe50a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-center-horizontal-simple-fill.svg)
-  static const alignCenterHorizontalSimple =
-      PhosphorFlatIconData(0xeb0e, 'Fill');
+  static const alignCenterHorizontalSimple = IconData(0xeb0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-center-vertical-fill.svg)
-  static const alignCenterVertical = PhosphorFlatIconData(0xe50c, 'Fill');
+  static const alignCenterVertical = IconData(0xe50c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-center-vertical-simple-fill.svg)
-  static const alignCenterVerticalSimple = PhosphorFlatIconData(0xeb10, 'Fill');
+  static const alignCenterVerticalSimple = IconData(0xeb10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-left-fill.svg)
-  static const alignLeft = PhosphorFlatIconData(0xe50e, 'Fill');
+  static const alignLeft = IconData(0xe50e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-left-simple-fill.svg)
-  static const alignLeftSimple = PhosphorFlatIconData(0xeaee, 'Fill');
+  static const alignLeftSimple = IconData(0xeaee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-right-fill.svg)
-  static const alignRight = PhosphorFlatIconData(0xe510, 'Fill');
+  static const alignRight = IconData(0xe510,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-right-simple-fill.svg)
-  static const alignRightSimple = PhosphorFlatIconData(0xeb12, 'Fill');
+  static const alignRightSimple = IconData(0xeb12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-top-fill.svg)
-  static const alignTop = PhosphorFlatIconData(0xe512, 'Fill');
+  static const alignTop = IconData(0xe512,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/align-top-simple-fill.svg)
-  static const alignTopSimple = PhosphorFlatIconData(0xeb14, 'Fill');
+  static const alignTopSimple = IconData(0xeb14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![amazon-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/amazon-logo-fill.svg)
-  static const amazonLogo = PhosphorFlatIconData(0xe96c, 'Fill');
+  static const amazonLogo = IconData(0xe96c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ambulance-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ambulance-fill.svg)
-  static const ambulance = PhosphorFlatIconData(0xe572, 'Fill');
+  static const ambulance = IconData(0xe572,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/anchor-fill.svg)
-  static const anchor = PhosphorFlatIconData(0xe514, 'Fill');
+  static const anchor = IconData(0xe514,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/anchor-simple-fill.svg)
-  static const anchorSimple = PhosphorFlatIconData(0xe5d8, 'Fill');
+  static const anchorSimple = IconData(0xe5d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![android-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/android-logo-fill.svg)
-  static const androidLogo = PhosphorFlatIconData(0xe008, 'Fill');
+  static const androidLogo = IconData(0xe008,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/angle-fill.svg)
-  static const angle = PhosphorFlatIconData(0xe7bc, 'Fill');
+  static const angle = IconData(0xe7bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angular-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/angular-logo-fill.svg)
-  static const angularLogo = PhosphorFlatIconData(0xeb80, 'Fill');
+  static const angularLogo = IconData(0xeb80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![aperture-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/aperture-fill.svg)
-  static const aperture = PhosphorFlatIconData(0xe00a, 'Fill');
+  static const aperture = IconData(0xe00a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-store-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/app-store-logo-fill.svg)
-  static const appStoreLogo = PhosphorFlatIconData(0xe974, 'Fill');
+  static const appStoreLogo = IconData(0xe974,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-window-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/app-window-fill.svg)
-  static const appWindow = PhosphorFlatIconData(0xe5da, 'Fill');
+  static const appWindow = IconData(0xe5da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/apple-logo-fill.svg)
-  static const appleLogo = PhosphorFlatIconData(0xe516, 'Fill');
+  static const appleLogo = IconData(0xe516,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-podcasts-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/apple-podcasts-logo-fill.svg)
-  static const applePodcastsLogo = PhosphorFlatIconData(0xeb96, 'Fill');
+  static const applePodcastsLogo = IconData(0xeb96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![approximate-equals-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/approximate-equals-fill.svg)
-  static const approximateEquals = PhosphorFlatIconData(0xedaa, 'Fill');
+  static const approximateEquals = IconData(0xedaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![archive-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/archive-fill.svg)
-  static const archive = PhosphorFlatIconData(0xe00c, 'Fill');
+  static const archive = IconData(0xe00c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![armchair-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/armchair-fill.svg)
-  static const armchair = PhosphorFlatIconData(0xe012, 'Fill');
+  static const armchair = IconData(0xe012,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-arc-left-fill.svg)
-  static const arrowArcLeft = PhosphorFlatIconData(0xe014, 'Fill');
+  static const arrowArcLeft = IconData(0xe014,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-arc-right-fill.svg)
-  static const arrowArcRight = PhosphorFlatIconData(0xe016, 'Fill');
+  static const arrowArcRight = IconData(0xe016,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-double-up-left-fill.svg)
-  static const arrowBendDoubleUpLeft = PhosphorFlatIconData(0xe03a, 'Fill');
+  static const arrowBendDoubleUpLeft = IconData(0xe03a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-double-up-right-fill.svg)
-  static const arrowBendDoubleUpRight = PhosphorFlatIconData(0xe03c, 'Fill');
+  static const arrowBendDoubleUpRight = IconData(0xe03c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-down-left-fill.svg)
-  static const arrowBendDownLeft = PhosphorFlatIconData(0xe018, 'Fill');
+  static const arrowBendDownLeft = IconData(0xe018,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-down-right-fill.svg)
-  static const arrowBendDownRight = PhosphorFlatIconData(0xe01a, 'Fill');
+  static const arrowBendDownRight = IconData(0xe01a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-left-down-fill.svg)
-  static const arrowBendLeftDown = PhosphorFlatIconData(0xe01c, 'Fill');
+  static const arrowBendLeftDown = IconData(0xe01c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-left-up-fill.svg)
-  static const arrowBendLeftUp = PhosphorFlatIconData(0xe01e, 'Fill');
+  static const arrowBendLeftUp = IconData(0xe01e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-right-down-fill.svg)
-  static const arrowBendRightDown = PhosphorFlatIconData(0xe020, 'Fill');
+  static const arrowBendRightDown = IconData(0xe020,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-right-up-fill.svg)
-  static const arrowBendRightUp = PhosphorFlatIconData(0xe022, 'Fill');
+  static const arrowBendRightUp = IconData(0xe022,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-up-left-fill.svg)
-  static const arrowBendUpLeft = PhosphorFlatIconData(0xe024, 'Fill');
+  static const arrowBendUpLeft = IconData(0xe024,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-bend-up-right-fill.svg)
-  static const arrowBendUpRight = PhosphorFlatIconData(0xe026, 'Fill');
+  static const arrowBendUpRight = IconData(0xe026,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-circle-down-fill.svg)
-  static const arrowCircleDown = PhosphorFlatIconData(0xe028, 'Fill');
+  static const arrowCircleDown = IconData(0xe028,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-circle-down-left-fill.svg)
-  static const arrowCircleDownLeft = PhosphorFlatIconData(0xe02a, 'Fill');
+  static const arrowCircleDownLeft = IconData(0xe02a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-circle-down-right-fill.svg)
-  static const arrowCircleDownRight = PhosphorFlatIconData(0xe02c, 'Fill');
+  static const arrowCircleDownRight = IconData(0xe02c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-circle-left-fill.svg)
-  static const arrowCircleLeft = PhosphorFlatIconData(0xe05a, 'Fill');
+  static const arrowCircleLeft = IconData(0xe05a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-circle-right-fill.svg)
-  static const arrowCircleRight = PhosphorFlatIconData(0xe02e, 'Fill');
+  static const arrowCircleRight = IconData(0xe02e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-circle-up-fill.svg)
-  static const arrowCircleUp = PhosphorFlatIconData(0xe030, 'Fill');
+  static const arrowCircleUp = IconData(0xe030,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-circle-up-left-fill.svg)
-  static const arrowCircleUpLeft = PhosphorFlatIconData(0xe032, 'Fill');
+  static const arrowCircleUpLeft = IconData(0xe032,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-circle-up-right-fill.svg)
-  static const arrowCircleUpRight = PhosphorFlatIconData(0xe034, 'Fill');
+  static const arrowCircleUpRight = IconData(0xe034,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-clockwise-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-clockwise-fill.svg)
-  static const arrowClockwise = PhosphorFlatIconData(0xe036, 'Fill');
+  static const arrowClockwise = IconData(0xe036,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-counter-clockwise-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-counter-clockwise-fill.svg)
-  static const arrowCounterClockwise = PhosphorFlatIconData(0xe038, 'Fill');
+  static const arrowCounterClockwise = IconData(0xe038,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-down-fill.svg)
-  static const arrowDown = PhosphorFlatIconData(0xe03e, 'Fill');
+  static const arrowDown = IconData(0xe03e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-down-left-fill.svg)
-  static const arrowDownLeft = PhosphorFlatIconData(0xe040, 'Fill');
+  static const arrowDownLeft = IconData(0xe040,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-down-right-fill.svg)
-  static const arrowDownRight = PhosphorFlatIconData(0xe042, 'Fill');
+  static const arrowDownRight = IconData(0xe042,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-down-left-fill.svg)
-  static const arrowElbowDownLeft = PhosphorFlatIconData(0xe044, 'Fill');
+  static const arrowElbowDownLeft = IconData(0xe044,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-down-right-fill.svg)
-  static const arrowElbowDownRight = PhosphorFlatIconData(0xe046, 'Fill');
+  static const arrowElbowDownRight = IconData(0xe046,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-left-fill.svg)
-  static const arrowElbowLeft = PhosphorFlatIconData(0xe048, 'Fill');
+  static const arrowElbowLeft = IconData(0xe048,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-left-down-fill.svg)
-  static const arrowElbowLeftDown = PhosphorFlatIconData(0xe04a, 'Fill');
+  static const arrowElbowLeftDown = IconData(0xe04a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-left-up-fill.svg)
-  static const arrowElbowLeftUp = PhosphorFlatIconData(0xe04c, 'Fill');
+  static const arrowElbowLeftUp = IconData(0xe04c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-right-fill.svg)
-  static const arrowElbowRight = PhosphorFlatIconData(0xe04e, 'Fill');
+  static const arrowElbowRight = IconData(0xe04e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-right-down-fill.svg)
-  static const arrowElbowRightDown = PhosphorFlatIconData(0xe050, 'Fill');
+  static const arrowElbowRightDown = IconData(0xe050,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-right-up-fill.svg)
-  static const arrowElbowRightUp = PhosphorFlatIconData(0xe052, 'Fill');
+  static const arrowElbowRightUp = IconData(0xe052,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-up-left-fill.svg)
-  static const arrowElbowUpLeft = PhosphorFlatIconData(0xe054, 'Fill');
+  static const arrowElbowUpLeft = IconData(0xe054,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-elbow-up-right-fill.svg)
-  static const arrowElbowUpRight = PhosphorFlatIconData(0xe056, 'Fill');
+  static const arrowElbowUpRight = IconData(0xe056,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-down-fill.svg)
-  static const arrowFatDown = PhosphorFlatIconData(0xe518, 'Fill');
+  static const arrowFatDown = IconData(0xe518,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-left-fill.svg)
-  static const arrowFatLeft = PhosphorFlatIconData(0xe51a, 'Fill');
+  static const arrowFatLeft = IconData(0xe51a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-line-down-fill.svg)
-  static const arrowFatLineDown = PhosphorFlatIconData(0xe51c, 'Fill');
+  static const arrowFatLineDown = IconData(0xe51c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-line-left-fill.svg)
-  static const arrowFatLineLeft = PhosphorFlatIconData(0xe51e, 'Fill');
+  static const arrowFatLineLeft = IconData(0xe51e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-line-right-fill.svg)
-  static const arrowFatLineRight = PhosphorFlatIconData(0xe520, 'Fill');
+  static const arrowFatLineRight = IconData(0xe520,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-line-up-fill.svg)
-  static const arrowFatLineUp = PhosphorFlatIconData(0xe522, 'Fill');
+  static const arrowFatLineUp = IconData(0xe522,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-lines-down-fill.svg)
-  static const arrowFatLinesDown = PhosphorFlatIconData(0xe524, 'Fill');
+  static const arrowFatLinesDown = IconData(0xe524,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-lines-left-fill.svg)
-  static const arrowFatLinesLeft = PhosphorFlatIconData(0xe526, 'Fill');
+  static const arrowFatLinesLeft = IconData(0xe526,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-lines-right-fill.svg)
-  static const arrowFatLinesRight = PhosphorFlatIconData(0xe528, 'Fill');
+  static const arrowFatLinesRight = IconData(0xe528,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-lines-up-fill.svg)
-  static const arrowFatLinesUp = PhosphorFlatIconData(0xe52a, 'Fill');
+  static const arrowFatLinesUp = IconData(0xe52a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-right-fill.svg)
-  static const arrowFatRight = PhosphorFlatIconData(0xe52c, 'Fill');
+  static const arrowFatRight = IconData(0xe52c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-fat-up-fill.svg)
-  static const arrowFatUp = PhosphorFlatIconData(0xe52e, 'Fill');
+  static const arrowFatUp = IconData(0xe52e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-left-fill.svg)
-  static const arrowLeft = PhosphorFlatIconData(0xe058, 'Fill');
+  static const arrowLeft = IconData(0xe058,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-line-down-fill.svg)
-  static const arrowLineDown = PhosphorFlatIconData(0xe05c, 'Fill');
+  static const arrowLineDown = IconData(0xe05c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-line-down-left-fill.svg)
-  static const arrowLineDownLeft = PhosphorFlatIconData(0xe05e, 'Fill');
+  static const arrowLineDownLeft = IconData(0xe05e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-line-down-right-fill.svg)
-  static const arrowLineDownRight = PhosphorFlatIconData(0xe060, 'Fill');
+  static const arrowLineDownRight = IconData(0xe060,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-line-left-fill.svg)
-  static const arrowLineLeft = PhosphorFlatIconData(0xe062, 'Fill');
+  static const arrowLineLeft = IconData(0xe062,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-line-right-fill.svg)
-  static const arrowLineRight = PhosphorFlatIconData(0xe064, 'Fill');
+  static const arrowLineRight = IconData(0xe064,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-line-up-fill.svg)
-  static const arrowLineUp = PhosphorFlatIconData(0xe066, 'Fill');
+  static const arrowLineUp = IconData(0xe066,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-line-up-left-fill.svg)
-  static const arrowLineUpLeft = PhosphorFlatIconData(0xe068, 'Fill');
+  static const arrowLineUpLeft = IconData(0xe068,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-line-up-right-fill.svg)
-  static const arrowLineUpRight = PhosphorFlatIconData(0xe06a, 'Fill');
+  static const arrowLineUpRight = IconData(0xe06a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-right-fill.svg)
-  static const arrowRight = PhosphorFlatIconData(0xe06c, 'Fill');
+  static const arrowRight = IconData(0xe06c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-down-fill.svg)
-  static const arrowSquareDown = PhosphorFlatIconData(0xe06e, 'Fill');
+  static const arrowSquareDown = IconData(0xe06e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-down-left-fill.svg)
-  static const arrowSquareDownLeft = PhosphorFlatIconData(0xe070, 'Fill');
+  static const arrowSquareDownLeft = IconData(0xe070,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-down-right-fill.svg)
-  static const arrowSquareDownRight = PhosphorFlatIconData(0xe072, 'Fill');
+  static const arrowSquareDownRight = IconData(0xe072,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-in-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-in-fill.svg)
-  static const arrowSquareIn = PhosphorFlatIconData(0xe5dc, 'Fill');
+  static const arrowSquareIn = IconData(0xe5dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-left-fill.svg)
-  static const arrowSquareLeft = PhosphorFlatIconData(0xe074, 'Fill');
+  static const arrowSquareLeft = IconData(0xe074,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-out-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-out-fill.svg)
-  static const arrowSquareOut = PhosphorFlatIconData(0xe5de, 'Fill');
+  static const arrowSquareOut = IconData(0xe5de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-right-fill.svg)
-  static const arrowSquareRight = PhosphorFlatIconData(0xe076, 'Fill');
+  static const arrowSquareRight = IconData(0xe076,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-up-fill.svg)
-  static const arrowSquareUp = PhosphorFlatIconData(0xe078, 'Fill');
+  static const arrowSquareUp = IconData(0xe078,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-up-left-fill.svg)
-  static const arrowSquareUpLeft = PhosphorFlatIconData(0xe07a, 'Fill');
+  static const arrowSquareUpLeft = IconData(0xe07a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-square-up-right-fill.svg)
-  static const arrowSquareUpRight = PhosphorFlatIconData(0xe07c, 'Fill');
+  static const arrowSquareUpRight = IconData(0xe07c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-u-down-left-fill.svg)
-  static const arrowUDownLeft = PhosphorFlatIconData(0xe07e, 'Fill');
+  static const arrowUDownLeft = IconData(0xe07e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-u-down-right-fill.svg)
-  static const arrowUDownRight = PhosphorFlatIconData(0xe080, 'Fill');
+  static const arrowUDownRight = IconData(0xe080,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-u-left-down-fill.svg)
-  static const arrowULeftDown = PhosphorFlatIconData(0xe082, 'Fill');
+  static const arrowULeftDown = IconData(0xe082,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-u-left-up-fill.svg)
-  static const arrowULeftUp = PhosphorFlatIconData(0xe084, 'Fill');
+  static const arrowULeftUp = IconData(0xe084,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-u-right-down-fill.svg)
-  static const arrowURightDown = PhosphorFlatIconData(0xe086, 'Fill');
+  static const arrowURightDown = IconData(0xe086,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-u-right-up-fill.svg)
-  static const arrowURightUp = PhosphorFlatIconData(0xe088, 'Fill');
+  static const arrowURightUp = IconData(0xe088,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-u-up-left-fill.svg)
-  static const arrowUUpLeft = PhosphorFlatIconData(0xe08a, 'Fill');
+  static const arrowUUpLeft = IconData(0xe08a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-u-up-right-fill.svg)
-  static const arrowUUpRight = PhosphorFlatIconData(0xe08c, 'Fill');
+  static const arrowUUpRight = IconData(0xe08c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-up-fill.svg)
-  static const arrowUp = PhosphorFlatIconData(0xe08e, 'Fill');
+  static const arrowUp = IconData(0xe08e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-up-left-fill.svg)
-  static const arrowUpLeft = PhosphorFlatIconData(0xe090, 'Fill');
+  static const arrowUpLeft = IconData(0xe090,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrow-up-right-fill.svg)
-  static const arrowUpRight = PhosphorFlatIconData(0xe092, 'Fill');
+  static const arrowUpRight = IconData(0xe092,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-clockwise-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-clockwise-fill.svg)
-  static const arrowsClockwise = PhosphorFlatIconData(0xe094, 'Fill');
+  static const arrowsClockwise = IconData(0xe094,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-counter-clockwise-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-counter-clockwise-fill.svg)
-  static const arrowsCounterClockwise = PhosphorFlatIconData(0xe096, 'Fill');
+  static const arrowsCounterClockwise = IconData(0xe096,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-down-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-down-up-fill.svg)
-  static const arrowsDownUp = PhosphorFlatIconData(0xe098, 'Fill');
+  static const arrowsDownUp = IconData(0xe098,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-horizontal-fill.svg)
-  static const arrowsHorizontal = PhosphorFlatIconData(0xeb06, 'Fill');
+  static const arrowsHorizontal = IconData(0xeb06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-in-fill.svg)
-  static const arrowsIn = PhosphorFlatIconData(0xe09a, 'Fill');
+  static const arrowsIn = IconData(0xe09a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-cardinal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-in-cardinal-fill.svg)
-  static const arrowsInCardinal = PhosphorFlatIconData(0xe09c, 'Fill');
+  static const arrowsInCardinal = IconData(0xe09c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-in-line-horizontal-fill.svg)
-  static const arrowsInLineHorizontal = PhosphorFlatIconData(0xe530, 'Fill');
+  static const arrowsInLineHorizontal = IconData(0xe530,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-in-line-vertical-fill.svg)
-  static const arrowsInLineVertical = PhosphorFlatIconData(0xe532, 'Fill');
+  static const arrowsInLineVertical = IconData(0xe532,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-in-simple-fill.svg)
-  static const arrowsInSimple = PhosphorFlatIconData(0xe09e, 'Fill');
+  static const arrowsInSimple = IconData(0xe09e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-left-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-left-right-fill.svg)
-  static const arrowsLeftRight = PhosphorFlatIconData(0xe0a0, 'Fill');
+  static const arrowsLeftRight = IconData(0xe0a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-merge-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-merge-fill.svg)
-  static const arrowsMerge = PhosphorFlatIconData(0xed3e, 'Fill');
+  static const arrowsMerge = IconData(0xed3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-out-fill.svg)
-  static const arrowsOut = PhosphorFlatIconData(0xe0a2, 'Fill');
+  static const arrowsOut = IconData(0xe0a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-cardinal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-out-cardinal-fill.svg)
-  static const arrowsOutCardinal = PhosphorFlatIconData(0xe0a4, 'Fill');
+  static const arrowsOutCardinal = IconData(0xe0a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-out-line-horizontal-fill.svg)
-  static const arrowsOutLineHorizontal = PhosphorFlatIconData(0xe534, 'Fill');
+  static const arrowsOutLineHorizontal = IconData(0xe534,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-out-line-vertical-fill.svg)
-  static const arrowsOutLineVertical = PhosphorFlatIconData(0xe536, 'Fill');
+  static const arrowsOutLineVertical = IconData(0xe536,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-out-simple-fill.svg)
-  static const arrowsOutSimple = PhosphorFlatIconData(0xe0a6, 'Fill');
+  static const arrowsOutSimple = IconData(0xe0a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-split-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-split-fill.svg)
-  static const arrowsSplit = PhosphorFlatIconData(0xed3c, 'Fill');
+  static const arrowsSplit = IconData(0xed3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/arrows-vertical-fill.svg)
-  static const arrowsVertical = PhosphorFlatIconData(0xeb04, 'Fill');
+  static const arrowsVertical = IconData(0xeb04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/article-fill.svg)
-  static const article = PhosphorFlatIconData(0xe0a8, 'Fill');
+  static const article = IconData(0xe0a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-medium-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/article-medium-fill.svg)
-  static const articleMedium = PhosphorFlatIconData(0xe5e0, 'Fill');
+  static const articleMedium = IconData(0xe5e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-ny-times-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/article-ny-times-fill.svg)
-  static const articleNyTimes = PhosphorFlatIconData(0xe5e2, 'Fill');
+  static const articleNyTimes = IconData(0xe5e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asclepius-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/asclepius-fill.svg)
-  static const asclepius = PhosphorFlatIconData(0xee34, 'Fill');
+  static const asclepius = IconData(0xee34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/asterisk-fill.svg)
-  static const asterisk = PhosphorFlatIconData(0xe0aa, 'Fill');
+  static const asterisk = IconData(0xe0aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/asterisk-simple-fill.svg)
-  static const asteriskSimple = PhosphorFlatIconData(0xe832, 'Fill');
+  static const asteriskSimple = IconData(0xe832,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![at-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/at-fill.svg)
-  static const at = PhosphorFlatIconData(0xe0ac, 'Fill');
+  static const at = IconData(0xe0ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![atom-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/atom-fill.svg)
-  static const atom = PhosphorFlatIconData(0xe5e4, 'Fill');
+  static const atom = IconData(0xe5e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![avocado-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/avocado-fill.svg)
-  static const avocado = PhosphorFlatIconData(0xee04, 'Fill');
+  static const avocado = IconData(0xee04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![axe-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/axe-fill.svg)
-  static const axe = PhosphorFlatIconData(0xe9fc, 'Fill');
+  static const axe = IconData(0xe9fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/baby-fill.svg)
-  static const baby = PhosphorFlatIconData(0xe774, 'Fill');
+  static const baby = IconData(0xe774,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-carriage-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/baby-carriage-fill.svg)
-  static const babyCarriage = PhosphorFlatIconData(0xe818, 'Fill');
+  static const babyCarriage = IconData(0xe818,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backpack-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/backpack-fill.svg)
-  static const backpack = PhosphorFlatIconData(0xe922, 'Fill');
+  static const backpack = IconData(0xe922,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backspace-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/backspace-fill.svg)
-  static const backspace = PhosphorFlatIconData(0xe0ae, 'Fill');
+  static const backspace = IconData(0xe0ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bag-fill.svg)
-  static const bag = PhosphorFlatIconData(0xe0b0, 'Fill');
+  static const bag = IconData(0xe0b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bag-simple-fill.svg)
-  static const bagSimple = PhosphorFlatIconData(0xe5e6, 'Fill');
+  static const bagSimple = IconData(0xe5e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![balloon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/balloon-fill.svg)
-  static const balloon = PhosphorFlatIconData(0xe76c, 'Fill');
+  static const balloon = IconData(0xe76c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bandaids-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bandaids-fill.svg)
-  static const bandaids = PhosphorFlatIconData(0xe0b2, 'Fill');
+  static const bandaids = IconData(0xe0b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bank-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bank-fill.svg)
-  static const bank = PhosphorFlatIconData(0xe0b4, 'Fill');
+  static const bank = IconData(0xe0b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barbell-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/barbell-fill.svg)
-  static const barbell = PhosphorFlatIconData(0xe0b6, 'Fill');
+  static const barbell = IconData(0xe0b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barcode-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/barcode-fill.svg)
-  static const barcode = PhosphorFlatIconData(0xe0b8, 'Fill');
+  static const barcode = IconData(0xe0b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barn-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/barn-fill.svg)
-  static const barn = PhosphorFlatIconData(0xec72, 'Fill');
+  static const barn = IconData(0xec72,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barricade-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/barricade-fill.svg)
-  static const barricade = PhosphorFlatIconData(0xe948, 'Fill');
+  static const barricade = IconData(0xe948,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/baseball-fill.svg)
-  static const baseball = PhosphorFlatIconData(0xe71a, 'Fill');
+  static const baseball = IconData(0xe71a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-cap-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/baseball-cap-fill.svg)
-  static const baseballCap = PhosphorFlatIconData(0xea28, 'Fill');
+  static const baseballCap = IconData(0xea28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-helmet-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/baseball-helmet-fill.svg)
-  static const baseballHelmet = PhosphorFlatIconData(0xee4a, 'Fill');
+  static const baseballHelmet = IconData(0xee4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basket-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/basket-fill.svg)
-  static const basket = PhosphorFlatIconData(0xe964, 'Fill');
+  static const basket = IconData(0xe964,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basketball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/basketball-fill.svg)
-  static const basketball = PhosphorFlatIconData(0xe724, 'Fill');
+  static const basketball = IconData(0xe724,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bathtub-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bathtub-fill.svg)
-  static const bathtub = PhosphorFlatIconData(0xe81e, 'Fill');
+  static const bathtub = IconData(0xe81e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-charging-fill.svg)
-  static const batteryCharging = PhosphorFlatIconData(0xe0ba, 'Fill');
+  static const batteryCharging = IconData(0xe0ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-charging-vertical-fill.svg)
-  static const batteryChargingVertical = PhosphorFlatIconData(0xe0bc, 'Fill');
+  static const batteryChargingVertical = IconData(0xe0bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-empty-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-empty-fill.svg)
-  static const batteryEmpty = PhosphorFlatIconData(0xe0be, 'Fill');
+  static const batteryEmpty = IconData(0xe0be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-full-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-full-fill.svg)
-  static const batteryFull = PhosphorFlatIconData(0xe0c0, 'Fill');
+  static const batteryFull = IconData(0xe0c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-high-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-high-fill.svg)
-  static const batteryHigh = PhosphorFlatIconData(0xe0c2, 'Fill');
+  static const batteryHigh = IconData(0xe0c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-low-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-low-fill.svg)
-  static const batteryLow = PhosphorFlatIconData(0xe0c4, 'Fill');
+  static const batteryLow = IconData(0xe0c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-medium-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-medium-fill.svg)
-  static const batteryMedium = PhosphorFlatIconData(0xe0c6, 'Fill');
+  static const batteryMedium = IconData(0xe0c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-plus-fill.svg)
-  static const batteryPlus = PhosphorFlatIconData(0xe808, 'Fill');
+  static const batteryPlus = IconData(0xe808,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-plus-vertical-fill.svg)
-  static const batteryPlusVertical = PhosphorFlatIconData(0xec50, 'Fill');
+  static const batteryPlusVertical = IconData(0xec50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-empty-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-vertical-empty-fill.svg)
-  static const batteryVerticalEmpty = PhosphorFlatIconData(0xe7c6, 'Fill');
+  static const batteryVerticalEmpty = IconData(0xe7c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-full-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-vertical-full-fill.svg)
-  static const batteryVerticalFull = PhosphorFlatIconData(0xe7c4, 'Fill');
+  static const batteryVerticalFull = IconData(0xe7c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-high-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-vertical-high-fill.svg)
-  static const batteryVerticalHigh = PhosphorFlatIconData(0xe7c2, 'Fill');
+  static const batteryVerticalHigh = IconData(0xe7c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-low-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-vertical-low-fill.svg)
-  static const batteryVerticalLow = PhosphorFlatIconData(0xe7be, 'Fill');
+  static const batteryVerticalLow = IconData(0xe7be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-medium-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-vertical-medium-fill.svg)
-  static const batteryVerticalMedium = PhosphorFlatIconData(0xe7c0, 'Fill');
+  static const batteryVerticalMedium = IconData(0xe7c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-warning-fill.svg)
-  static const batteryWarning = PhosphorFlatIconData(0xe0c8, 'Fill');
+  static const batteryWarning = IconData(0xe0c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/battery-warning-vertical-fill.svg)
-  static const batteryWarningVertical = PhosphorFlatIconData(0xe0ca, 'Fill');
+  static const batteryWarningVertical = IconData(0xe0ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beach-ball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/beach-ball-fill.svg)
-  static const beachBall = PhosphorFlatIconData(0xed24, 'Fill');
+  static const beachBall = IconData(0xed24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beanie-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/beanie-fill.svg)
-  static const beanie = PhosphorFlatIconData(0xea2a, 'Fill');
+  static const beanie = IconData(0xea2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bed-fill.svg)
-  static const bed = PhosphorFlatIconData(0xe0cc, 'Fill');
+  static const bed = IconData(0xe0cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-bottle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/beer-bottle-fill.svg)
-  static const beerBottle = PhosphorFlatIconData(0xe7b0, 'Fill');
+  static const beerBottle = IconData(0xe7b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-stein-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/beer-stein-fill.svg)
-  static const beerStein = PhosphorFlatIconData(0xeb62, 'Fill');
+  static const beerStein = IconData(0xeb62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![behance-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/behance-logo-fill.svg)
-  static const behanceLogo = PhosphorFlatIconData(0xe7f4, 'Fill');
+  static const behanceLogo = IconData(0xe7f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bell-fill.svg)
-  static const bell = PhosphorFlatIconData(0xe0ce, 'Fill');
+  static const bell = IconData(0xe0ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-ringing-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bell-ringing-fill.svg)
-  static const bellRinging = PhosphorFlatIconData(0xe5e8, 'Fill');
+  static const bellRinging = IconData(0xe5e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bell-simple-fill.svg)
-  static const bellSimple = PhosphorFlatIconData(0xe0d0, 'Fill');
+  static const bellSimple = IconData(0xe0d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-ringing-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bell-simple-ringing-fill.svg)
-  static const bellSimpleRinging = PhosphorFlatIconData(0xe5ea, 'Fill');
+  static const bellSimpleRinging = IconData(0xe5ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bell-simple-slash-fill.svg)
-  static const bellSimpleSlash = PhosphorFlatIconData(0xe0d2, 'Fill');
+  static const bellSimpleSlash = IconData(0xe0d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-z-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bell-simple-z-fill.svg)
-  static const bellSimpleZ = PhosphorFlatIconData(0xe5ec, 'Fill');
+  static const bellSimpleZ = IconData(0xe5ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bell-slash-fill.svg)
-  static const bellSlash = PhosphorFlatIconData(0xe0d4, 'Fill');
+  static const bellSlash = IconData(0xe0d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-z-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bell-z-fill.svg)
-  static const bellZ = PhosphorFlatIconData(0xe5ee, 'Fill');
+  static const bellZ = IconData(0xe5ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![belt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/belt-fill.svg)
-  static const belt = PhosphorFlatIconData(0xea2c, 'Fill');
+  static const belt = IconData(0xea2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bezier-curve-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bezier-curve-fill.svg)
-  static const bezierCurve = PhosphorFlatIconData(0xeb00, 'Fill');
+  static const bezierCurve = IconData(0xeb00,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bicycle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bicycle-fill.svg)
-  static const bicycle = PhosphorFlatIconData(0xe0d6, 'Fill');
+  static const bicycle = IconData(0xe0d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binary-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/binary-fill.svg)
-  static const binary = PhosphorFlatIconData(0xee60, 'Fill');
+  static const binary = IconData(0xee60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binoculars-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/binoculars-fill.svg)
-  static const binoculars = PhosphorFlatIconData(0xea64, 'Fill');
+  static const binoculars = IconData(0xea64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![biohazard-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/biohazard-fill.svg)
-  static const biohazard = PhosphorFlatIconData(0xe9e0, 'Fill');
+  static const biohazard = IconData(0xe9e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bird-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bird-fill.svg)
-  static const bird = PhosphorFlatIconData(0xe72c, 'Fill');
+  static const bird = IconData(0xe72c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![blueprint-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/blueprint-fill.svg)
-  static const blueprint = PhosphorFlatIconData(0xeda0, 'Fill');
+  static const blueprint = IconData(0xeda0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bluetooth-fill.svg)
-  static const bluetooth = PhosphorFlatIconData(0xe0da, 'Fill');
+  static const bluetooth = IconData(0xe0da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-connected-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bluetooth-connected-fill.svg)
-  static const bluetoothConnected = PhosphorFlatIconData(0xe0dc, 'Fill');
+  static const bluetoothConnected = IconData(0xe0dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bluetooth-slash-fill.svg)
-  static const bluetoothSlash = PhosphorFlatIconData(0xe0de, 'Fill');
+  static const bluetoothSlash = IconData(0xe0de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bluetooth-x-fill.svg)
-  static const bluetoothX = PhosphorFlatIconData(0xe0e0, 'Fill');
+  static const bluetoothX = IconData(0xe0e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/boat-fill.svg)
-  static const boat = PhosphorFlatIconData(0xe786, 'Fill');
+  static const boat = IconData(0xe786,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bomb-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bomb-fill.svg)
-  static const bomb = PhosphorFlatIconData(0xee0a, 'Fill');
+  static const bomb = IconData(0xee0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bone-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bone-fill.svg)
-  static const bone = PhosphorFlatIconData(0xe7f2, 'Fill');
+  static const bone = IconData(0xe7f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/book-fill.svg)
-  static const book = PhosphorFlatIconData(0xe0e2, 'Fill');
+  static const book = IconData(0xe0e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-bookmark-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/book-bookmark-fill.svg)
-  static const bookBookmark = PhosphorFlatIconData(0xe0e4, 'Fill');
+  static const bookBookmark = IconData(0xe0e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/book-open-fill.svg)
-  static const bookOpen = PhosphorFlatIconData(0xe0e6, 'Fill');
+  static const bookOpen = IconData(0xe0e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-text-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/book-open-text-fill.svg)
-  static const bookOpenText = PhosphorFlatIconData(0xe8f2, 'Fill');
+  static const bookOpenText = IconData(0xe8f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-user-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/book-open-user-fill.svg)
-  static const bookOpenUser = PhosphorFlatIconData(0xede0, 'Fill');
+  static const bookOpenUser = IconData(0xede0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bookmark-fill.svg)
-  static const bookmark = PhosphorFlatIconData(0xe0e8, 'Fill');
+  static const bookmark = IconData(0xe0e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bookmark-simple-fill.svg)
-  static const bookmarkSimple = PhosphorFlatIconData(0xe0ea, 'Fill');
+  static const bookmarkSimple = IconData(0xe0ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bookmarks-fill.svg)
-  static const bookmarks = PhosphorFlatIconData(0xe0ec, 'Fill');
+  static const bookmarks = IconData(0xe0ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bookmarks-simple-fill.svg)
-  static const bookmarksSimple = PhosphorFlatIconData(0xe5f0, 'Fill');
+  static const bookmarksSimple = IconData(0xe5f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![books-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/books-fill.svg)
-  static const books = PhosphorFlatIconData(0xe758, 'Fill');
+  static const books = IconData(0xe758,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boot-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/boot-fill.svg)
-  static const boot = PhosphorFlatIconData(0xecca, 'Fill');
+  static const boot = IconData(0xecca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boules-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/boules-fill.svg)
-  static const boules = PhosphorFlatIconData(0xe722, 'Fill');
+  static const boules = IconData(0xe722,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bounding-box-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bounding-box-fill.svg)
-  static const boundingBox = PhosphorFlatIconData(0xe6ce, 'Fill');
+  static const boundingBox = IconData(0xe6ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-food-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bowl-food-fill.svg)
-  static const bowlFood = PhosphorFlatIconData(0xeaa4, 'Fill');
+  static const bowlFood = IconData(0xeaa4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-steam-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bowl-steam-fill.svg)
-  static const bowlSteam = PhosphorFlatIconData(0xe8e4, 'Fill');
+  static const bowlSteam = IconData(0xe8e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowling-ball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bowling-ball-fill.svg)
-  static const bowlingBall = PhosphorFlatIconData(0xea34, 'Fill');
+  static const bowlingBall = IconData(0xea34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/box-arrow-down-fill.svg)
-  static const boxArrowDown = PhosphorFlatIconData(0xe00e, 'Fill');
+  static const boxArrowDown = IconData(0xe00e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/box-arrow-up-fill.svg)
-  static const boxArrowUp = PhosphorFlatIconData(0xee54, 'Fill');
+  static const boxArrowUp = IconData(0xee54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boxing-glove-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/boxing-glove-fill.svg)
-  static const boxingGlove = PhosphorFlatIconData(0xea36, 'Fill');
+  static const boxingGlove = IconData(0xea36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-angle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/brackets-angle-fill.svg)
-  static const bracketsAngle = PhosphorFlatIconData(0xe862, 'Fill');
+  static const bracketsAngle = IconData(0xe862,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-curly-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/brackets-curly-fill.svg)
-  static const bracketsCurly = PhosphorFlatIconData(0xe860, 'Fill');
+  static const bracketsCurly = IconData(0xe860,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-round-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/brackets-round-fill.svg)
-  static const bracketsRound = PhosphorFlatIconData(0xe864, 'Fill');
+  static const bracketsRound = IconData(0xe864,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/brackets-square-fill.svg)
-  static const bracketsSquare = PhosphorFlatIconData(0xe85e, 'Fill');
+  static const bracketsSquare = IconData(0xe85e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brain-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/brain-fill.svg)
-  static const brain = PhosphorFlatIconData(0xe74e, 'Fill');
+  static const brain = IconData(0xe74e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brandy-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/brandy-fill.svg)
-  static const brandy = PhosphorFlatIconData(0xe6b4, 'Fill');
+  static const brandy = IconData(0xe6b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bread-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bread-fill.svg)
-  static const bread = PhosphorFlatIconData(0xe81c, 'Fill');
+  static const bread = IconData(0xe81c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bridge-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bridge-fill.svg)
-  static const bridge = PhosphorFlatIconData(0xea68, 'Fill');
+  static const bridge = IconData(0xea68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/briefcase-fill.svg)
-  static const briefcase = PhosphorFlatIconData(0xe0ee, 'Fill');
+  static const briefcase = IconData(0xe0ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-metal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/briefcase-metal-fill.svg)
-  static const briefcaseMetal = PhosphorFlatIconData(0xe5f2, 'Fill');
+  static const briefcaseMetal = IconData(0xe5f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broadcast-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/broadcast-fill.svg)
-  static const broadcast = PhosphorFlatIconData(0xe0f2, 'Fill');
+  static const broadcast = IconData(0xe0f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broom-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/broom-fill.svg)
-  static const broom = PhosphorFlatIconData(0xec54, 'Fill');
+  static const broom = IconData(0xec54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browser-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/browser-fill.svg)
-  static const browser = PhosphorFlatIconData(0xe0f4, 'Fill');
+  static const browser = IconData(0xe0f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browsers-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/browsers-fill.svg)
-  static const browsers = PhosphorFlatIconData(0xe0f6, 'Fill');
+  static const browsers = IconData(0xe0f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bug-fill.svg)
-  static const bug = PhosphorFlatIconData(0xe5f4, 'Fill');
+  static const bug = IconData(0xe5f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-beetle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bug-beetle-fill.svg)
-  static const bugBeetle = PhosphorFlatIconData(0xe5f6, 'Fill');
+  static const bugBeetle = IconData(0xe5f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-droid-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bug-droid-fill.svg)
-  static const bugDroid = PhosphorFlatIconData(0xe5f8, 'Fill');
+  static const bugDroid = IconData(0xe5f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/building-fill.svg)
-  static const building = PhosphorFlatIconData(0xe100, 'Fill');
+  static const building = IconData(0xe100,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-apartment-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/building-apartment-fill.svg)
-  static const buildingApartment = PhosphorFlatIconData(0xe0fe, 'Fill');
+  static const buildingApartment = IconData(0xe0fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-office-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/building-office-fill.svg)
-  static const buildingOffice = PhosphorFlatIconData(0xe0ff, 'Fill');
+  static const buildingOffice = IconData(0xe0ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![buildings-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/buildings-fill.svg)
-  static const buildings = PhosphorFlatIconData(0xe102, 'Fill');
+  static const buildings = IconData(0xe102,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bulldozer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bulldozer-fill.svg)
-  static const bulldozer = PhosphorFlatIconData(0xec6c, 'Fill');
+  static const bulldozer = IconData(0xec6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/bus-fill.svg)
-  static const bus = PhosphorFlatIconData(0xe106, 'Fill');
+  static const bus = IconData(0xe106,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![butterfly-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/butterfly-fill.svg)
-  static const butterfly = PhosphorFlatIconData(0xea6e, 'Fill');
+  static const butterfly = IconData(0xea6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cable-car-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cable-car-fill.svg)
-  static const cableCar = PhosphorFlatIconData(0xe49c, 'Fill');
+  static const cableCar = IconData(0xe49c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cactus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cactus-fill.svg)
-  static const cactus = PhosphorFlatIconData(0xe918, 'Fill');
+  static const cactus = IconData(0xe918,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cake-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cake-fill.svg)
-  static const cake = PhosphorFlatIconData(0xe780, 'Fill');
+  static const cake = IconData(0xe780,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calculator-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calculator-fill.svg)
-  static const calculator = PhosphorFlatIconData(0xe538, 'Fill');
+  static const calculator = IconData(0xe538,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-fill.svg)
-  static const calendar = PhosphorFlatIconData(0xe108, 'Fill');
+  static const calendar = IconData(0xe108,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-blank-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-blank-fill.svg)
-  static const calendarBlank = PhosphorFlatIconData(0xe10a, 'Fill');
+  static const calendarBlank = IconData(0xe10a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-check-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-check-fill.svg)
-  static const calendarCheck = PhosphorFlatIconData(0xe712, 'Fill');
+  static const calendarCheck = IconData(0xe712,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dot-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-dot-fill.svg)
-  static const calendarDot = PhosphorFlatIconData(0xe7b2, 'Fill');
+  static const calendarDot = IconData(0xe7b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dots-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-dots-fill.svg)
-  static const calendarDots = PhosphorFlatIconData(0xe7b4, 'Fill');
+  static const calendarDots = IconData(0xe7b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-heart-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-heart-fill.svg)
-  static const calendarHeart = PhosphorFlatIconData(0xe8b0, 'Fill');
+  static const calendarHeart = IconData(0xe8b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-minus-fill.svg)
-  static const calendarMinus = PhosphorFlatIconData(0xea14, 'Fill');
+  static const calendarMinus = IconData(0xea14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-plus-fill.svg)
-  static const calendarPlus = PhosphorFlatIconData(0xe714, 'Fill');
+  static const calendarPlus = IconData(0xe714,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-slash-fill.svg)
-  static const calendarSlash = PhosphorFlatIconData(0xea12, 'Fill');
+  static const calendarSlash = IconData(0xea12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-star-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-star-fill.svg)
-  static const calendarStar = PhosphorFlatIconData(0xe8b2, 'Fill');
+  static const calendarStar = IconData(0xe8b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/calendar-x-fill.svg)
-  static const calendarX = PhosphorFlatIconData(0xe10c, 'Fill');
+  static const calendarX = IconData(0xe10c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![call-bell-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/call-bell-fill.svg)
-  static const callBell = PhosphorFlatIconData(0xe7de, 'Fill');
+  static const callBell = IconData(0xe7de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/camera-fill.svg)
-  static const camera = PhosphorFlatIconData(0xe10e, 'Fill');
+  static const camera = IconData(0xe10e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/camera-plus-fill.svg)
-  static const cameraPlus = PhosphorFlatIconData(0xec58, 'Fill');
+  static const cameraPlus = IconData(0xec58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-rotate-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/camera-rotate-fill.svg)
-  static const cameraRotate = PhosphorFlatIconData(0xe7a4, 'Fill');
+  static const cameraRotate = IconData(0xe7a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/camera-slash-fill.svg)
-  static const cameraSlash = PhosphorFlatIconData(0xe110, 'Fill');
+  static const cameraSlash = IconData(0xe110,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![campfire-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/campfire-fill.svg)
-  static const campfire = PhosphorFlatIconData(0xe9d8, 'Fill');
+  static const campfire = IconData(0xe9d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/car-fill.svg)
-  static const car = PhosphorFlatIconData(0xe112, 'Fill');
+  static const car = IconData(0xe112,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-battery-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/car-battery-fill.svg)
-  static const carBattery = PhosphorFlatIconData(0xee30, 'Fill');
+  static const carBattery = IconData(0xee30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-profile-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/car-profile-fill.svg)
-  static const carProfile = PhosphorFlatIconData(0xe8cc, 'Fill');
+  static const carProfile = IconData(0xe8cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/car-simple-fill.svg)
-  static const carSimple = PhosphorFlatIconData(0xe114, 'Fill');
+  static const carSimple = IconData(0xe114,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cardholder-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cardholder-fill.svg)
-  static const cardholder = PhosphorFlatIconData(0xe5fa, 'Fill');
+  static const cardholder = IconData(0xe5fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cards-fill.svg)
-  static const cards = PhosphorFlatIconData(0xe0f8, 'Fill');
+  static const cards = IconData(0xe0f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cards-three-fill.svg)
-  static const cardsThree = PhosphorFlatIconData(0xee50, 'Fill');
+  static const cardsThree = IconData(0xee50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-double-down-fill.svg)
-  static const caretCircleDoubleDown = PhosphorFlatIconData(0xe116, 'Fill');
+  static const caretCircleDoubleDown = IconData(0xe116,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-double-left-fill.svg)
-  static const caretCircleDoubleLeft = PhosphorFlatIconData(0xe118, 'Fill');
+  static const caretCircleDoubleLeft = IconData(0xe118,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-double-right-fill.svg)
-  static const caretCircleDoubleRight = PhosphorFlatIconData(0xe11a, 'Fill');
+  static const caretCircleDoubleRight = IconData(0xe11a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-double-up-fill.svg)
-  static const caretCircleDoubleUp = PhosphorFlatIconData(0xe11c, 'Fill');
+  static const caretCircleDoubleUp = IconData(0xe11c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-down-fill.svg)
-  static const caretCircleDown = PhosphorFlatIconData(0xe11e, 'Fill');
+  static const caretCircleDown = IconData(0xe11e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-left-fill.svg)
-  static const caretCircleLeft = PhosphorFlatIconData(0xe120, 'Fill');
+  static const caretCircleLeft = IconData(0xe120,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-right-fill.svg)
-  static const caretCircleRight = PhosphorFlatIconData(0xe122, 'Fill');
+  static const caretCircleRight = IconData(0xe122,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-up-fill.svg)
-  static const caretCircleUp = PhosphorFlatIconData(0xe124, 'Fill');
+  static const caretCircleUp = IconData(0xe124,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-circle-up-down-fill.svg)
-  static const caretCircleUpDown = PhosphorFlatIconData(0xe13e, 'Fill');
+  static const caretCircleUpDown = IconData(0xe13e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-double-down-fill.svg)
-  static const caretDoubleDown = PhosphorFlatIconData(0xe126, 'Fill');
+  static const caretDoubleDown = IconData(0xe126,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-double-left-fill.svg)
-  static const caretDoubleLeft = PhosphorFlatIconData(0xe128, 'Fill');
+  static const caretDoubleLeft = IconData(0xe128,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-double-right-fill.svg)
-  static const caretDoubleRight = PhosphorFlatIconData(0xe12a, 'Fill');
+  static const caretDoubleRight = IconData(0xe12a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-double-up-fill.svg)
-  static const caretDoubleUp = PhosphorFlatIconData(0xe12c, 'Fill');
+  static const caretDoubleUp = IconData(0xe12c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-down-fill.svg)
-  static const caretDown = PhosphorFlatIconData(0xe136, 'Fill');
+  static const caretDown = IconData(0xe136,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-left-fill.svg)
-  static const caretLeft = PhosphorFlatIconData(0xe138, 'Fill');
+  static const caretLeft = IconData(0xe138,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-line-down-fill.svg)
-  static const caretLineDown = PhosphorFlatIconData(0xe134, 'Fill');
+  static const caretLineDown = IconData(0xe134,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-line-left-fill.svg)
-  static const caretLineLeft = PhosphorFlatIconData(0xe132, 'Fill');
+  static const caretLineLeft = IconData(0xe132,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-line-right-fill.svg)
-  static const caretLineRight = PhosphorFlatIconData(0xe130, 'Fill');
+  static const caretLineRight = IconData(0xe130,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-line-up-fill.svg)
-  static const caretLineUp = PhosphorFlatIconData(0xe12e, 'Fill');
+  static const caretLineUp = IconData(0xe12e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-right-fill.svg)
-  static const caretRight = PhosphorFlatIconData(0xe13a, 'Fill');
+  static const caretRight = IconData(0xe13a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-up-fill.svg)
-  static const caretUp = PhosphorFlatIconData(0xe13c, 'Fill');
+  static const caretUp = IconData(0xe13c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/caret-up-down-fill.svg)
-  static const caretUpDown = PhosphorFlatIconData(0xe140, 'Fill');
+  static const caretUpDown = IconData(0xe140,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![carrot-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/carrot-fill.svg)
-  static const carrot = PhosphorFlatIconData(0xed38, 'Fill');
+  static const carrot = IconData(0xed38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cash-register-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cash-register-fill.svg)
-  static const cashRegister = PhosphorFlatIconData(0xed80, 'Fill');
+  static const cashRegister = IconData(0xed80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cassette-tape-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cassette-tape-fill.svg)
-  static const cassetteTape = PhosphorFlatIconData(0xed2e, 'Fill');
+  static const cassetteTape = IconData(0xed2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![castle-turret-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/castle-turret-fill.svg)
-  static const castleTurret = PhosphorFlatIconData(0xe9d0, 'Fill');
+  static const castleTurret = IconData(0xe9d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cat-fill.svg)
-  static const cat = PhosphorFlatIconData(0xe748, 'Fill');
+  static const cat = IconData(0xe748,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-full-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cell-signal-full-fill.svg)
-  static const cellSignalFull = PhosphorFlatIconData(0xe142, 'Fill');
+  static const cellSignalFull = IconData(0xe142,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-high-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cell-signal-high-fill.svg)
-  static const cellSignalHigh = PhosphorFlatIconData(0xe144, 'Fill');
+  static const cellSignalHigh = IconData(0xe144,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-low-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cell-signal-low-fill.svg)
-  static const cellSignalLow = PhosphorFlatIconData(0xe146, 'Fill');
+  static const cellSignalLow = IconData(0xe146,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-medium-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cell-signal-medium-fill.svg)
-  static const cellSignalMedium = PhosphorFlatIconData(0xe148, 'Fill');
+  static const cellSignalMedium = IconData(0xe148,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-none-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cell-signal-none-fill.svg)
-  static const cellSignalNone = PhosphorFlatIconData(0xe14a, 'Fill');
+  static const cellSignalNone = IconData(0xe14a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cell-signal-slash-fill.svg)
-  static const cellSignalSlash = PhosphorFlatIconData(0xe14c, 'Fill');
+  static const cellSignalSlash = IconData(0xe14c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cell-signal-x-fill.svg)
-  static const cellSignalX = PhosphorFlatIconData(0xe14e, 'Fill');
+  static const cellSignalX = IconData(0xe14e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-tower-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cell-tower-fill.svg)
-  static const cellTower = PhosphorFlatIconData(0xebaa, 'Fill');
+  static const cellTower = IconData(0xebaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![certificate-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/certificate-fill.svg)
-  static const certificate = PhosphorFlatIconData(0xe766, 'Fill');
+  static const certificate = IconData(0xe766,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chair-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chair-fill.svg)
-  static const chair = PhosphorFlatIconData(0xe950, 'Fill');
+  static const chair = IconData(0xe950,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chalkboard-fill.svg)
-  static const chalkboard = PhosphorFlatIconData(0xe5fc, 'Fill');
+  static const chalkboard = IconData(0xe5fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chalkboard-simple-fill.svg)
-  static const chalkboardSimple = PhosphorFlatIconData(0xe5fe, 'Fill');
+  static const chalkboardSimple = IconData(0xe5fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-teacher-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chalkboard-teacher-fill.svg)
-  static const chalkboardTeacher = PhosphorFlatIconData(0xe600, 'Fill');
+  static const chalkboardTeacher = IconData(0xe600,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![champagne-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/champagne-fill.svg)
-  static const champagne = PhosphorFlatIconData(0xeaca, 'Fill');
+  static const champagne = IconData(0xeaca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![charging-station-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/charging-station-fill.svg)
-  static const chargingStation = PhosphorFlatIconData(0xe8d0, 'Fill');
+  static const chargingStation = IconData(0xe8d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-bar-fill.svg)
-  static const chartBar = PhosphorFlatIconData(0xe150, 'Fill');
+  static const chartBar = IconData(0xe150,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-bar-horizontal-fill.svg)
-  static const chartBarHorizontal = PhosphorFlatIconData(0xe152, 'Fill');
+  static const chartBarHorizontal = IconData(0xe152,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-donut-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-donut-fill.svg)
-  static const chartDonut = PhosphorFlatIconData(0xeaa6, 'Fill');
+  static const chartDonut = IconData(0xeaa6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-line-fill.svg)
-  static const chartLine = PhosphorFlatIconData(0xe154, 'Fill');
+  static const chartLine = IconData(0xe154,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-line-down-fill.svg)
-  static const chartLineDown = PhosphorFlatIconData(0xe8b6, 'Fill');
+  static const chartLineDown = IconData(0xe8b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-line-up-fill.svg)
-  static const chartLineUp = PhosphorFlatIconData(0xe156, 'Fill');
+  static const chartLineUp = IconData(0xe156,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-pie-fill.svg)
-  static const chartPie = PhosphorFlatIconData(0xe158, 'Fill');
+  static const chartPie = IconData(0xe158,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-slice-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-pie-slice-fill.svg)
-  static const chartPieSlice = PhosphorFlatIconData(0xe15a, 'Fill');
+  static const chartPieSlice = IconData(0xe15a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-polar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-polar-fill.svg)
-  static const chartPolar = PhosphorFlatIconData(0xeaa8, 'Fill');
+  static const chartPolar = IconData(0xeaa8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-scatter-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chart-scatter-fill.svg)
-  static const chartScatter = PhosphorFlatIconData(0xeaac, 'Fill');
+  static const chartScatter = IconData(0xeaac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-fill.svg)
-  static const chat = PhosphorFlatIconData(0xe15c, 'Fill');
+  static const chat = IconData(0xe15c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-centered-fill.svg)
-  static const chatCentered = PhosphorFlatIconData(0xe160, 'Fill');
+  static const chatCentered = IconData(0xe160,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-dots-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-centered-dots-fill.svg)
-  static const chatCenteredDots = PhosphorFlatIconData(0xe164, 'Fill');
+  static const chatCenteredDots = IconData(0xe164,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-centered-slash-fill.svg)
-  static const chatCenteredSlash = PhosphorFlatIconData(0xe162, 'Fill');
+  static const chatCenteredSlash = IconData(0xe162,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-text-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-centered-text-fill.svg)
-  static const chatCenteredText = PhosphorFlatIconData(0xe166, 'Fill');
+  static const chatCenteredText = IconData(0xe166,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-circle-fill.svg)
-  static const chatCircle = PhosphorFlatIconData(0xe168, 'Fill');
+  static const chatCircle = IconData(0xe168,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-dots-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-circle-dots-fill.svg)
-  static const chatCircleDots = PhosphorFlatIconData(0xe16c, 'Fill');
+  static const chatCircleDots = IconData(0xe16c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-circle-slash-fill.svg)
-  static const chatCircleSlash = PhosphorFlatIconData(0xe16a, 'Fill');
+  static const chatCircleSlash = IconData(0xe16a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-text-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-circle-text-fill.svg)
-  static const chatCircleText = PhosphorFlatIconData(0xe16e, 'Fill');
+  static const chatCircleText = IconData(0xe16e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-dots-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-dots-fill.svg)
-  static const chatDots = PhosphorFlatIconData(0xe170, 'Fill');
+  static const chatDots = IconData(0xe170,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-slash-fill.svg)
-  static const chatSlash = PhosphorFlatIconData(0xe15e, 'Fill');
+  static const chatSlash = IconData(0xe15e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-teardrop-fill.svg)
-  static const chatTeardrop = PhosphorFlatIconData(0xe172, 'Fill');
+  static const chatTeardrop = IconData(0xe172,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-dots-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-teardrop-dots-fill.svg)
-  static const chatTeardropDots = PhosphorFlatIconData(0xe176, 'Fill');
+  static const chatTeardropDots = IconData(0xe176,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-teardrop-slash-fill.svg)
-  static const chatTeardropSlash = PhosphorFlatIconData(0xe174, 'Fill');
+  static const chatTeardropSlash = IconData(0xe174,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-text-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-teardrop-text-fill.svg)
-  static const chatTeardropText = PhosphorFlatIconData(0xe178, 'Fill');
+  static const chatTeardropText = IconData(0xe178,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-text-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chat-text-fill.svg)
-  static const chatText = PhosphorFlatIconData(0xe17a, 'Fill');
+  static const chatText = IconData(0xe17a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chats-fill.svg)
-  static const chats = PhosphorFlatIconData(0xe17c, 'Fill');
+  static const chats = IconData(0xe17c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chats-circle-fill.svg)
-  static const chatsCircle = PhosphorFlatIconData(0xe17e, 'Fill');
+  static const chatsCircle = IconData(0xe17e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-teardrop-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chats-teardrop-fill.svg)
-  static const chatsTeardrop = PhosphorFlatIconData(0xe180, 'Fill');
+  static const chatsTeardrop = IconData(0xe180,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/check-fill.svg)
-  static const check = PhosphorFlatIconData(0xe182, 'Fill');
+  static const check = IconData(0xe182,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/check-circle-fill.svg)
-  static const checkCircle = PhosphorFlatIconData(0xe184, 'Fill');
+  static const checkCircle = IconData(0xe184,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-fat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/check-fat-fill.svg)
-  static const checkFat = PhosphorFlatIconData(0xeba6, 'Fill');
+  static const checkFat = IconData(0xeba6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/check-square-fill.svg)
-  static const checkSquare = PhosphorFlatIconData(0xe186, 'Fill');
+  static const checkSquare = IconData(0xe186,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-offset-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/check-square-offset-fill.svg)
-  static const checkSquareOffset = PhosphorFlatIconData(0xe188, 'Fill');
+  static const checkSquareOffset = IconData(0xe188,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checkerboard-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/checkerboard-fill.svg)
-  static const checkerboard = PhosphorFlatIconData(0xe8c4, 'Fill');
+  static const checkerboard = IconData(0xe8c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checks-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/checks-fill.svg)
-  static const checks = PhosphorFlatIconData(0xe53a, 'Fill');
+  static const checks = IconData(0xe53a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheers-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cheers-fill.svg)
-  static const cheers = PhosphorFlatIconData(0xea4a, 'Fill');
+  static const cheers = IconData(0xea4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheese-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cheese-fill.svg)
-  static const cheese = PhosphorFlatIconData(0xe9fe, 'Fill');
+  static const cheese = IconData(0xe9fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chef-hat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/chef-hat-fill.svg)
-  static const chefHat = PhosphorFlatIconData(0xed8e, 'Fill');
+  static const chefHat = IconData(0xed8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cherries-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cherries-fill.svg)
-  static const cherries = PhosphorFlatIconData(0xe830, 'Fill');
+  static const cherries = IconData(0xe830,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![church-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/church-fill.svg)
-  static const church = PhosphorFlatIconData(0xecea, 'Fill');
+  static const church = IconData(0xecea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cigarette-fill.svg)
-  static const cigarette = PhosphorFlatIconData(0xed90, 'Fill');
+  static const cigarette = IconData(0xed90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cigarette-slash-fill.svg)
-  static const cigaretteSlash = PhosphorFlatIconData(0xed92, 'Fill');
+  static const cigaretteSlash = IconData(0xed92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circle-fill.svg)
-  static const circle = PhosphorFlatIconData(0xe18a, 'Fill');
+  static const circle = IconData(0xe18a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-dashed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circle-dashed-fill.svg)
-  static const circleDashed = PhosphorFlatIconData(0xe602, 'Fill');
+  static const circleDashed = IconData(0xe602,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circle-half-fill.svg)
-  static const circleHalf = PhosphorFlatIconData(0xe18c, 'Fill');
+  static const circleHalf = IconData(0xe18c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-tilt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circle-half-tilt-fill.svg)
-  static const circleHalfTilt = PhosphorFlatIconData(0xe18e, 'Fill');
+  static const circleHalfTilt = IconData(0xe18e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-notch-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circle-notch-fill.svg)
-  static const circleNotch = PhosphorFlatIconData(0xeb44, 'Fill');
+  static const circleNotch = IconData(0xeb44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circles-four-fill.svg)
-  static const circlesFour = PhosphorFlatIconData(0xe190, 'Fill');
+  static const circlesFour = IconData(0xe190,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circles-three-fill.svg)
-  static const circlesThree = PhosphorFlatIconData(0xe192, 'Fill');
+  static const circlesThree = IconData(0xe192,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circles-three-plus-fill.svg)
-  static const circlesThreePlus = PhosphorFlatIconData(0xe194, 'Fill');
+  static const circlesThreePlus = IconData(0xe194,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circuitry-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/circuitry-fill.svg)
-  static const circuitry = PhosphorFlatIconData(0xe9c2, 'Fill');
+  static const circuitry = IconData(0xe9c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![city-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/city-fill.svg)
-  static const city = PhosphorFlatIconData(0xea6a, 'Fill');
+  static const city = IconData(0xea6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clipboard-fill.svg)
-  static const clipboard = PhosphorFlatIconData(0xe196, 'Fill');
+  static const clipboard = IconData(0xe196,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-text-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clipboard-text-fill.svg)
-  static const clipboardText = PhosphorFlatIconData(0xe198, 'Fill');
+  static const clipboardText = IconData(0xe198,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clock-fill.svg)
-  static const clock = PhosphorFlatIconData(0xe19a, 'Fill');
+  static const clock = IconData(0xe19a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-afternoon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clock-afternoon-fill.svg)
-  static const clockAfternoon = PhosphorFlatIconData(0xe19c, 'Fill');
+  static const clockAfternoon = IconData(0xe19c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-clockwise-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clock-clockwise-fill.svg)
-  static const clockClockwise = PhosphorFlatIconData(0xe19e, 'Fill');
+  static const clockClockwise = IconData(0xe19e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-countdown-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clock-countdown-fill.svg)
-  static const clockCountdown = PhosphorFlatIconData(0xed2c, 'Fill');
+  static const clockCountdown = IconData(0xed2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-counter-clockwise-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clock-counter-clockwise-fill.svg)
-  static const clockCounterClockwise = PhosphorFlatIconData(0xe1a0, 'Fill');
+  static const clockCounterClockwise = IconData(0xe1a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-user-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clock-user-fill.svg)
-  static const clockUser = PhosphorFlatIconData(0xedec, 'Fill');
+  static const clockUser = IconData(0xedec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![closed-captioning-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/closed-captioning-fill.svg)
-  static const closedCaptioning = PhosphorFlatIconData(0xe1a4, 'Fill');
+  static const closedCaptioning = IconData(0xe1a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-fill.svg)
-  static const cloud = PhosphorFlatIconData(0xe1aa, 'Fill');
+  static const cloud = IconData(0xe1aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-arrow-down-fill.svg)
-  static const cloudArrowDown = PhosphorFlatIconData(0xe1ac, 'Fill');
+  static const cloudArrowDown = IconData(0xe1ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-arrow-up-fill.svg)
-  static const cloudArrowUp = PhosphorFlatIconData(0xe1ae, 'Fill');
+  static const cloudArrowUp = IconData(0xe1ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-check-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-check-fill.svg)
-  static const cloudCheck = PhosphorFlatIconData(0xe1b0, 'Fill');
+  static const cloudCheck = IconData(0xe1b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-fog-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-fog-fill.svg)
-  static const cloudFog = PhosphorFlatIconData(0xe53c, 'Fill');
+  static const cloudFog = IconData(0xe53c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-lightning-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-lightning-fill.svg)
-  static const cloudLightning = PhosphorFlatIconData(0xe1b2, 'Fill');
+  static const cloudLightning = IconData(0xe1b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-moon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-moon-fill.svg)
-  static const cloudMoon = PhosphorFlatIconData(0xe53e, 'Fill');
+  static const cloudMoon = IconData(0xe53e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-rain-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-rain-fill.svg)
-  static const cloudRain = PhosphorFlatIconData(0xe1b4, 'Fill');
+  static const cloudRain = IconData(0xe1b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-slash-fill.svg)
-  static const cloudSlash = PhosphorFlatIconData(0xe1b6, 'Fill');
+  static const cloudSlash = IconData(0xe1b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-snow-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-snow-fill.svg)
-  static const cloudSnow = PhosphorFlatIconData(0xe1b8, 'Fill');
+  static const cloudSnow = IconData(0xe1b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-sun-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-sun-fill.svg)
-  static const cloudSun = PhosphorFlatIconData(0xe540, 'Fill');
+  static const cloudSun = IconData(0xe540,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-warning-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-warning-fill.svg)
-  static const cloudWarning = PhosphorFlatIconData(0xea98, 'Fill');
+  static const cloudWarning = IconData(0xea98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cloud-x-fill.svg)
-  static const cloudX = PhosphorFlatIconData(0xea96, 'Fill');
+  static const cloudX = IconData(0xea96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clover-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/clover-fill.svg)
-  static const clover = PhosphorFlatIconData(0xedc8, 'Fill');
+  static const clover = IconData(0xedc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![club-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/club-fill.svg)
-  static const club = PhosphorFlatIconData(0xe1ba, 'Fill');
+  static const club = IconData(0xe1ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coat-hanger-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/coat-hanger-fill.svg)
-  static const coatHanger = PhosphorFlatIconData(0xe7fe, 'Fill');
+  static const coatHanger = IconData(0xe7fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coda-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/coda-logo-fill.svg)
-  static const codaLogo = PhosphorFlatIconData(0xe7ce, 'Fill');
+  static const codaLogo = IconData(0xe7ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/code-fill.svg)
-  static const code = PhosphorFlatIconData(0xe1bc, 'Fill');
+  static const code = IconData(0xe1bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-block-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/code-block-fill.svg)
-  static const codeBlock = PhosphorFlatIconData(0xeafe, 'Fill');
+  static const codeBlock = IconData(0xeafe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/code-simple-fill.svg)
-  static const codeSimple = PhosphorFlatIconData(0xe1be, 'Fill');
+  static const codeSimple = IconData(0xe1be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codepen-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/codepen-logo-fill.svg)
-  static const codepenLogo = PhosphorFlatIconData(0xe978, 'Fill');
+  static const codepenLogo = IconData(0xe978,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codesandbox-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/codesandbox-logo-fill.svg)
-  static const codesandboxLogo = PhosphorFlatIconData(0xea06, 'Fill');
+  static const codesandboxLogo = IconData(0xea06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/coffee-fill.svg)
-  static const coffee = PhosphorFlatIconData(0xe1c2, 'Fill');
+  static const coffee = IconData(0xe1c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-bean-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/coffee-bean-fill.svg)
-  static const coffeeBean = PhosphorFlatIconData(0xe1c0, 'Fill');
+  static const coffeeBean = IconData(0xe1c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/coin-fill.svg)
-  static const coin = PhosphorFlatIconData(0xe60e, 'Fill');
+  static const coin = IconData(0xe60e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/coin-vertical-fill.svg)
-  static const coinVertical = PhosphorFlatIconData(0xeb48, 'Fill');
+  static const coinVertical = IconData(0xeb48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coins-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/coins-fill.svg)
-  static const coins = PhosphorFlatIconData(0xe78e, 'Fill');
+  static const coins = IconData(0xe78e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/columns-fill.svg)
-  static const columns = PhosphorFlatIconData(0xe546, 'Fill');
+  static const columns = IconData(0xe546,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/columns-plus-left-fill.svg)
-  static const columnsPlusLeft = PhosphorFlatIconData(0xe544, 'Fill');
+  static const columnsPlusLeft = IconData(0xe544,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/columns-plus-right-fill.svg)
-  static const columnsPlusRight = PhosphorFlatIconData(0xe542, 'Fill');
+  static const columnsPlusRight = IconData(0xe542,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![command-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/command-fill.svg)
-  static const command = PhosphorFlatIconData(0xe1c4, 'Fill');
+  static const command = IconData(0xe1c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/compass-fill.svg)
-  static const compass = PhosphorFlatIconData(0xe1c8, 'Fill');
+  static const compass = IconData(0xe1c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-rose-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/compass-rose-fill.svg)
-  static const compassRose = PhosphorFlatIconData(0xe1c6, 'Fill');
+  static const compassRose = IconData(0xe1c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-tool-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/compass-tool-fill.svg)
-  static const compassTool = PhosphorFlatIconData(0xea0e, 'Fill');
+  static const compassTool = IconData(0xea0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![computer-tower-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/computer-tower-fill.svg)
-  static const computerTower = PhosphorFlatIconData(0xe548, 'Fill');
+  static const computerTower = IconData(0xe548,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![confetti-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/confetti-fill.svg)
-  static const confetti = PhosphorFlatIconData(0xe81a, 'Fill');
+  static const confetti = IconData(0xe81a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![contactless-payment-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/contactless-payment-fill.svg)
-  static const contactlessPayment = PhosphorFlatIconData(0xed42, 'Fill');
+  static const contactlessPayment = IconData(0xed42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![control-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/control-fill.svg)
-  static const control = PhosphorFlatIconData(0xeca6, 'Fill');
+  static const control = IconData(0xeca6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cookie-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cookie-fill.svg)
-  static const cookie = PhosphorFlatIconData(0xe6ca, 'Fill');
+  static const cookie = IconData(0xe6ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cooking-pot-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cooking-pot-fill.svg)
-  static const cookingPot = PhosphorFlatIconData(0xe764, 'Fill');
+  static const cookingPot = IconData(0xe764,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/copy-fill.svg)
-  static const copy = PhosphorFlatIconData(0xe1ca, 'Fill');
+  static const copy = IconData(0xe1ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/copy-simple-fill.svg)
-  static const copySimple = PhosphorFlatIconData(0xe1cc, 'Fill');
+  static const copySimple = IconData(0xe1cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyleft-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/copyleft-fill.svg)
-  static const copyleft = PhosphorFlatIconData(0xe86a, 'Fill');
+  static const copyleft = IconData(0xe86a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyright-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/copyright-fill.svg)
-  static const copyright = PhosphorFlatIconData(0xe54a, 'Fill');
+  static const copyright = IconData(0xe54a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-in-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/corners-in-fill.svg)
-  static const cornersIn = PhosphorFlatIconData(0xe1ce, 'Fill');
+  static const cornersIn = IconData(0xe1ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-out-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/corners-out-fill.svg)
-  static const cornersOut = PhosphorFlatIconData(0xe1d0, 'Fill');
+  static const cornersOut = IconData(0xe1d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![couch-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/couch-fill.svg)
-  static const couch = PhosphorFlatIconData(0xe7f6, 'Fill');
+  static const couch = IconData(0xe7f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![court-basketball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/court-basketball-fill.svg)
-  static const courtBasketball = PhosphorFlatIconData(0xee36, 'Fill');
+  static const courtBasketball = IconData(0xee36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cow-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cow-fill.svg)
-  static const cow = PhosphorFlatIconData(0xeabe, 'Fill');
+  static const cow = IconData(0xeabe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cowboy-hat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cowboy-hat-fill.svg)
-  static const cowboyHat = PhosphorFlatIconData(0xed12, 'Fill');
+  static const cowboyHat = IconData(0xed12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cpu-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cpu-fill.svg)
-  static const cpu = PhosphorFlatIconData(0xe610, 'Fill');
+  static const cpu = IconData(0xe610,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/crane-fill.svg)
-  static const crane = PhosphorFlatIconData(0xed48, 'Fill');
+  static const crane = IconData(0xed48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-tower-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/crane-tower-fill.svg)
-  static const craneTower = PhosphorFlatIconData(0xed49, 'Fill');
+  static const craneTower = IconData(0xed49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![credit-card-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/credit-card-fill.svg)
-  static const creditCard = PhosphorFlatIconData(0xe1d2, 'Fill');
+  static const creditCard = IconData(0xe1d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cricket-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cricket-fill.svg)
-  static const cricket = PhosphorFlatIconData(0xee12, 'Fill');
+  static const cricket = IconData(0xee12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crop-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/crop-fill.svg)
-  static const crop = PhosphorFlatIconData(0xe1d4, 'Fill');
+  static const crop = IconData(0xe1d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cross-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cross-fill.svg)
-  static const cross = PhosphorFlatIconData(0xe8a0, 'Fill');
+  static const cross = IconData(0xe8a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/crosshair-fill.svg)
-  static const crosshair = PhosphorFlatIconData(0xe1d6, 'Fill');
+  static const crosshair = IconData(0xe1d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/crosshair-simple-fill.svg)
-  static const crosshairSimple = PhosphorFlatIconData(0xe1d8, 'Fill');
+  static const crosshairSimple = IconData(0xe1d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/crown-fill.svg)
-  static const crown = PhosphorFlatIconData(0xe614, 'Fill');
+  static const crown = IconData(0xe614,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-cross-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/crown-cross-fill.svg)
-  static const crownCross = PhosphorFlatIconData(0xee5e, 'Fill');
+  static const crownCross = IconData(0xee5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/crown-simple-fill.svg)
-  static const crownSimple = PhosphorFlatIconData(0xe616, 'Fill');
+  static const crownSimple = IconData(0xe616,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cube-fill.svg)
-  static const cube = PhosphorFlatIconData(0xe1da, 'Fill');
+  static const cube = IconData(0xe1da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-focus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cube-focus-fill.svg)
-  static const cubeFocus = PhosphorFlatIconData(0xed0a, 'Fill');
+  static const cubeFocus = IconData(0xed0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-transparent-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cube-transparent-fill.svg)
-  static const cubeTransparent = PhosphorFlatIconData(0xec7c, 'Fill');
+  static const cubeTransparent = IconData(0xec7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-btc-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-btc-fill.svg)
-  static const currencyBtc = PhosphorFlatIconData(0xe618, 'Fill');
+  static const currencyBtc = IconData(0xe618,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-circle-dollar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-circle-dollar-fill.svg)
-  static const currencyCircleDollar = PhosphorFlatIconData(0xe54c, 'Fill');
+  static const currencyCircleDollar = IconData(0xe54c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-cny-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-cny-fill.svg)
-  static const currencyCny = PhosphorFlatIconData(0xe54e, 'Fill');
+  static const currencyCny = IconData(0xe54e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-dollar-fill.svg)
-  static const currencyDollar = PhosphorFlatIconData(0xe550, 'Fill');
+  static const currencyDollar = IconData(0xe550,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-dollar-simple-fill.svg)
-  static const currencyDollarSimple = PhosphorFlatIconData(0xe552, 'Fill');
+  static const currencyDollarSimple = IconData(0xe552,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eth-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-eth-fill.svg)
-  static const currencyEth = PhosphorFlatIconData(0xeada, 'Fill');
+  static const currencyEth = IconData(0xeada,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eur-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-eur-fill.svg)
-  static const currencyEur = PhosphorFlatIconData(0xe554, 'Fill');
+  static const currencyEur = IconData(0xe554,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-gbp-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-gbp-fill.svg)
-  static const currencyGbp = PhosphorFlatIconData(0xe556, 'Fill');
+  static const currencyGbp = IconData(0xe556,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-inr-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-inr-fill.svg)
-  static const currencyInr = PhosphorFlatIconData(0xe558, 'Fill');
+  static const currencyInr = IconData(0xe558,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-jpy-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-jpy-fill.svg)
-  static const currencyJpy = PhosphorFlatIconData(0xe55a, 'Fill');
+  static const currencyJpy = IconData(0xe55a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-krw-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-krw-fill.svg)
-  static const currencyKrw = PhosphorFlatIconData(0xe55c, 'Fill');
+  static const currencyKrw = IconData(0xe55c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-kzt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-kzt-fill.svg)
-  static const currencyKzt = PhosphorFlatIconData(0xec4c, 'Fill');
+  static const currencyKzt = IconData(0xec4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-ngn-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-ngn-fill.svg)
-  static const currencyNgn = PhosphorFlatIconData(0xeb52, 'Fill');
+  static const currencyNgn = IconData(0xeb52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-rub-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/currency-rub-fill.svg)
-  static const currencyRub = PhosphorFlatIconData(0xe55e, 'Fill');
+  static const currencyRub = IconData(0xe55e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cursor-fill.svg)
-  static const cursor = PhosphorFlatIconData(0xe1dc, 'Fill');
+  static const cursor = IconData(0xe1dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-click-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cursor-click-fill.svg)
-  static const cursorClick = PhosphorFlatIconData(0xe7c8, 'Fill');
+  static const cursorClick = IconData(0xe7c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-text-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cursor-text-fill.svg)
-  static const cursorText = PhosphorFlatIconData(0xe7d8, 'Fill');
+  static const cursorText = IconData(0xe7d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cylinder-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/cylinder-fill.svg)
-  static const cylinder = PhosphorFlatIconData(0xe8fc, 'Fill');
+  static const cylinder = IconData(0xe8fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![database-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/database-fill.svg)
-  static const database = PhosphorFlatIconData(0xe1de, 'Fill');
+  static const database = IconData(0xe1de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desk-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/desk-fill.svg)
-  static const desk = PhosphorFlatIconData(0xed16, 'Fill');
+  static const desk = IconData(0xed16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/desktop-fill.svg)
-  static const desktop = PhosphorFlatIconData(0xe560, 'Fill');
+  static const desktop = IconData(0xe560,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-tower-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/desktop-tower-fill.svg)
-  static const desktopTower = PhosphorFlatIconData(0xe562, 'Fill');
+  static const desktopTower = IconData(0xe562,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![detective-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/detective-fill.svg)
-  static const detective = PhosphorFlatIconData(0xe83e, 'Fill');
+  static const detective = IconData(0xe83e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dev-to-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dev-to-logo-fill.svg)
-  static const devToLogo = PhosphorFlatIconData(0xed0e, 'Fill');
+  static const devToLogo = IconData(0xed0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/device-mobile-fill.svg)
-  static const deviceMobile = PhosphorFlatIconData(0xe1e0, 'Fill');
+  static const deviceMobile = IconData(0xe1e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-camera-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/device-mobile-camera-fill.svg)
-  static const deviceMobileCamera = PhosphorFlatIconData(0xe1e2, 'Fill');
+  static const deviceMobileCamera = IconData(0xe1e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/device-mobile-slash-fill.svg)
-  static const deviceMobileSlash = PhosphorFlatIconData(0xee46, 'Fill');
+  static const deviceMobileSlash = IconData(0xee46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-speaker-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/device-mobile-speaker-fill.svg)
-  static const deviceMobileSpeaker = PhosphorFlatIconData(0xe1e4, 'Fill');
+  static const deviceMobileSpeaker = IconData(0xe1e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-rotate-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/device-rotate-fill.svg)
-  static const deviceRotate = PhosphorFlatIconData(0xedf2, 'Fill');
+  static const deviceRotate = IconData(0xedf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/device-tablet-fill.svg)
-  static const deviceTablet = PhosphorFlatIconData(0xe1e6, 'Fill');
+  static const deviceTablet = IconData(0xe1e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-camera-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/device-tablet-camera-fill.svg)
-  static const deviceTabletCamera = PhosphorFlatIconData(0xe1e8, 'Fill');
+  static const deviceTabletCamera = IconData(0xe1e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-speaker-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/device-tablet-speaker-fill.svg)
-  static const deviceTabletSpeaker = PhosphorFlatIconData(0xe1ea, 'Fill');
+  static const deviceTabletSpeaker = IconData(0xe1ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![devices-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/devices-fill.svg)
-  static const devices = PhosphorFlatIconData(0xeba4, 'Fill');
+  static const devices = IconData(0xeba4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamond-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/diamond-fill.svg)
-  static const diamond = PhosphorFlatIconData(0xe1ec, 'Fill');
+  static const diamond = IconData(0xe1ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamonds-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/diamonds-four-fill.svg)
-  static const diamondsFour = PhosphorFlatIconData(0xe8f4, 'Fill');
+  static const diamondsFour = IconData(0xe8f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-five-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dice-five-fill.svg)
-  static const diceFive = PhosphorFlatIconData(0xe1ee, 'Fill');
+  static const diceFive = IconData(0xe1ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dice-four-fill.svg)
-  static const diceFour = PhosphorFlatIconData(0xe1f0, 'Fill');
+  static const diceFour = IconData(0xe1f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-one-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dice-one-fill.svg)
-  static const diceOne = PhosphorFlatIconData(0xe1f2, 'Fill');
+  static const diceOne = IconData(0xe1f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-six-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dice-six-fill.svg)
-  static const diceSix = PhosphorFlatIconData(0xe1f4, 'Fill');
+  static const diceSix = IconData(0xe1f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dice-three-fill.svg)
-  static const diceThree = PhosphorFlatIconData(0xe1f6, 'Fill');
+  static const diceThree = IconData(0xe1f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-two-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dice-two-fill.svg)
-  static const diceTwo = PhosphorFlatIconData(0xe1f8, 'Fill');
+  static const diceTwo = IconData(0xe1f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disc-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/disc-fill.svg)
-  static const disc = PhosphorFlatIconData(0xe564, 'Fill');
+  static const disc = IconData(0xe564,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disco-ball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/disco-ball-fill.svg)
-  static const discoBall = PhosphorFlatIconData(0xed98, 'Fill');
+  static const discoBall = IconData(0xed98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![discord-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/discord-logo-fill.svg)
-  static const discordLogo = PhosphorFlatIconData(0xe61a, 'Fill');
+  static const discordLogo = IconData(0xe61a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![divide-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/divide-fill.svg)
-  static const divide = PhosphorFlatIconData(0xe1fa, 'Fill');
+  static const divide = IconData(0xe1fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dna-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dna-fill.svg)
-  static const dna = PhosphorFlatIconData(0xe924, 'Fill');
+  static const dna = IconData(0xe924,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dog-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dog-fill.svg)
-  static const dog = PhosphorFlatIconData(0xe74a, 'Fill');
+  static const dog = IconData(0xe74a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/door-fill.svg)
-  static const door = PhosphorFlatIconData(0xe61c, 'Fill');
+  static const door = IconData(0xe61c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/door-open-fill.svg)
-  static const doorOpen = PhosphorFlatIconData(0xe7e6, 'Fill');
+  static const doorOpen = IconData(0xe7e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dot-fill.svg)
-  static const dot = PhosphorFlatIconData(0xecde, 'Fill');
+  static const dot = IconData(0xecde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-outline-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dot-outline-fill.svg)
-  static const dotOutline = PhosphorFlatIconData(0xece0, 'Fill');
+  static const dotOutline = IconData(0xece0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-nine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-nine-fill.svg)
-  static const dotsNine = PhosphorFlatIconData(0xe1fc, 'Fill');
+  static const dotsNine = IconData(0xe1fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-six-fill.svg)
-  static const dotsSix = PhosphorFlatIconData(0xe794, 'Fill');
+  static const dotsSix = IconData(0xe794,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-six-vertical-fill.svg)
-  static const dotsSixVertical = PhosphorFlatIconData(0xeae2, 'Fill');
+  static const dotsSixVertical = IconData(0xeae2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-three-fill.svg)
-  static const dotsThree = PhosphorFlatIconData(0xe1fe, 'Fill');
+  static const dotsThree = IconData(0xe1fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-three-circle-fill.svg)
-  static const dotsThreeCircle = PhosphorFlatIconData(0xe200, 'Fill');
+  static const dotsThreeCircle = IconData(0xe200,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-three-circle-vertical-fill.svg)
-  static const dotsThreeCircleVertical = PhosphorFlatIconData(0xe202, 'Fill');
+  static const dotsThreeCircleVertical = IconData(0xe202,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-three-outline-fill.svg)
-  static const dotsThreeOutline = PhosphorFlatIconData(0xe204, 'Fill');
+  static const dotsThreeOutline = IconData(0xe204,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-three-outline-vertical-fill.svg)
-  static const dotsThreeOutlineVertical = PhosphorFlatIconData(0xe206, 'Fill');
+  static const dotsThreeOutlineVertical = IconData(0xe206,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dots-three-vertical-fill.svg)
-  static const dotsThreeVertical = PhosphorFlatIconData(0xe208, 'Fill');
+  static const dotsThreeVertical = IconData(0xe208,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/download-fill.svg)
-  static const download = PhosphorFlatIconData(0xe20a, 'Fill');
+  static const download = IconData(0xe20a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/download-simple-fill.svg)
-  static const downloadSimple = PhosphorFlatIconData(0xe20c, 'Fill');
+  static const downloadSimple = IconData(0xe20c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dress-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dress-fill.svg)
-  static const dress = PhosphorFlatIconData(0xea7e, 'Fill');
+  static const dress = IconData(0xea7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dresser-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dresser-fill.svg)
-  static const dresser = PhosphorFlatIconData(0xe94e, 'Fill');
+  static const dresser = IconData(0xe94e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dribbble-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dribbble-logo-fill.svg)
-  static const dribbbleLogo = PhosphorFlatIconData(0xe20e, 'Fill');
+  static const dribbbleLogo = IconData(0xe20e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drone-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/drone-fill.svg)
-  static const drone = PhosphorFlatIconData(0xed74, 'Fill');
+  static const drone = IconData(0xed74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/drop-fill.svg)
-  static const drop = PhosphorFlatIconData(0xe210, 'Fill');
+  static const drop = IconData(0xe210,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/drop-half-fill.svg)
-  static const dropHalf = PhosphorFlatIconData(0xe566, 'Fill');
+  static const dropHalf = IconData(0xe566,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-bottom-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/drop-half-bottom-fill.svg)
-  static const dropHalfBottom = PhosphorFlatIconData(0xeb40, 'Fill');
+  static const dropHalfBottom = IconData(0xeb40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/drop-simple-fill.svg)
-  static const dropSimple = PhosphorFlatIconData(0xee32, 'Fill');
+  static const dropSimple = IconData(0xee32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/drop-slash-fill.svg)
-  static const dropSlash = PhosphorFlatIconData(0xe954, 'Fill');
+  static const dropSlash = IconData(0xe954,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dropbox-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/dropbox-logo-fill.svg)
-  static const dropboxLogo = PhosphorFlatIconData(0xe7d0, 'Fill');
+  static const dropboxLogo = IconData(0xe7d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ear-fill.svg)
-  static const ear = PhosphorFlatIconData(0xe70c, 'Fill');
+  static const ear = IconData(0xe70c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ear-slash-fill.svg)
-  static const earSlash = PhosphorFlatIconData(0xe70e, 'Fill');
+  static const earSlash = IconData(0xe70e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/egg-fill.svg)
-  static const egg = PhosphorFlatIconData(0xe812, 'Fill');
+  static const egg = IconData(0xe812,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-crack-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/egg-crack-fill.svg)
-  static const eggCrack = PhosphorFlatIconData(0xeb64, 'Fill');
+  static const eggCrack = IconData(0xeb64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eject-fill.svg)
-  static const eject = PhosphorFlatIconData(0xe212, 'Fill');
+  static const eject = IconData(0xe212,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eject-simple-fill.svg)
-  static const ejectSimple = PhosphorFlatIconData(0xe6ae, 'Fill');
+  static const ejectSimple = IconData(0xe6ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![elevator-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/elevator-fill.svg)
-  static const elevator = PhosphorFlatIconData(0xecc0, 'Fill');
+  static const elevator = IconData(0xecc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![empty-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/empty-fill.svg)
-  static const empty = PhosphorFlatIconData(0xedbc, 'Fill');
+  static const empty = IconData(0xedbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![engine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/engine-fill.svg)
-  static const engine = PhosphorFlatIconData(0xea80, 'Fill');
+  static const engine = IconData(0xea80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/envelope-fill.svg)
-  static const envelope = PhosphorFlatIconData(0xe214, 'Fill');
+  static const envelope = IconData(0xe214,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/envelope-open-fill.svg)
-  static const envelopeOpen = PhosphorFlatIconData(0xe216, 'Fill');
+  static const envelopeOpen = IconData(0xe216,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/envelope-simple-fill.svg)
-  static const envelopeSimple = PhosphorFlatIconData(0xe218, 'Fill');
+  static const envelopeSimple = IconData(0xe218,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/envelope-simple-open-fill.svg)
-  static const envelopeSimpleOpen = PhosphorFlatIconData(0xe21a, 'Fill');
+  static const envelopeSimpleOpen = IconData(0xe21a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equalizer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/equalizer-fill.svg)
-  static const equalizer = PhosphorFlatIconData(0xebbc, 'Fill');
+  static const equalizer = IconData(0xebbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equals-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/equals-fill.svg)
-  static const equals = PhosphorFlatIconData(0xe21c, 'Fill');
+  static const equals = IconData(0xe21c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eraser-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eraser-fill.svg)
-  static const eraser = PhosphorFlatIconData(0xe21e, 'Fill');
+  static const eraser = IconData(0xe21e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/escalator-down-fill.svg)
-  static const escalatorDown = PhosphorFlatIconData(0xecba, 'Fill');
+  static const escalatorDown = IconData(0xecba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/escalator-up-fill.svg)
-  static const escalatorUp = PhosphorFlatIconData(0xecbc, 'Fill');
+  static const escalatorUp = IconData(0xecbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exam-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/exam-fill.svg)
-  static const exam = PhosphorFlatIconData(0xe742, 'Fill');
+  static const exam = IconData(0xe742,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclamation-mark-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/exclamation-mark-fill.svg)
-  static const exclamationMark = PhosphorFlatIconData(0xee44, 'Fill');
+  static const exclamationMark = IconData(0xee44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/exclude-fill.svg)
-  static const exclude = PhosphorFlatIconData(0xe882, 'Fill');
+  static const exclude = IconData(0xe882,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/exclude-square-fill.svg)
-  static const excludeSquare = PhosphorFlatIconData(0xe880, 'Fill');
+  static const excludeSquare = IconData(0xe880,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![export-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/export-fill.svg)
-  static const export = PhosphorFlatIconData(0xeaf0, 'Fill');
+  static const export = IconData(0xeaf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eye-fill.svg)
-  static const eye = PhosphorFlatIconData(0xe220, 'Fill');
+  static const eye = IconData(0xe220,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-closed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eye-closed-fill.svg)
-  static const eyeClosed = PhosphorFlatIconData(0xe222, 'Fill');
+  static const eyeClosed = IconData(0xe222,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eye-slash-fill.svg)
-  static const eyeSlash = PhosphorFlatIconData(0xe224, 'Fill');
+  static const eyeSlash = IconData(0xe224,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eyedropper-fill.svg)
-  static const eyedropper = PhosphorFlatIconData(0xe568, 'Fill');
+  static const eyedropper = IconData(0xe568,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-sample-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eyedropper-sample-fill.svg)
-  static const eyedropperSample = PhosphorFlatIconData(0xeac4, 'Fill');
+  static const eyedropperSample = IconData(0xeac4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyeglasses-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eyeglasses-fill.svg)
-  static const eyeglasses = PhosphorFlatIconData(0xe7ba, 'Fill');
+  static const eyeglasses = IconData(0xe7ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyes-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/eyes-fill.svg)
-  static const eyes = PhosphorFlatIconData(0xee5c, 'Fill');
+  static const eyes = IconData(0xee5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![face-mask-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/face-mask-fill.svg)
-  static const faceMask = PhosphorFlatIconData(0xe56a, 'Fill');
+  static const faceMask = IconData(0xe56a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![facebook-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/facebook-logo-fill.svg)
-  static const facebookLogo = PhosphorFlatIconData(0xe226, 'Fill');
+  static const facebookLogo = IconData(0xe226,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![factory-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/factory-fill.svg)
-  static const factory = PhosphorFlatIconData(0xe760, 'Fill');
+  static const factory = IconData(0xe760,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/faders-fill.svg)
-  static const faders = PhosphorFlatIconData(0xe228, 'Fill');
+  static const faders = IconData(0xe228,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/faders-horizontal-fill.svg)
-  static const fadersHorizontal = PhosphorFlatIconData(0xe22a, 'Fill');
+  static const fadersHorizontal = IconData(0xe22a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fallout-shelter-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fallout-shelter-fill.svg)
-  static const falloutShelter = PhosphorFlatIconData(0xe9de, 'Fill');
+  static const falloutShelter = IconData(0xe9de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fan-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fan-fill.svg)
-  static const fan = PhosphorFlatIconData(0xe9f2, 'Fill');
+  static const fan = IconData(0xe9f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![farm-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/farm-fill.svg)
-  static const farm = PhosphorFlatIconData(0xec70, 'Fill');
+  static const farm = IconData(0xec70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fast-forward-fill.svg)
-  static const fastForward = PhosphorFlatIconData(0xe6a6, 'Fill');
+  static const fastForward = IconData(0xe6a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fast-forward-circle-fill.svg)
-  static const fastForwardCircle = PhosphorFlatIconData(0xe22c, 'Fill');
+  static const fastForwardCircle = IconData(0xe22c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![feather-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/feather-fill.svg)
-  static const feather = PhosphorFlatIconData(0xe9c0, 'Fill');
+  static const feather = IconData(0xe9c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fediverse-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fediverse-logo-fill.svg)
-  static const fediverseLogo = PhosphorFlatIconData(0xed66, 'Fill');
+  static const fediverseLogo = IconData(0xed66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![figma-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/figma-logo-fill.svg)
-  static const figmaLogo = PhosphorFlatIconData(0xe22e, 'Fill');
+  static const figmaLogo = IconData(0xe22e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-fill.svg)
-  static const file = PhosphorFlatIconData(0xe230, 'Fill');
+  static const file = IconData(0xe230,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-archive-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-archive-fill.svg)
-  static const fileArchive = PhosphorFlatIconData(0xeb2a, 'Fill');
+  static const fileArchive = IconData(0xeb2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-arrow-down-fill.svg)
-  static const fileArrowDown = PhosphorFlatIconData(0xe232, 'Fill');
+  static const fileArrowDown = IconData(0xe232,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-arrow-up-fill.svg)
-  static const fileArrowUp = PhosphorFlatIconData(0xe61e, 'Fill');
+  static const fileArrowUp = IconData(0xe61e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-audio-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-audio-fill.svg)
-  static const fileAudio = PhosphorFlatIconData(0xea20, 'Fill');
+  static const fileAudio = IconData(0xea20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-c-fill.svg)
-  static const fileC = PhosphorFlatIconData(0xeb32, 'Fill');
+  static const fileC = IconData(0xeb32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-sharp-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-c-sharp-fill.svg)
-  static const fileCSharp = PhosphorFlatIconData(0xeb30, 'Fill');
+  static const fileCSharp = IconData(0xeb30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cloud-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-cloud-fill.svg)
-  static const fileCloud = PhosphorFlatIconData(0xe95e, 'Fill');
+  static const fileCloud = IconData(0xe95e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-code-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-code-fill.svg)
-  static const fileCode = PhosphorFlatIconData(0xe914, 'Fill');
+  static const fileCode = IconData(0xe914,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cpp-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-cpp-fill.svg)
-  static const fileCpp = PhosphorFlatIconData(0xeb2e, 'Fill');
+  static const fileCpp = IconData(0xeb2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-css-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-css-fill.svg)
-  static const fileCss = PhosphorFlatIconData(0xeb34, 'Fill');
+  static const fileCss = IconData(0xeb34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-csv-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-csv-fill.svg)
-  static const fileCsv = PhosphorFlatIconData(0xeb1c, 'Fill');
+  static const fileCsv = IconData(0xeb1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-dashed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-dashed-fill.svg)
-  static const fileDashed = PhosphorFlatIconData(0xe704, 'Fill');
+  static const fileDashed = IconData(0xe704,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-doc-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-doc-fill.svg)
-  static const fileDoc = PhosphorFlatIconData(0xeb1e, 'Fill');
+  static const fileDoc = IconData(0xeb1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-html-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-html-fill.svg)
-  static const fileHtml = PhosphorFlatIconData(0xeb38, 'Fill');
+  static const fileHtml = IconData(0xeb38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-image-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-image-fill.svg)
-  static const fileImage = PhosphorFlatIconData(0xea24, 'Fill');
+  static const fileImage = IconData(0xea24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ini-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-ini-fill.svg)
-  static const fileIni = PhosphorFlatIconData(0xeb33, 'Fill');
+  static const fileIni = IconData(0xeb33,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jpg-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-jpg-fill.svg)
-  static const fileJpg = PhosphorFlatIconData(0xeb1a, 'Fill');
+  static const fileJpg = IconData(0xeb1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-js-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-js-fill.svg)
-  static const fileJs = PhosphorFlatIconData(0xeb24, 'Fill');
+  static const fileJs = IconData(0xeb24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jsx-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-jsx-fill.svg)
-  static const fileJsx = PhosphorFlatIconData(0xeb3a, 'Fill');
+  static const fileJsx = IconData(0xeb3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-lock-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-lock-fill.svg)
-  static const fileLock = PhosphorFlatIconData(0xe95c, 'Fill');
+  static const fileLock = IconData(0xe95c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-magnifying-glass-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-magnifying-glass-fill.svg)
-  static const fileMagnifyingGlass = PhosphorFlatIconData(0xe238, 'Fill');
+  static const fileMagnifyingGlass = IconData(0xe238,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-md-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-md-fill.svg)
-  static const fileMd = PhosphorFlatIconData(0xed50, 'Fill');
+  static const fileMd = IconData(0xed50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-minus-fill.svg)
-  static const fileMinus = PhosphorFlatIconData(0xe234, 'Fill');
+  static const fileMinus = IconData(0xe234,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-pdf-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-pdf-fill.svg)
-  static const filePdf = PhosphorFlatIconData(0xe702, 'Fill');
+  static const filePdf = IconData(0xe702,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-plus-fill.svg)
-  static const filePlus = PhosphorFlatIconData(0xe236, 'Fill');
+  static const filePlus = IconData(0xe236,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-png-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-png-fill.svg)
-  static const filePng = PhosphorFlatIconData(0xeb18, 'Fill');
+  static const filePng = IconData(0xeb18,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ppt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-ppt-fill.svg)
-  static const filePpt = PhosphorFlatIconData(0xeb20, 'Fill');
+  static const filePpt = IconData(0xeb20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-py-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-py-fill.svg)
-  static const filePy = PhosphorFlatIconData(0xeb2c, 'Fill');
+  static const filePy = IconData(0xeb2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-rs-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-rs-fill.svg)
-  static const fileRs = PhosphorFlatIconData(0xeb28, 'Fill');
+  static const fileRs = IconData(0xeb28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-sql-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-sql-fill.svg)
-  static const fileSql = PhosphorFlatIconData(0xed4e, 'Fill');
+  static const fileSql = IconData(0xed4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-svg-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-svg-fill.svg)
-  static const fileSvg = PhosphorFlatIconData(0xed08, 'Fill');
+  static const fileSvg = IconData(0xed08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-text-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-text-fill.svg)
-  static const fileText = PhosphorFlatIconData(0xe23a, 'Fill');
+  static const fileText = IconData(0xe23a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ts-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-ts-fill.svg)
-  static const fileTs = PhosphorFlatIconData(0xeb26, 'Fill');
+  static const fileTs = IconData(0xeb26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-tsx-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-tsx-fill.svg)
-  static const fileTsx = PhosphorFlatIconData(0xeb3c, 'Fill');
+  static const fileTsx = IconData(0xeb3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-txt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-txt-fill.svg)
-  static const fileTxt = PhosphorFlatIconData(0xeb35, 'Fill');
+  static const fileTxt = IconData(0xeb35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-video-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-video-fill.svg)
-  static const fileVideo = PhosphorFlatIconData(0xea22, 'Fill');
+  static const fileVideo = IconData(0xea22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-vue-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-vue-fill.svg)
-  static const fileVue = PhosphorFlatIconData(0xeb3e, 'Fill');
+  static const fileVue = IconData(0xeb3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-x-fill.svg)
-  static const fileX = PhosphorFlatIconData(0xe23c, 'Fill');
+  static const fileX = IconData(0xe23c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-xls-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-xls-fill.svg)
-  static const fileXls = PhosphorFlatIconData(0xeb22, 'Fill');
+  static const fileXls = IconData(0xeb22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-zip-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/file-zip-fill.svg)
-  static const fileZip = PhosphorFlatIconData(0xe958, 'Fill');
+  static const fileZip = IconData(0xe958,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![files-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/files-fill.svg)
-  static const files = PhosphorFlatIconData(0xe710, 'Fill');
+  static const files = IconData(0xe710,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-reel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/film-reel-fill.svg)
-  static const filmReel = PhosphorFlatIconData(0xe8c0, 'Fill');
+  static const filmReel = IconData(0xe8c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-script-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/film-script-fill.svg)
-  static const filmScript = PhosphorFlatIconData(0xeb50, 'Fill');
+  static const filmScript = IconData(0xeb50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-slate-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/film-slate-fill.svg)
-  static const filmSlate = PhosphorFlatIconData(0xe8c2, 'Fill');
+  static const filmSlate = IconData(0xe8c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-strip-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/film-strip-fill.svg)
-  static const filmStrip = PhosphorFlatIconData(0xe792, 'Fill');
+  static const filmStrip = IconData(0xe792,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fingerprint-fill.svg)
-  static const fingerprint = PhosphorFlatIconData(0xe23e, 'Fill');
+  static const fingerprint = IconData(0xe23e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fingerprint-simple-fill.svg)
-  static const fingerprintSimple = PhosphorFlatIconData(0xe240, 'Fill');
+  static const fingerprintSimple = IconData(0xe240,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![finn-the-human-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/finn-the-human-fill.svg)
-  static const finnTheHuman = PhosphorFlatIconData(0xe56c, 'Fill');
+  static const finnTheHuman = IconData(0xe56c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fire-fill.svg)
-  static const fire = PhosphorFlatIconData(0xe242, 'Fill');
+  static const fire = IconData(0xe242,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-extinguisher-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fire-extinguisher-fill.svg)
-  static const fireExtinguisher = PhosphorFlatIconData(0xe9e8, 'Fill');
+  static const fireExtinguisher = IconData(0xe9e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fire-simple-fill.svg)
-  static const fireSimple = PhosphorFlatIconData(0xe620, 'Fill');
+  static const fireSimple = IconData(0xe620,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-truck-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fire-truck-fill.svg)
-  static const fireTruck = PhosphorFlatIconData(0xe574, 'Fill');
+  static const fireTruck = IconData(0xe574,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/first-aid-fill.svg)
-  static const firstAid = PhosphorFlatIconData(0xe56e, 'Fill');
+  static const firstAid = IconData(0xe56e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-kit-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/first-aid-kit-fill.svg)
-  static const firstAidKit = PhosphorFlatIconData(0xe570, 'Fill');
+  static const firstAidKit = IconData(0xe570,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fish-fill.svg)
-  static const fish = PhosphorFlatIconData(0xe728, 'Fill');
+  static const fish = IconData(0xe728,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fish-simple-fill.svg)
-  static const fishSimple = PhosphorFlatIconData(0xe72a, 'Fill');
+  static const fishSimple = IconData(0xe72a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flag-fill.svg)
-  static const flag = PhosphorFlatIconData(0xe244, 'Fill');
+  static const flag = IconData(0xe244,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flag-banner-fill.svg)
-  static const flagBanner = PhosphorFlatIconData(0xe622, 'Fill');
+  static const flagBanner = IconData(0xe622,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-fold-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flag-banner-fold-fill.svg)
-  static const flagBannerFold = PhosphorFlatIconData(0xecf2, 'Fill');
+  static const flagBannerFold = IconData(0xecf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-checkered-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flag-checkered-fill.svg)
-  static const flagCheckered = PhosphorFlatIconData(0xea38, 'Fill');
+  static const flagCheckered = IconData(0xea38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-pennant-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flag-pennant-fill.svg)
-  static const flagPennant = PhosphorFlatIconData(0xecf0, 'Fill');
+  static const flagPennant = IconData(0xecf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flame-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flame-fill.svg)
-  static const flame = PhosphorFlatIconData(0xe624, 'Fill');
+  static const flame = IconData(0xe624,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flashlight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flashlight-fill.svg)
-  static const flashlight = PhosphorFlatIconData(0xe246, 'Fill');
+  static const flashlight = IconData(0xe246,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flask-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flask-fill.svg)
-  static const flask = PhosphorFlatIconData(0xe79e, 'Fill');
+  static const flask = IconData(0xe79e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flip-horizontal-fill.svg)
-  static const flipHorizontal = PhosphorFlatIconData(0xed6a, 'Fill');
+  static const flipHorizontal = IconData(0xed6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flip-vertical-fill.svg)
-  static const flipVertical = PhosphorFlatIconData(0xed6c, 'Fill');
+  static const flipVertical = IconData(0xed6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/floppy-disk-fill.svg)
-  static const floppyDisk = PhosphorFlatIconData(0xe248, 'Fill');
+  static const floppyDisk = IconData(0xe248,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-back-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/floppy-disk-back-fill.svg)
-  static const floppyDiskBack = PhosphorFlatIconData(0xeaf4, 'Fill');
+  static const floppyDiskBack = IconData(0xeaf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flow-arrow-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flow-arrow-fill.svg)
-  static const flowArrow = PhosphorFlatIconData(0xe6ec, 'Fill');
+  static const flowArrow = IconData(0xe6ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flower-fill.svg)
-  static const flower = PhosphorFlatIconData(0xe75e, 'Fill');
+  static const flower = IconData(0xe75e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-lotus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flower-lotus-fill.svg)
-  static const flowerLotus = PhosphorFlatIconData(0xe6cc, 'Fill');
+  static const flowerLotus = IconData(0xe6cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-tulip-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flower-tulip-fill.svg)
-  static const flowerTulip = PhosphorFlatIconData(0xeacc, 'Fill');
+  static const flowerTulip = IconData(0xeacc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flying-saucer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/flying-saucer-fill.svg)
-  static const flyingSaucer = PhosphorFlatIconData(0xeb4a, 'Fill');
+  static const flyingSaucer = IconData(0xeb4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-fill.svg)
-  static const folder = PhosphorFlatIconData(0xe24a, 'Fill');
+  static const folder = IconData(0xe24a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-dashed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-dashed-fill.svg)
-  static const folderDashed = PhosphorFlatIconData(0xe8f8, 'Fill');
+  static const folderDashed = IconData(0xe8f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-lock-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-lock-fill.svg)
-  static const folderLock = PhosphorFlatIconData(0xea3c, 'Fill');
+  static const folderLock = IconData(0xea3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-minus-fill.svg)
-  static const folderMinus = PhosphorFlatIconData(0xe254, 'Fill');
+  static const folderMinus = IconData(0xe254,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-open-fill.svg)
-  static const folderOpen = PhosphorFlatIconData(0xe256, 'Fill');
+  static const folderOpen = IconData(0xe256,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-plus-fill.svg)
-  static const folderPlus = PhosphorFlatIconData(0xe258, 'Fill');
+  static const folderPlus = IconData(0xe258,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-simple-fill.svg)
-  static const folderSimple = PhosphorFlatIconData(0xe25a, 'Fill');
+  static const folderSimple = IconData(0xe25a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-dashed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-simple-dashed-fill.svg)
-  static const folderSimpleDashed = PhosphorFlatIconData(0xec2a, 'Fill');
+  static const folderSimpleDashed = IconData(0xec2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-lock-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-simple-lock-fill.svg)
-  static const folderSimpleLock = PhosphorFlatIconData(0xeb5e, 'Fill');
+  static const folderSimpleLock = IconData(0xeb5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-simple-minus-fill.svg)
-  static const folderSimpleMinus = PhosphorFlatIconData(0xe25c, 'Fill');
+  static const folderSimpleMinus = IconData(0xe25c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-simple-plus-fill.svg)
-  static const folderSimplePlus = PhosphorFlatIconData(0xe25e, 'Fill');
+  static const folderSimplePlus = IconData(0xe25e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-star-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-simple-star-fill.svg)
-  static const folderSimpleStar = PhosphorFlatIconData(0xec2e, 'Fill');
+  static const folderSimpleStar = IconData(0xec2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-user-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-simple-user-fill.svg)
-  static const folderSimpleUser = PhosphorFlatIconData(0xeb60, 'Fill');
+  static const folderSimpleUser = IconData(0xeb60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-star-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-star-fill.svg)
-  static const folderStar = PhosphorFlatIconData(0xea86, 'Fill');
+  static const folderStar = IconData(0xea86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-user-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folder-user-fill.svg)
-  static const folderUser = PhosphorFlatIconData(0xeb46, 'Fill');
+  static const folderUser = IconData(0xeb46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folders-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/folders-fill.svg)
-  static const folders = PhosphorFlatIconData(0xe260, 'Fill');
+  static const folders = IconData(0xe260,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/football-fill.svg)
-  static const football = PhosphorFlatIconData(0xe718, 'Fill');
+  static const football = IconData(0xe718,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-helmet-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/football-helmet-fill.svg)
-  static const footballHelmet = PhosphorFlatIconData(0xee4c, 'Fill');
+  static const footballHelmet = IconData(0xee4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![footprints-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/footprints-fill.svg)
-  static const footprints = PhosphorFlatIconData(0xea88, 'Fill');
+  static const footprints = IconData(0xea88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fork-knife-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/fork-knife-fill.svg)
-  static const forkKnife = PhosphorFlatIconData(0xe262, 'Fill');
+  static const forkKnife = IconData(0xe262,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![four-k-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/four-k-fill.svg)
-  static const fourK = PhosphorFlatIconData(0xea5c, 'Fill');
+  static const fourK = IconData(0xea5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![frame-corners-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/frame-corners-fill.svg)
-  static const frameCorners = PhosphorFlatIconData(0xe626, 'Fill');
+  static const frameCorners = IconData(0xe626,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![framer-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/framer-logo-fill.svg)
-  static const framerLogo = PhosphorFlatIconData(0xe264, 'Fill');
+  static const framerLogo = IconData(0xe264,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![function-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/function-fill.svg)
-  static const function = PhosphorFlatIconData(0xebe4, 'Fill');
+  static const function = IconData(0xebe4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/funnel-fill.svg)
-  static const funnel = PhosphorFlatIconData(0xe266, 'Fill');
+  static const funnel = IconData(0xe266,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/funnel-simple-fill.svg)
-  static const funnelSimple = PhosphorFlatIconData(0xe268, 'Fill');
+  static const funnelSimple = IconData(0xe268,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/funnel-simple-x-fill.svg)
-  static const funnelSimpleX = PhosphorFlatIconData(0xe26a, 'Fill');
+  static const funnelSimpleX = IconData(0xe26a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/funnel-x-fill.svg)
-  static const funnelX = PhosphorFlatIconData(0xe26c, 'Fill');
+  static const funnelX = IconData(0xe26c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![game-controller-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/game-controller-fill.svg)
-  static const gameController = PhosphorFlatIconData(0xe26e, 'Fill');
+  static const gameController = IconData(0xe26e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![garage-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/garage-fill.svg)
-  static const garage = PhosphorFlatIconData(0xecd6, 'Fill');
+  static const garage = IconData(0xecd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-can-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gas-can-fill.svg)
-  static const gasCan = PhosphorFlatIconData(0xe8ce, 'Fill');
+  static const gasCan = IconData(0xe8ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-pump-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gas-pump-fill.svg)
-  static const gasPump = PhosphorFlatIconData(0xe768, 'Fill');
+  static const gasPump = IconData(0xe768,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gauge-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gauge-fill.svg)
-  static const gauge = PhosphorFlatIconData(0xe628, 'Fill');
+  static const gauge = IconData(0xe628,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gavel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gavel-fill.svg)
-  static const gavel = PhosphorFlatIconData(0xea32, 'Fill');
+  static const gavel = IconData(0xea32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gear-fill.svg)
-  static const gear = PhosphorFlatIconData(0xe270, 'Fill');
+  static const gear = IconData(0xe270,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-fine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gear-fine-fill.svg)
-  static const gearFine = PhosphorFlatIconData(0xe87c, 'Fill');
+  static const gearFine = IconData(0xe87c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-six-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gear-six-fill.svg)
-  static const gearSix = PhosphorFlatIconData(0xe272, 'Fill');
+  static const gearSix = IconData(0xe272,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-female-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gender-female-fill.svg)
-  static const genderFemale = PhosphorFlatIconData(0xe6e0, 'Fill');
+  static const genderFemale = IconData(0xe6e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-intersex-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gender-intersex-fill.svg)
-  static const genderIntersex = PhosphorFlatIconData(0xe6e6, 'Fill');
+  static const genderIntersex = IconData(0xe6e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-male-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gender-male-fill.svg)
-  static const genderMale = PhosphorFlatIconData(0xe6e2, 'Fill');
+  static const genderMale = IconData(0xe6e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-neuter-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gender-neuter-fill.svg)
-  static const genderNeuter = PhosphorFlatIconData(0xe6ea, 'Fill');
+  static const genderNeuter = IconData(0xe6ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-nonbinary-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gender-nonbinary-fill.svg)
-  static const genderNonbinary = PhosphorFlatIconData(0xe6e4, 'Fill');
+  static const genderNonbinary = IconData(0xe6e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-transgender-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gender-transgender-fill.svg)
-  static const genderTransgender = PhosphorFlatIconData(0xe6e8, 'Fill');
+  static const genderTransgender = IconData(0xe6e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ghost-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ghost-fill.svg)
-  static const ghost = PhosphorFlatIconData(0xe62a, 'Fill');
+  static const ghost = IconData(0xe62a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gif-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gif-fill.svg)
-  static const gif = PhosphorFlatIconData(0xe274, 'Fill');
+  static const gif = IconData(0xe274,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gift-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gift-fill.svg)
-  static const gift = PhosphorFlatIconData(0xe276, 'Fill');
+  static const gift = IconData(0xe276,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-branch-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/git-branch-fill.svg)
-  static const gitBranch = PhosphorFlatIconData(0xe278, 'Fill');
+  static const gitBranch = IconData(0xe278,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-commit-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/git-commit-fill.svg)
-  static const gitCommit = PhosphorFlatIconData(0xe27a, 'Fill');
+  static const gitCommit = IconData(0xe27a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-diff-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/git-diff-fill.svg)
-  static const gitDiff = PhosphorFlatIconData(0xe27c, 'Fill');
+  static const gitDiff = IconData(0xe27c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-fork-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/git-fork-fill.svg)
-  static const gitFork = PhosphorFlatIconData(0xe27e, 'Fill');
+  static const gitFork = IconData(0xe27e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-merge-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/git-merge-fill.svg)
-  static const gitMerge = PhosphorFlatIconData(0xe280, 'Fill');
+  static const gitMerge = IconData(0xe280,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-pull-request-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/git-pull-request-fill.svg)
-  static const gitPullRequest = PhosphorFlatIconData(0xe282, 'Fill');
+  static const gitPullRequest = IconData(0xe282,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![github-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/github-logo-fill.svg)
-  static const githubLogo = PhosphorFlatIconData(0xe576, 'Fill');
+  static const githubLogo = IconData(0xe576,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gitlab-logo-fill.svg)
-  static const gitlabLogo = PhosphorFlatIconData(0xe694, 'Fill');
+  static const gitlabLogo = IconData(0xe694,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gitlab-logo-simple-fill.svg)
-  static const gitlabLogoSimple = PhosphorFlatIconData(0xe696, 'Fill');
+  static const gitlabLogoSimple = IconData(0xe696,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/globe-fill.svg)
-  static const globe = PhosphorFlatIconData(0xe288, 'Fill');
+  static const globe = IconData(0xe288,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-east-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/globe-hemisphere-east-fill.svg)
-  static const globeHemisphereEast = PhosphorFlatIconData(0xe28a, 'Fill');
+  static const globeHemisphereEast = IconData(0xe28a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-west-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/globe-hemisphere-west-fill.svg)
-  static const globeHemisphereWest = PhosphorFlatIconData(0xe28c, 'Fill');
+  static const globeHemisphereWest = IconData(0xe28c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/globe-simple-fill.svg)
-  static const globeSimple = PhosphorFlatIconData(0xe28e, 'Fill');
+  static const globeSimple = IconData(0xe28e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/globe-simple-x-fill.svg)
-  static const globeSimpleX = PhosphorFlatIconData(0xe284, 'Fill');
+  static const globeSimpleX = IconData(0xe284,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-stand-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/globe-stand-fill.svg)
-  static const globeStand = PhosphorFlatIconData(0xe290, 'Fill');
+  static const globeStand = IconData(0xe290,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/globe-x-fill.svg)
-  static const globeX = PhosphorFlatIconData(0xe286, 'Fill');
+  static const globeX = IconData(0xe286,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goggles-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/goggles-fill.svg)
-  static const goggles = PhosphorFlatIconData(0xecb4, 'Fill');
+  static const goggles = IconData(0xecb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![golf-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/golf-fill.svg)
-  static const golf = PhosphorFlatIconData(0xea3e, 'Fill');
+  static const golf = IconData(0xea3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goodreads-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/goodreads-logo-fill.svg)
-  static const goodreadsLogo = PhosphorFlatIconData(0xed10, 'Fill');
+  static const goodreadsLogo = IconData(0xed10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-cardboard-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/google-cardboard-logo-fill.svg)
-  static const googleCardboardLogo = PhosphorFlatIconData(0xe7b6, 'Fill');
+  static const googleCardboardLogo = IconData(0xe7b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-chrome-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/google-chrome-logo-fill.svg)
-  static const googleChromeLogo = PhosphorFlatIconData(0xe976, 'Fill');
+  static const googleChromeLogo = IconData(0xe976,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-drive-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/google-drive-logo-fill.svg)
-  static const googleDriveLogo = PhosphorFlatIconData(0xe8f6, 'Fill');
+  static const googleDriveLogo = IconData(0xe8f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/google-logo-fill.svg)
-  static const googleLogo = PhosphorFlatIconData(0xe292, 'Fill');
+  static const googleLogo = IconData(0xe292,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-photos-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/google-photos-logo-fill.svg)
-  static const googlePhotosLogo = PhosphorFlatIconData(0xeb92, 'Fill');
+  static const googlePhotosLogo = IconData(0xeb92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-play-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/google-play-logo-fill.svg)
-  static const googlePlayLogo = PhosphorFlatIconData(0xe294, 'Fill');
+  static const googlePlayLogo = IconData(0xe294,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-podcasts-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/google-podcasts-logo-fill.svg)
-  static const googlePodcastsLogo = PhosphorFlatIconData(0xeb94, 'Fill');
+  static const googlePodcastsLogo = IconData(0xeb94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gps-fill.svg)
-  static const gps = PhosphorFlatIconData(0xedd8, 'Fill');
+  static const gps = IconData(0xedd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-fix-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gps-fix-fill.svg)
-  static const gpsFix = PhosphorFlatIconData(0xedd6, 'Fill');
+  static const gpsFix = IconData(0xedd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gps-slash-fill.svg)
-  static const gpsSlash = PhosphorFlatIconData(0xedd4, 'Fill');
+  static const gpsSlash = IconData(0xedd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gradient-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/gradient-fill.svg)
-  static const gradient = PhosphorFlatIconData(0xeb42, 'Fill');
+  static const gradient = IconData(0xeb42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graduation-cap-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/graduation-cap-fill.svg)
-  static const graduationCap = PhosphorFlatIconData(0xe62c, 'Fill');
+  static const graduationCap = IconData(0xe62c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/grains-fill.svg)
-  static const grains = PhosphorFlatIconData(0xec68, 'Fill');
+  static const grains = IconData(0xec68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/grains-slash-fill.svg)
-  static const grainsSlash = PhosphorFlatIconData(0xec6a, 'Fill');
+  static const grainsSlash = IconData(0xec6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graph-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/graph-fill.svg)
-  static const graph = PhosphorFlatIconData(0xeb58, 'Fill');
+  static const graph = IconData(0xeb58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graphics-card-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/graphics-card-fill.svg)
-  static const graphicsCard = PhosphorFlatIconData(0xe612, 'Fill');
+  static const graphicsCard = IconData(0xe612,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/greater-than-fill.svg)
-  static const greaterThan = PhosphorFlatIconData(0xedc4, 'Fill');
+  static const greaterThan = IconData(0xedc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-or-equal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/greater-than-or-equal-fill.svg)
-  static const greaterThanOrEqual = PhosphorFlatIconData(0xeda2, 'Fill');
+  static const greaterThanOrEqual = IconData(0xeda2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/grid-four-fill.svg)
-  static const gridFour = PhosphorFlatIconData(0xe296, 'Fill');
+  static const gridFour = IconData(0xe296,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-nine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/grid-nine-fill.svg)
-  static const gridNine = PhosphorFlatIconData(0xec8c, 'Fill');
+  static const gridNine = IconData(0xec8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![guitar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/guitar-fill.svg)
-  static const guitar = PhosphorFlatIconData(0xea8a, 'Fill');
+  static const guitar = IconData(0xea8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hair-dryer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hair-dryer-fill.svg)
-  static const hairDryer = PhosphorFlatIconData(0xea66, 'Fill');
+  static const hairDryer = IconData(0xea66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hamburger-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hamburger-fill.svg)
-  static const hamburger = PhosphorFlatIconData(0xe790, 'Fill');
+  static const hamburger = IconData(0xe790,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hammer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hammer-fill.svg)
-  static const hammer = PhosphorFlatIconData(0xe80e, 'Fill');
+  static const hammer = IconData(0xe80e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-fill.svg)
-  static const hand = PhosphorFlatIconData(0xe298, 'Fill');
+  static const hand = IconData(0xe298,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-arrow-down-fill.svg)
-  static const handArrowDown = PhosphorFlatIconData(0xea4e, 'Fill');
+  static const handArrowDown = IconData(0xea4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-arrow-up-fill.svg)
-  static const handArrowUp = PhosphorFlatIconData(0xee5a, 'Fill');
+  static const handArrowUp = IconData(0xee5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-coins-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-coins-fill.svg)
-  static const handCoins = PhosphorFlatIconData(0xea8c, 'Fill');
+  static const handCoins = IconData(0xea8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-deposit-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-deposit-fill.svg)
-  static const handDeposit = PhosphorFlatIconData(0xee82, 'Fill');
+  static const handDeposit = IconData(0xee82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-eye-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-eye-fill.svg)
-  static const handEye = PhosphorFlatIconData(0xea4c, 'Fill');
+  static const handEye = IconData(0xea4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-fist-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-fist-fill.svg)
-  static const handFist = PhosphorFlatIconData(0xe57a, 'Fill');
+  static const handFist = IconData(0xe57a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-grabbing-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-grabbing-fill.svg)
-  static const handGrabbing = PhosphorFlatIconData(0xe57c, 'Fill');
+  static const handGrabbing = IconData(0xe57c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-heart-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-heart-fill.svg)
-  static const handHeart = PhosphorFlatIconData(0xe810, 'Fill');
+  static const handHeart = IconData(0xe810,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-palm-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-palm-fill.svg)
-  static const handPalm = PhosphorFlatIconData(0xe57e, 'Fill');
+  static const handPalm = IconData(0xe57e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-peace-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-peace-fill.svg)
-  static const handPeace = PhosphorFlatIconData(0xe7cc, 'Fill');
+  static const handPeace = IconData(0xe7cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-pointing-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-pointing-fill.svg)
-  static const handPointing = PhosphorFlatIconData(0xe29a, 'Fill');
+  static const handPointing = IconData(0xe29a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-soap-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-soap-fill.svg)
-  static const handSoap = PhosphorFlatIconData(0xe630, 'Fill');
+  static const handSoap = IconData(0xe630,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-swipe-left-fill.svg)
-  static const handSwipeLeft = PhosphorFlatIconData(0xec94, 'Fill');
+  static const handSwipeLeft = IconData(0xec94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-swipe-right-fill.svg)
-  static const handSwipeRight = PhosphorFlatIconData(0xec92, 'Fill');
+  static const handSwipeRight = IconData(0xec92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-tap-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-tap-fill.svg)
-  static const handTap = PhosphorFlatIconData(0xec90, 'Fill');
+  static const handTap = IconData(0xec90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-waving-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-waving-fill.svg)
-  static const handWaving = PhosphorFlatIconData(0xe580, 'Fill');
+  static const handWaving = IconData(0xe580,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-withdraw-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hand-withdraw-fill.svg)
-  static const handWithdraw = PhosphorFlatIconData(0xee80, 'Fill');
+  static const handWithdraw = IconData(0xee80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/handbag-fill.svg)
-  static const handbag = PhosphorFlatIconData(0xe29c, 'Fill');
+  static const handbag = IconData(0xe29c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/handbag-simple-fill.svg)
-  static const handbagSimple = PhosphorFlatIconData(0xe62e, 'Fill');
+  static const handbagSimple = IconData(0xe62e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-clapping-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hands-clapping-fill.svg)
-  static const handsClapping = PhosphorFlatIconData(0xe6a0, 'Fill');
+  static const handsClapping = IconData(0xe6a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-praying-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hands-praying-fill.svg)
-  static const handsPraying = PhosphorFlatIconData(0xecc8, 'Fill');
+  static const handsPraying = IconData(0xecc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handshake-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/handshake-fill.svg)
-  static const handshake = PhosphorFlatIconData(0xe582, 'Fill');
+  static const handshake = IconData(0xe582,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drive-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hard-drive-fill.svg)
-  static const hardDrive = PhosphorFlatIconData(0xe29e, 'Fill');
+  static const hardDrive = IconData(0xe29e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drives-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hard-drives-fill.svg)
-  static const hardDrives = PhosphorFlatIconData(0xe2a0, 'Fill');
+  static const hardDrives = IconData(0xe2a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-hat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hard-hat-fill.svg)
-  static const hardHat = PhosphorFlatIconData(0xed46, 'Fill');
+  static const hardHat = IconData(0xed46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hash-fill.svg)
-  static const hash = PhosphorFlatIconData(0xe2a2, 'Fill');
+  static const hash = IconData(0xe2a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-straight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hash-straight-fill.svg)
-  static const hashStraight = PhosphorFlatIconData(0xe2a4, 'Fill');
+  static const hashStraight = IconData(0xe2a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![head-circuit-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/head-circuit-fill.svg)
-  static const headCircuit = PhosphorFlatIconData(0xe7d4, 'Fill');
+  static const headCircuit = IconData(0xe7d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headlights-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/headlights-fill.svg)
-  static const headlights = PhosphorFlatIconData(0xe6fe, 'Fill');
+  static const headlights = IconData(0xe6fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headphones-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/headphones-fill.svg)
-  static const headphones = PhosphorFlatIconData(0xe2a6, 'Fill');
+  static const headphones = IconData(0xe2a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headset-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/headset-fill.svg)
-  static const headset = PhosphorFlatIconData(0xe584, 'Fill');
+  static const headset = IconData(0xe584,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/heart-fill.svg)
-  static const heart = PhosphorFlatIconData(0xe2a8, 'Fill');
+  static const heart = IconData(0xe2a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-break-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/heart-break-fill.svg)
-  static const heartBreak = PhosphorFlatIconData(0xebe8, 'Fill');
+  static const heartBreak = IconData(0xebe8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-half-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/heart-half-fill.svg)
-  static const heartHalf = PhosphorFlatIconData(0xec48, 'Fill');
+  static const heartHalf = IconData(0xec48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/heart-straight-fill.svg)
-  static const heartStraight = PhosphorFlatIconData(0xe2aa, 'Fill');
+  static const heartStraight = IconData(0xe2aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-break-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/heart-straight-break-fill.svg)
-  static const heartStraightBreak = PhosphorFlatIconData(0xeb98, 'Fill');
+  static const heartStraightBreak = IconData(0xeb98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heartbeat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/heartbeat-fill.svg)
-  static const heartbeat = PhosphorFlatIconData(0xe2ac, 'Fill');
+  static const heartbeat = IconData(0xe2ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hexagon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hexagon-fill.svg)
-  static const hexagon = PhosphorFlatIconData(0xe2ae, 'Fill');
+  static const hexagon = IconData(0xe2ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-definition-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/high-definition-fill.svg)
-  static const highDefinition = PhosphorFlatIconData(0xea8e, 'Fill');
+  static const highDefinition = IconData(0xea8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-heel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/high-heel-fill.svg)
-  static const highHeel = PhosphorFlatIconData(0xe8e8, 'Fill');
+  static const highHeel = IconData(0xe8e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/highlighter-fill.svg)
-  static const highlighter = PhosphorFlatIconData(0xec76, 'Fill');
+  static const highlighter = IconData(0xec76,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/highlighter-circle-fill.svg)
-  static const highlighterCircle = PhosphorFlatIconData(0xe632, 'Fill');
+  static const highlighterCircle = IconData(0xe632,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hockey-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hockey-fill.svg)
-  static const hockey = PhosphorFlatIconData(0xec86, 'Fill');
+  static const hockey = IconData(0xec86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hoodie-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hoodie-fill.svg)
-  static const hoodie = PhosphorFlatIconData(0xecd0, 'Fill');
+  static const hoodie = IconData(0xecd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![horse-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/horse-fill.svg)
-  static const horse = PhosphorFlatIconData(0xe2b0, 'Fill');
+  static const horse = IconData(0xe2b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hospital-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hospital-fill.svg)
-  static const hospital = PhosphorFlatIconData(0xe844, 'Fill');
+  static const hospital = IconData(0xe844,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hourglass-fill.svg)
-  static const hourglass = PhosphorFlatIconData(0xe2b2, 'Fill');
+  static const hourglass = IconData(0xe2b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-high-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hourglass-high-fill.svg)
-  static const hourglassHigh = PhosphorFlatIconData(0xe2b4, 'Fill');
+  static const hourglassHigh = IconData(0xe2b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-low-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hourglass-low-fill.svg)
-  static const hourglassLow = PhosphorFlatIconData(0xe2b6, 'Fill');
+  static const hourglassLow = IconData(0xe2b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-medium-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hourglass-medium-fill.svg)
-  static const hourglassMedium = PhosphorFlatIconData(0xe2b8, 'Fill');
+  static const hourglassMedium = IconData(0xe2b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hourglass-simple-fill.svg)
-  static const hourglassSimple = PhosphorFlatIconData(0xe2ba, 'Fill');
+  static const hourglassSimple = IconData(0xe2ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-high-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hourglass-simple-high-fill.svg)
-  static const hourglassSimpleHigh = PhosphorFlatIconData(0xe2bc, 'Fill');
+  static const hourglassSimpleHigh = IconData(0xe2bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-low-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hourglass-simple-low-fill.svg)
-  static const hourglassSimpleLow = PhosphorFlatIconData(0xe2be, 'Fill');
+  static const hourglassSimpleLow = IconData(0xe2be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-medium-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hourglass-simple-medium-fill.svg)
-  static const hourglassSimpleMedium = PhosphorFlatIconData(0xe2c0, 'Fill');
+  static const hourglassSimpleMedium = IconData(0xe2c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/house-fill.svg)
-  static const house = PhosphorFlatIconData(0xe2c2, 'Fill');
+  static const house = IconData(0xe2c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-line-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/house-line-fill.svg)
-  static const houseLine = PhosphorFlatIconData(0xe2c4, 'Fill');
+  static const houseLine = IconData(0xe2c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/house-simple-fill.svg)
-  static const houseSimple = PhosphorFlatIconData(0xe2c6, 'Fill');
+  static const houseSimple = IconData(0xe2c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hurricane-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/hurricane-fill.svg)
-  static const hurricane = PhosphorFlatIconData(0xe88e, 'Fill');
+  static const hurricane = IconData(0xe88e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ice-cream-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ice-cream-fill.svg)
-  static const iceCream = PhosphorFlatIconData(0xe804, 'Fill');
+  static const iceCream = IconData(0xe804,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-badge-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/identification-badge-fill.svg)
-  static const identificationBadge = PhosphorFlatIconData(0xe6f6, 'Fill');
+  static const identificationBadge = IconData(0xe6f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-card-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/identification-card-fill.svg)
-  static const identificationCard = PhosphorFlatIconData(0xe2c8, 'Fill');
+  static const identificationCard = IconData(0xe2c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/image-fill.svg)
-  static const image = PhosphorFlatIconData(0xe2ca, 'Fill');
+  static const image = IconData(0xe2ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-broken-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/image-broken-fill.svg)
-  static const imageBroken = PhosphorFlatIconData(0xe7a8, 'Fill');
+  static const imageBroken = IconData(0xe7a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/image-square-fill.svg)
-  static const imageSquare = PhosphorFlatIconData(0xe2cc, 'Fill');
+  static const imageSquare = IconData(0xe2cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/images-fill.svg)
-  static const images = PhosphorFlatIconData(0xe836, 'Fill');
+  static const images = IconData(0xe836,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/images-square-fill.svg)
-  static const imagesSquare = PhosphorFlatIconData(0xe834, 'Fill');
+  static const imagesSquare = IconData(0xe834,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![infinity-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/infinity-fill.svg)
-  static const infinity = PhosphorFlatIconData(0xe634, 'Fill');
+  static const infinity = IconData(0xe634,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![info-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/info-fill.svg)
-  static const info = PhosphorFlatIconData(0xe2ce, 'Fill');
+  static const info = IconData(0xe2ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![instagram-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/instagram-logo-fill.svg)
-  static const instagramLogo = PhosphorFlatIconData(0xe2d0, 'Fill');
+  static const instagramLogo = IconData(0xe2d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/intersect-fill.svg)
-  static const intersect = PhosphorFlatIconData(0xe2d2, 'Fill');
+  static const intersect = IconData(0xe2d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/intersect-square-fill.svg)
-  static const intersectSquare = PhosphorFlatIconData(0xe87a, 'Fill');
+  static const intersectSquare = IconData(0xe87a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/intersect-three-fill.svg)
-  static const intersectThree = PhosphorFlatIconData(0xecc4, 'Fill');
+  static const intersectThree = IconData(0xecc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersection-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/intersection-fill.svg)
-  static const intersection = PhosphorFlatIconData(0xedba, 'Fill');
+  static const intersection = IconData(0xedba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![invoice-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/invoice-fill.svg)
-  static const invoice = PhosphorFlatIconData(0xee42, 'Fill');
+  static const invoice = IconData(0xee42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![island-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/island-fill.svg)
-  static const island = PhosphorFlatIconData(0xee06, 'Fill');
+  static const island = IconData(0xee06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/jar-fill.svg)
-  static const jar = PhosphorFlatIconData(0xe7e0, 'Fill');
+  static const jar = IconData(0xe7e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-label-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/jar-label-fill.svg)
-  static const jarLabel = PhosphorFlatIconData(0xe7e1, 'Fill');
+  static const jarLabel = IconData(0xe7e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jeep-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/jeep-fill.svg)
-  static const jeep = PhosphorFlatIconData(0xe2d4, 'Fill');
+  static const jeep = IconData(0xe2d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![joystick-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/joystick-fill.svg)
-  static const joystick = PhosphorFlatIconData(0xea5e, 'Fill');
+  static const joystick = IconData(0xea5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![kanban-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/kanban-fill.svg)
-  static const kanban = PhosphorFlatIconData(0xeb54, 'Fill');
+  static const kanban = IconData(0xeb54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/key-fill.svg)
-  static const key = PhosphorFlatIconData(0xe2d6, 'Fill');
+  static const key = IconData(0xe2d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-return-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/key-return-fill.svg)
-  static const keyReturn = PhosphorFlatIconData(0xe782, 'Fill');
+  static const keyReturn = IconData(0xe782,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyboard-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/keyboard-fill.svg)
-  static const keyboard = PhosphorFlatIconData(0xe2d8, 'Fill');
+  static const keyboard = IconData(0xe2d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyhole-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/keyhole-fill.svg)
-  static const keyhole = PhosphorFlatIconData(0xea78, 'Fill');
+  static const keyhole = IconData(0xea78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![knife-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/knife-fill.svg)
-  static const knife = PhosphorFlatIconData(0xe636, 'Fill');
+  static const knife = IconData(0xe636,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ladder-fill.svg)
-  static const ladder = PhosphorFlatIconData(0xe9e4, 'Fill');
+  static const ladder = IconData(0xe9e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ladder-simple-fill.svg)
-  static const ladderSimple = PhosphorFlatIconData(0xec26, 'Fill');
+  static const ladderSimple = IconData(0xec26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lamp-fill.svg)
-  static const lamp = PhosphorFlatIconData(0xe638, 'Fill');
+  static const lamp = IconData(0xe638,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-pendant-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lamp-pendant-fill.svg)
-  static const lampPendant = PhosphorFlatIconData(0xee2e, 'Fill');
+  static const lampPendant = IconData(0xee2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![laptop-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/laptop-fill.svg)
-  static const laptop = PhosphorFlatIconData(0xe586, 'Fill');
+  static const laptop = IconData(0xe586,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lasso-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lasso-fill.svg)
-  static const lasso = PhosphorFlatIconData(0xedc6, 'Fill');
+  static const lasso = IconData(0xedc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lastfm-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lastfm-logo-fill.svg)
-  static const lastfmLogo = PhosphorFlatIconData(0xe842, 'Fill');
+  static const lastfmLogo = IconData(0xe842,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![layout-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/layout-fill.svg)
-  static const layout = PhosphorFlatIconData(0xe6d6, 'Fill');
+  static const layout = IconData(0xe6d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![leaf-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/leaf-fill.svg)
-  static const leaf = PhosphorFlatIconData(0xe2da, 'Fill');
+  static const leaf = IconData(0xe2da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lectern-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lectern-fill.svg)
-  static const lectern = PhosphorFlatIconData(0xe95a, 'Fill');
+  static const lectern = IconData(0xe95a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lego-fill.svg)
-  static const lego = PhosphorFlatIconData(0xe8c6, 'Fill');
+  static const lego = IconData(0xe8c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-smiley-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lego-smiley-fill.svg)
-  static const legoSmiley = PhosphorFlatIconData(0xe8c7, 'Fill');
+  static const legoSmiley = IconData(0xe8c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/less-than-fill.svg)
-  static const lessThan = PhosphorFlatIconData(0xedac, 'Fill');
+  static const lessThan = IconData(0xedac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-or-equal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/less-than-or-equal-fill.svg)
-  static const lessThanOrEqual = PhosphorFlatIconData(0xeda4, 'Fill');
+  static const lessThanOrEqual = IconData(0xeda4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-h-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/letter-circle-h-fill.svg)
-  static const letterCircleH = PhosphorFlatIconData(0xebf8, 'Fill');
+  static const letterCircleH = IconData(0xebf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-p-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/letter-circle-p-fill.svg)
-  static const letterCircleP = PhosphorFlatIconData(0xec08, 'Fill');
+  static const letterCircleP = IconData(0xec08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-v-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/letter-circle-v-fill.svg)
-  static const letterCircleV = PhosphorFlatIconData(0xec14, 'Fill');
+  static const letterCircleV = IconData(0xec14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lifebuoy-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lifebuoy-fill.svg)
-  static const lifebuoy = PhosphorFlatIconData(0xe63a, 'Fill');
+  static const lifebuoy = IconData(0xe63a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lightbulb-fill.svg)
-  static const lightbulb = PhosphorFlatIconData(0xe2dc, 'Fill');
+  static const lightbulb = IconData(0xe2dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-filament-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lightbulb-filament-fill.svg)
-  static const lightbulbFilament = PhosphorFlatIconData(0xe63c, 'Fill');
+  static const lightbulbFilament = IconData(0xe63c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lighthouse-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lighthouse-fill.svg)
-  static const lighthouse = PhosphorFlatIconData(0xe9f6, 'Fill');
+  static const lighthouse = IconData(0xe9f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lightning-fill.svg)
-  static const lightning = PhosphorFlatIconData(0xe2de, 'Fill');
+  static const lightning = IconData(0xe2de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-a-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lightning-a-fill.svg)
-  static const lightningA = PhosphorFlatIconData(0xea84, 'Fill');
+  static const lightningA = IconData(0xea84,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lightning-slash-fill.svg)
-  static const lightningSlash = PhosphorFlatIconData(0xe2e0, 'Fill');
+  static const lightningSlash = IconData(0xe2e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segment-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/line-segment-fill.svg)
-  static const lineSegment = PhosphorFlatIconData(0xe6d2, 'Fill');
+  static const lineSegment = IconData(0xe6d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segments-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/line-segments-fill.svg)
-  static const lineSegments = PhosphorFlatIconData(0xe6d4, 'Fill');
+  static const lineSegments = IconData(0xe6d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/line-vertical-fill.svg)
-  static const lineVertical = PhosphorFlatIconData(0xed70, 'Fill');
+  static const lineVertical = IconData(0xed70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/link-fill.svg)
-  static const link = PhosphorFlatIconData(0xe2e2, 'Fill');
+  static const link = IconData(0xe2e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-break-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/link-break-fill.svg)
-  static const linkBreak = PhosphorFlatIconData(0xe2e4, 'Fill');
+  static const linkBreak = IconData(0xe2e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/link-simple-fill.svg)
-  static const linkSimple = PhosphorFlatIconData(0xe2e6, 'Fill');
+  static const linkSimple = IconData(0xe2e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-break-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/link-simple-break-fill.svg)
-  static const linkSimpleBreak = PhosphorFlatIconData(0xe2e8, 'Fill');
+  static const linkSimpleBreak = IconData(0xe2e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/link-simple-horizontal-fill.svg)
-  static const linkSimpleHorizontal = PhosphorFlatIconData(0xe2ea, 'Fill');
+  static const linkSimpleHorizontal = IconData(0xe2ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-break-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/link-simple-horizontal-break-fill.svg)
-  static const linkSimpleHorizontalBreak = PhosphorFlatIconData(0xe2ec, 'Fill');
+  static const linkSimpleHorizontalBreak = IconData(0xe2ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linkedin-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/linkedin-logo-fill.svg)
-  static const linkedinLogo = PhosphorFlatIconData(0xe2ee, 'Fill');
+  static const linkedinLogo = IconData(0xe2ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linktree-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/linktree-logo-fill.svg)
-  static const linktreeLogo = PhosphorFlatIconData(0xedee, 'Fill');
+  static const linktreeLogo = IconData(0xedee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linux-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/linux-logo-fill.svg)
-  static const linuxLogo = PhosphorFlatIconData(0xeb02, 'Fill');
+  static const linuxLogo = IconData(0xeb02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-fill.svg)
-  static const list = PhosphorFlatIconData(0xe2f0, 'Fill');
+  static const list = IconData(0xe2f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-bullets-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-bullets-fill.svg)
-  static const listBullets = PhosphorFlatIconData(0xe2f2, 'Fill');
+  static const listBullets = IconData(0xe2f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-checks-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-checks-fill.svg)
-  static const listChecks = PhosphorFlatIconData(0xeadc, 'Fill');
+  static const listChecks = IconData(0xeadc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-dashes-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-dashes-fill.svg)
-  static const listDashes = PhosphorFlatIconData(0xe2f4, 'Fill');
+  static const listDashes = IconData(0xe2f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-heart-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-heart-fill.svg)
-  static const listHeart = PhosphorFlatIconData(0xebde, 'Fill');
+  static const listHeart = IconData(0xebde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-magnifying-glass-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-magnifying-glass-fill.svg)
-  static const listMagnifyingGlass = PhosphorFlatIconData(0xebe0, 'Fill');
+  static const listMagnifyingGlass = IconData(0xebe0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-numbers-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-numbers-fill.svg)
-  static const listNumbers = PhosphorFlatIconData(0xe2f6, 'Fill');
+  static const listNumbers = IconData(0xe2f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-plus-fill.svg)
-  static const listPlus = PhosphorFlatIconData(0xe2f8, 'Fill');
+  static const listPlus = IconData(0xe2f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-star-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/list-star-fill.svg)
-  static const listStar = PhosphorFlatIconData(0xebdc, 'Fill');
+  static const listStar = IconData(0xebdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lock-fill.svg)
-  static const lock = PhosphorFlatIconData(0xe2fa, 'Fill');
+  static const lock = IconData(0xe2fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lock-key-fill.svg)
-  static const lockKey = PhosphorFlatIconData(0xe2fe, 'Fill');
+  static const lockKey = IconData(0xe2fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lock-key-open-fill.svg)
-  static const lockKeyOpen = PhosphorFlatIconData(0xe300, 'Fill');
+  static const lockKeyOpen = IconData(0xe300,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lock-laminated-fill.svg)
-  static const lockLaminated = PhosphorFlatIconData(0xe302, 'Fill');
+  static const lockLaminated = IconData(0xe302,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lock-laminated-open-fill.svg)
-  static const lockLaminatedOpen = PhosphorFlatIconData(0xe304, 'Fill');
+  static const lockLaminatedOpen = IconData(0xe304,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lock-open-fill.svg)
-  static const lockOpen = PhosphorFlatIconData(0xe306, 'Fill');
+  static const lockOpen = IconData(0xe306,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lock-simple-fill.svg)
-  static const lockSimple = PhosphorFlatIconData(0xe308, 'Fill');
+  static const lockSimple = IconData(0xe308,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lock-simple-open-fill.svg)
-  static const lockSimpleOpen = PhosphorFlatIconData(0xe30a, 'Fill');
+  static const lockSimpleOpen = IconData(0xe30a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lockers-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/lockers-fill.svg)
-  static const lockers = PhosphorFlatIconData(0xecb8, 'Fill');
+  static const lockers = IconData(0xecb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![log-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/log-fill.svg)
-  static const log = PhosphorFlatIconData(0xed82, 'Fill');
+  static const log = IconData(0xed82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magic-wand-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/magic-wand-fill.svg)
-  static const magicWand = PhosphorFlatIconData(0xe6b6, 'Fill');
+  static const magicWand = IconData(0xe6b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/magnet-fill.svg)
-  static const magnet = PhosphorFlatIconData(0xe680, 'Fill');
+  static const magnet = IconData(0xe680,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-straight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/magnet-straight-fill.svg)
-  static const magnetStraight = PhosphorFlatIconData(0xe682, 'Fill');
+  static const magnetStraight = IconData(0xe682,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/magnifying-glass-fill.svg)
-  static const magnifyingGlass = PhosphorFlatIconData(0xe30c, 'Fill');
+  static const magnifyingGlass = IconData(0xe30c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/magnifying-glass-minus-fill.svg)
-  static const magnifyingGlassMinus = PhosphorFlatIconData(0xe30e, 'Fill');
+  static const magnifyingGlassMinus = IconData(0xe30e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/magnifying-glass-plus-fill.svg)
-  static const magnifyingGlassPlus = PhosphorFlatIconData(0xe310, 'Fill');
+  static const magnifyingGlassPlus = IconData(0xe310,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mailbox-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mailbox-fill.svg)
-  static const mailbox = PhosphorFlatIconData(0xec1e, 'Fill');
+  static const mailbox = IconData(0xec1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/map-pin-fill.svg)
-  static const mapPin = PhosphorFlatIconData(0xe316, 'Fill');
+  static const mapPin = IconData(0xe316,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-area-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/map-pin-area-fill.svg)
-  static const mapPinArea = PhosphorFlatIconData(0xee3a, 'Fill');
+  static const mapPinArea = IconData(0xee3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-line-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/map-pin-line-fill.svg)
-  static const mapPinLine = PhosphorFlatIconData(0xe318, 'Fill');
+  static const mapPinLine = IconData(0xe318,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/map-pin-plus-fill.svg)
-  static const mapPinPlus = PhosphorFlatIconData(0xe314, 'Fill');
+  static const mapPinPlus = IconData(0xe314,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/map-pin-simple-fill.svg)
-  static const mapPinSimple = PhosphorFlatIconData(0xee3e, 'Fill');
+  static const mapPinSimple = IconData(0xee3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-area-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/map-pin-simple-area-fill.svg)
-  static const mapPinSimpleArea = PhosphorFlatIconData(0xee3c, 'Fill');
+  static const mapPinSimpleArea = IconData(0xee3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-line-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/map-pin-simple-line-fill.svg)
-  static const mapPinSimpleLine = PhosphorFlatIconData(0xee38, 'Fill');
+  static const mapPinSimpleLine = IconData(0xee38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-trifold-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/map-trifold-fill.svg)
-  static const mapTrifold = PhosphorFlatIconData(0xe31a, 'Fill');
+  static const mapTrifold = IconData(0xe31a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![markdown-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/markdown-logo-fill.svg)
-  static const markdownLogo = PhosphorFlatIconData(0xe508, 'Fill');
+  static const markdownLogo = IconData(0xe508,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![marker-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/marker-circle-fill.svg)
-  static const markerCircle = PhosphorFlatIconData(0xe640, 'Fill');
+  static const markerCircle = IconData(0xe640,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![martini-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/martini-fill.svg)
-  static const martini = PhosphorFlatIconData(0xe31c, 'Fill');
+  static const martini = IconData(0xe31c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-happy-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mask-happy-fill.svg)
-  static const maskHappy = PhosphorFlatIconData(0xe9f4, 'Fill');
+  static const maskHappy = IconData(0xe9f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-sad-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mask-sad-fill.svg)
-  static const maskSad = PhosphorFlatIconData(0xeb9e, 'Fill');
+  static const maskSad = IconData(0xeb9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mastodon-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mastodon-logo-fill.svg)
-  static const mastodonLogo = PhosphorFlatIconData(0xed68, 'Fill');
+  static const mastodonLogo = IconData(0xed68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![math-operations-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/math-operations-fill.svg)
-  static const mathOperations = PhosphorFlatIconData(0xe31e, 'Fill');
+  static const mathOperations = IconData(0xe31e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![matrix-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/matrix-logo-fill.svg)
-  static const matrixLogo = PhosphorFlatIconData(0xed64, 'Fill');
+  static const matrixLogo = IconData(0xed64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/medal-fill.svg)
-  static const medal = PhosphorFlatIconData(0xe320, 'Fill');
+  static const medal = IconData(0xe320,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-military-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/medal-military-fill.svg)
-  static const medalMilitary = PhosphorFlatIconData(0xecfc, 'Fill');
+  static const medalMilitary = IconData(0xecfc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medium-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/medium-logo-fill.svg)
-  static const mediumLogo = PhosphorFlatIconData(0xe322, 'Fill');
+  static const mediumLogo = IconData(0xe322,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/megaphone-fill.svg)
-  static const megaphone = PhosphorFlatIconData(0xe324, 'Fill');
+  static const megaphone = IconData(0xe324,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/megaphone-simple-fill.svg)
-  static const megaphoneSimple = PhosphorFlatIconData(0xe642, 'Fill');
+  static const megaphoneSimple = IconData(0xe642,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![member-of-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/member-of-fill.svg)
-  static const memberOf = PhosphorFlatIconData(0xedc2, 'Fill');
+  static const memberOf = IconData(0xedc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![memory-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/memory-fill.svg)
-  static const memory = PhosphorFlatIconData(0xe9c4, 'Fill');
+  static const memory = IconData(0xe9c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![messenger-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/messenger-logo-fill.svg)
-  static const messengerLogo = PhosphorFlatIconData(0xe6d8, 'Fill');
+  static const messengerLogo = IconData(0xe6d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meta-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/meta-logo-fill.svg)
-  static const metaLogo = PhosphorFlatIconData(0xed02, 'Fill');
+  static const metaLogo = IconData(0xed02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meteor-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/meteor-fill.svg)
-  static const meteor = PhosphorFlatIconData(0xe9ba, 'Fill');
+  static const meteor = IconData(0xe9ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![metronome-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/metronome-fill.svg)
-  static const metronome = PhosphorFlatIconData(0xec8e, 'Fill');
+  static const metronome = IconData(0xec8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microphone-fill.svg)
-  static const microphone = PhosphorFlatIconData(0xe326, 'Fill');
+  static const microphone = IconData(0xe326,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microphone-slash-fill.svg)
-  static const microphoneSlash = PhosphorFlatIconData(0xe328, 'Fill');
+  static const microphoneSlash = IconData(0xe328,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-stage-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microphone-stage-fill.svg)
-  static const microphoneStage = PhosphorFlatIconData(0xe75c, 'Fill');
+  static const microphoneStage = IconData(0xe75c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microscope-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microscope-fill.svg)
-  static const microscope = PhosphorFlatIconData(0xec7a, 'Fill');
+  static const microscope = IconData(0xec7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-excel-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microsoft-excel-logo-fill.svg)
-  static const microsoftExcelLogo = PhosphorFlatIconData(0xeb6c, 'Fill');
+  static const microsoftExcelLogo = IconData(0xeb6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-outlook-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microsoft-outlook-logo-fill.svg)
-  static const microsoftOutlookLogo = PhosphorFlatIconData(0xeb70, 'Fill');
+  static const microsoftOutlookLogo = IconData(0xeb70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-powerpoint-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microsoft-powerpoint-logo-fill.svg)
-  static const microsoftPowerpointLogo = PhosphorFlatIconData(0xeace, 'Fill');
+  static const microsoftPowerpointLogo = IconData(0xeace,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-teams-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microsoft-teams-logo-fill.svg)
-  static const microsoftTeamsLogo = PhosphorFlatIconData(0xeb66, 'Fill');
+  static const microsoftTeamsLogo = IconData(0xeb66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-word-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/microsoft-word-logo-fill.svg)
-  static const microsoftWordLogo = PhosphorFlatIconData(0xeb6a, 'Fill');
+  static const microsoftWordLogo = IconData(0xeb6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/minus-fill.svg)
-  static const minus = PhosphorFlatIconData(0xe32a, 'Fill');
+  static const minus = IconData(0xe32a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/minus-circle-fill.svg)
-  static const minusCircle = PhosphorFlatIconData(0xe32c, 'Fill');
+  static const minusCircle = IconData(0xe32c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/minus-square-fill.svg)
-  static const minusSquare = PhosphorFlatIconData(0xed4c, 'Fill');
+  static const minusSquare = IconData(0xed4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/money-fill.svg)
-  static const money = PhosphorFlatIconData(0xe588, 'Fill');
+  static const money = IconData(0xe588,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-wavy-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/money-wavy-fill.svg)
-  static const moneyWavy = PhosphorFlatIconData(0xee68, 'Fill');
+  static const moneyWavy = IconData(0xee68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/monitor-fill.svg)
-  static const monitor = PhosphorFlatIconData(0xe32e, 'Fill');
+  static const monitor = IconData(0xe32e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-arrow-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/monitor-arrow-up-fill.svg)
-  static const monitorArrowUp = PhosphorFlatIconData(0xe58a, 'Fill');
+  static const monitorArrowUp = IconData(0xe58a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-play-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/monitor-play-fill.svg)
-  static const monitorPlay = PhosphorFlatIconData(0xe58c, 'Fill');
+  static const monitorPlay = IconData(0xe58c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/moon-fill.svg)
-  static const moon = PhosphorFlatIconData(0xe330, 'Fill');
+  static const moon = IconData(0xe330,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-stars-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/moon-stars-fill.svg)
-  static const moonStars = PhosphorFlatIconData(0xe58e, 'Fill');
+  static const moonStars = IconData(0xe58e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/moped-fill.svg)
-  static const moped = PhosphorFlatIconData(0xe824, 'Fill');
+  static const moped = IconData(0xe824,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-front-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/moped-front-fill.svg)
-  static const mopedFront = PhosphorFlatIconData(0xe822, 'Fill');
+  static const mopedFront = IconData(0xe822,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mosque-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mosque-fill.svg)
-  static const mosque = PhosphorFlatIconData(0xecee, 'Fill');
+  static const mosque = IconData(0xecee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![motorcycle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/motorcycle-fill.svg)
-  static const motorcycle = PhosphorFlatIconData(0xe80a, 'Fill');
+  static const motorcycle = IconData(0xe80a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mountains-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mountains-fill.svg)
-  static const mountains = PhosphorFlatIconData(0xe7ae, 'Fill');
+  static const mountains = IconData(0xe7ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mouse-fill.svg)
-  static const mouse = PhosphorFlatIconData(0xe33a, 'Fill');
+  static const mouse = IconData(0xe33a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-left-click-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mouse-left-click-fill.svg)
-  static const mouseLeftClick = PhosphorFlatIconData(0xe334, 'Fill');
+  static const mouseLeftClick = IconData(0xe334,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-middle-click-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mouse-middle-click-fill.svg)
-  static const mouseMiddleClick = PhosphorFlatIconData(0xe338, 'Fill');
+  static const mouseMiddleClick = IconData(0xe338,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-right-click-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mouse-right-click-fill.svg)
-  static const mouseRightClick = PhosphorFlatIconData(0xe336, 'Fill');
+  static const mouseRightClick = IconData(0xe336,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-scroll-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mouse-scroll-fill.svg)
-  static const mouseScroll = PhosphorFlatIconData(0xe332, 'Fill');
+  static const mouseScroll = IconData(0xe332,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/mouse-simple-fill.svg)
-  static const mouseSimple = PhosphorFlatIconData(0xe644, 'Fill');
+  static const mouseSimple = IconData(0xe644,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/music-note-fill.svg)
-  static const musicNote = PhosphorFlatIconData(0xe33c, 'Fill');
+  static const musicNote = IconData(0xe33c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/music-note-simple-fill.svg)
-  static const musicNoteSimple = PhosphorFlatIconData(0xe33e, 'Fill');
+  static const musicNoteSimple = IconData(0xe33e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/music-notes-fill.svg)
-  static const musicNotes = PhosphorFlatIconData(0xe340, 'Fill');
+  static const musicNotes = IconData(0xe340,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/music-notes-minus-fill.svg)
-  static const musicNotesMinus = PhosphorFlatIconData(0xee0c, 'Fill');
+  static const musicNotesMinus = IconData(0xee0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/music-notes-plus-fill.svg)
-  static const musicNotesPlus = PhosphorFlatIconData(0xeb7c, 'Fill');
+  static const musicNotesPlus = IconData(0xeb7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/music-notes-simple-fill.svg)
-  static const musicNotesSimple = PhosphorFlatIconData(0xe342, 'Fill');
+  static const musicNotesSimple = IconData(0xe342,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![navigation-arrow-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/navigation-arrow-fill.svg)
-  static const navigationArrow = PhosphorFlatIconData(0xeade, 'Fill');
+  static const navigationArrow = IconData(0xeade,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![needle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/needle-fill.svg)
-  static const needle = PhosphorFlatIconData(0xe82e, 'Fill');
+  static const needle = IconData(0xe82e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/network-fill.svg)
-  static const network = PhosphorFlatIconData(0xedde, 'Fill');
+  static const network = IconData(0xedde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/network-slash-fill.svg)
-  static const networkSlash = PhosphorFlatIconData(0xeddc, 'Fill');
+  static const networkSlash = IconData(0xeddc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/network-x-fill.svg)
-  static const networkX = PhosphorFlatIconData(0xedda, 'Fill');
+  static const networkX = IconData(0xedda,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/newspaper-fill.svg)
-  static const newspaper = PhosphorFlatIconData(0xe344, 'Fill');
+  static const newspaper = IconData(0xe344,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-clipping-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/newspaper-clipping-fill.svg)
-  static const newspaperClipping = PhosphorFlatIconData(0xe346, 'Fill');
+  static const newspaperClipping = IconData(0xe346,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-equals-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/not-equals-fill.svg)
-  static const notEquals = PhosphorFlatIconData(0xeda6, 'Fill');
+  static const notEquals = IconData(0xeda6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-member-of-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/not-member-of-fill.svg)
-  static const notMemberOf = PhosphorFlatIconData(0xedae, 'Fill');
+  static const notMemberOf = IconData(0xedae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-subset-of-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/not-subset-of-fill.svg)
-  static const notSubsetOf = PhosphorFlatIconData(0xedb0, 'Fill');
+  static const notSubsetOf = IconData(0xedb0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-superset-of-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/not-superset-of-fill.svg)
-  static const notSupersetOf = PhosphorFlatIconData(0xedb2, 'Fill');
+  static const notSupersetOf = IconData(0xedb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notches-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/notches-fill.svg)
-  static const notches = PhosphorFlatIconData(0xed3a, 'Fill');
+  static const notches = IconData(0xed3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/note-fill.svg)
-  static const note = PhosphorFlatIconData(0xe348, 'Fill');
+  static const note = IconData(0xe348,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-blank-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/note-blank-fill.svg)
-  static const noteBlank = PhosphorFlatIconData(0xe34a, 'Fill');
+  static const noteBlank = IconData(0xe34a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-pencil-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/note-pencil-fill.svg)
-  static const notePencil = PhosphorFlatIconData(0xe34c, 'Fill');
+  static const notePencil = IconData(0xe34c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notebook-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/notebook-fill.svg)
-  static const notebook = PhosphorFlatIconData(0xe34e, 'Fill');
+  static const notebook = IconData(0xe34e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notepad-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/notepad-fill.svg)
-  static const notepad = PhosphorFlatIconData(0xe63e, 'Fill');
+  static const notepad = IconData(0xe63e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notification-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/notification-fill.svg)
-  static const notification = PhosphorFlatIconData(0xe6fa, 'Fill');
+  static const notification = IconData(0xe6fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notion-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/notion-logo-fill.svg)
-  static const notionLogo = PhosphorFlatIconData(0xe9a0, 'Fill');
+  static const notionLogo = IconData(0xe9a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nuclear-plant-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/nuclear-plant-fill.svg)
-  static const nuclearPlant = PhosphorFlatIconData(0xed7c, 'Fill');
+  static const nuclearPlant = IconData(0xed7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-eight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-eight-fill.svg)
-  static const numberCircleEight = PhosphorFlatIconData(0xe352, 'Fill');
+  static const numberCircleEight = IconData(0xe352,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-five-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-five-fill.svg)
-  static const numberCircleFive = PhosphorFlatIconData(0xe358, 'Fill');
+  static const numberCircleFive = IconData(0xe358,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-four-fill.svg)
-  static const numberCircleFour = PhosphorFlatIconData(0xe35e, 'Fill');
+  static const numberCircleFour = IconData(0xe35e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-nine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-nine-fill.svg)
-  static const numberCircleNine = PhosphorFlatIconData(0xe364, 'Fill');
+  static const numberCircleNine = IconData(0xe364,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-one-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-one-fill.svg)
-  static const numberCircleOne = PhosphorFlatIconData(0xe36a, 'Fill');
+  static const numberCircleOne = IconData(0xe36a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-seven-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-seven-fill.svg)
-  static const numberCircleSeven = PhosphorFlatIconData(0xe370, 'Fill');
+  static const numberCircleSeven = IconData(0xe370,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-six-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-six-fill.svg)
-  static const numberCircleSix = PhosphorFlatIconData(0xe376, 'Fill');
+  static const numberCircleSix = IconData(0xe376,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-three-fill.svg)
-  static const numberCircleThree = PhosphorFlatIconData(0xe37c, 'Fill');
+  static const numberCircleThree = IconData(0xe37c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-two-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-two-fill.svg)
-  static const numberCircleTwo = PhosphorFlatIconData(0xe382, 'Fill');
+  static const numberCircleTwo = IconData(0xe382,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-zero-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-circle-zero-fill.svg)
-  static const numberCircleZero = PhosphorFlatIconData(0xe388, 'Fill');
+  static const numberCircleZero = IconData(0xe388,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-eight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-eight-fill.svg)
-  static const numberEight = PhosphorFlatIconData(0xe350, 'Fill');
+  static const numberEight = IconData(0xe350,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-five-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-five-fill.svg)
-  static const numberFive = PhosphorFlatIconData(0xe356, 'Fill');
+  static const numberFive = IconData(0xe356,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-four-fill.svg)
-  static const numberFour = PhosphorFlatIconData(0xe35c, 'Fill');
+  static const numberFour = IconData(0xe35c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-nine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-nine-fill.svg)
-  static const numberNine = PhosphorFlatIconData(0xe362, 'Fill');
+  static const numberNine = IconData(0xe362,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-one-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-one-fill.svg)
-  static const numberOne = PhosphorFlatIconData(0xe368, 'Fill');
+  static const numberOne = IconData(0xe368,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-seven-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-seven-fill.svg)
-  static const numberSeven = PhosphorFlatIconData(0xe36e, 'Fill');
+  static const numberSeven = IconData(0xe36e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-six-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-six-fill.svg)
-  static const numberSix = PhosphorFlatIconData(0xe374, 'Fill');
+  static const numberSix = IconData(0xe374,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-eight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-eight-fill.svg)
-  static const numberSquareEight = PhosphorFlatIconData(0xe354, 'Fill');
+  static const numberSquareEight = IconData(0xe354,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-five-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-five-fill.svg)
-  static const numberSquareFive = PhosphorFlatIconData(0xe35a, 'Fill');
+  static const numberSquareFive = IconData(0xe35a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-four-fill.svg)
-  static const numberSquareFour = PhosphorFlatIconData(0xe360, 'Fill');
+  static const numberSquareFour = IconData(0xe360,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-nine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-nine-fill.svg)
-  static const numberSquareNine = PhosphorFlatIconData(0xe366, 'Fill');
+  static const numberSquareNine = IconData(0xe366,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-one-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-one-fill.svg)
-  static const numberSquareOne = PhosphorFlatIconData(0xe36c, 'Fill');
+  static const numberSquareOne = IconData(0xe36c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-seven-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-seven-fill.svg)
-  static const numberSquareSeven = PhosphorFlatIconData(0xe372, 'Fill');
+  static const numberSquareSeven = IconData(0xe372,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-six-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-six-fill.svg)
-  static const numberSquareSix = PhosphorFlatIconData(0xe378, 'Fill');
+  static const numberSquareSix = IconData(0xe378,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-three-fill.svg)
-  static const numberSquareThree = PhosphorFlatIconData(0xe37e, 'Fill');
+  static const numberSquareThree = IconData(0xe37e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-two-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-two-fill.svg)
-  static const numberSquareTwo = PhosphorFlatIconData(0xe384, 'Fill');
+  static const numberSquareTwo = IconData(0xe384,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-zero-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-square-zero-fill.svg)
-  static const numberSquareZero = PhosphorFlatIconData(0xe38a, 'Fill');
+  static const numberSquareZero = IconData(0xe38a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-three-fill.svg)
-  static const numberThree = PhosphorFlatIconData(0xe37a, 'Fill');
+  static const numberThree = IconData(0xe37a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-two-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-two-fill.svg)
-  static const numberTwo = PhosphorFlatIconData(0xe380, 'Fill');
+  static const numberTwo = IconData(0xe380,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-zero-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/number-zero-fill.svg)
-  static const numberZero = PhosphorFlatIconData(0xe386, 'Fill');
+  static const numberZero = IconData(0xe386,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![numpad-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/numpad-fill.svg)
-  static const numpad = PhosphorFlatIconData(0xe3c8, 'Fill');
+  static const numpad = IconData(0xe3c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nut-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/nut-fill.svg)
-  static const nut = PhosphorFlatIconData(0xe38c, 'Fill');
+  static const nut = IconData(0xe38c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ny-times-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ny-times-logo-fill.svg)
-  static const nyTimesLogo = PhosphorFlatIconData(0xe646, 'Fill');
+  static const nyTimesLogo = IconData(0xe646,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![octagon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/octagon-fill.svg)
-  static const octagon = PhosphorFlatIconData(0xe38e, 'Fill');
+  static const octagon = IconData(0xe38e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![office-chair-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/office-chair-fill.svg)
-  static const officeChair = PhosphorFlatIconData(0xea46, 'Fill');
+  static const officeChair = IconData(0xea46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![onigiri-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/onigiri-fill.svg)
-  static const onigiri = PhosphorFlatIconData(0xee2c, 'Fill');
+  static const onigiri = IconData(0xee2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![open-ai-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/open-ai-logo-fill.svg)
-  static const openAiLogo = PhosphorFlatIconData(0xe7d2, 'Fill');
+  static const openAiLogo = IconData(0xe7d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![option-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/option-fill.svg)
-  static const option = PhosphorFlatIconData(0xe8a8, 'Fill');
+  static const option = IconData(0xe8a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/orange-fill.svg)
-  static const orange = PhosphorFlatIconData(0xee40, 'Fill');
+  static const orange = IconData(0xee40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-slice-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/orange-slice-fill.svg)
-  static const orangeSlice = PhosphorFlatIconData(0xed36, 'Fill');
+  static const orangeSlice = IconData(0xed36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![oven-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/oven-fill.svg)
-  static const oven = PhosphorFlatIconData(0xed8c, 'Fill');
+  static const oven = IconData(0xed8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![package-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/package-fill.svg)
-  static const package = PhosphorFlatIconData(0xe390, 'Fill');
+  static const package = IconData(0xe390,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paint-brush-fill.svg)
-  static const paintBrush = PhosphorFlatIconData(0xe6f0, 'Fill');
+  static const paintBrush = IconData(0xe6f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-broad-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paint-brush-broad-fill.svg)
-  static const paintBrushBroad = PhosphorFlatIconData(0xe590, 'Fill');
+  static const paintBrushBroad = IconData(0xe590,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-household-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paint-brush-household-fill.svg)
-  static const paintBrushHousehold = PhosphorFlatIconData(0xe6f2, 'Fill');
+  static const paintBrushHousehold = IconData(0xe6f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-bucket-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paint-bucket-fill.svg)
-  static const paintBucket = PhosphorFlatIconData(0xe392, 'Fill');
+  static const paintBucket = IconData(0xe392,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-roller-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paint-roller-fill.svg)
-  static const paintRoller = PhosphorFlatIconData(0xe6f4, 'Fill');
+  static const paintRoller = IconData(0xe6f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![palette-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/palette-fill.svg)
-  static const palette = PhosphorFlatIconData(0xe6c8, 'Fill');
+  static const palette = IconData(0xe6c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![panorama-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/panorama-fill.svg)
-  static const panorama = PhosphorFlatIconData(0xeaa2, 'Fill');
+  static const panorama = IconData(0xeaa2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pants-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pants-fill.svg)
-  static const pants = PhosphorFlatIconData(0xec88, 'Fill');
+  static const pants = IconData(0xec88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paper-plane-fill.svg)
-  static const paperPlane = PhosphorFlatIconData(0xe394, 'Fill');
+  static const paperPlane = IconData(0xe394,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paper-plane-right-fill.svg)
-  static const paperPlaneRight = PhosphorFlatIconData(0xe396, 'Fill');
+  static const paperPlaneRight = IconData(0xe396,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-tilt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paper-plane-tilt-fill.svg)
-  static const paperPlaneTilt = PhosphorFlatIconData(0xe398, 'Fill');
+  static const paperPlaneTilt = IconData(0xe398,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paperclip-fill.svg)
-  static const paperclip = PhosphorFlatIconData(0xe39a, 'Fill');
+  static const paperclip = IconData(0xe39a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paperclip-horizontal-fill.svg)
-  static const paperclipHorizontal = PhosphorFlatIconData(0xe592, 'Fill');
+  static const paperclipHorizontal = IconData(0xe592,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parachute-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/parachute-fill.svg)
-  static const parachute = PhosphorFlatIconData(0xea7c, 'Fill');
+  static const parachute = IconData(0xea7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paragraph-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paragraph-fill.svg)
-  static const paragraph = PhosphorFlatIconData(0xe960, 'Fill');
+  static const paragraph = IconData(0xe960,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parallelogram-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/parallelogram-fill.svg)
-  static const parallelogram = PhosphorFlatIconData(0xecc6, 'Fill');
+  static const parallelogram = IconData(0xecc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![park-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/park-fill.svg)
-  static const park = PhosphorFlatIconData(0xecb2, 'Fill');
+  static const park = IconData(0xecb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![password-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/password-fill.svg)
-  static const password = PhosphorFlatIconData(0xe752, 'Fill');
+  static const password = IconData(0xe752,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![path-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/path-fill.svg)
-  static const path = PhosphorFlatIconData(0xe39c, 'Fill');
+  static const path = IconData(0xe39c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![patreon-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/patreon-logo-fill.svg)
-  static const patreonLogo = PhosphorFlatIconData(0xe98a, 'Fill');
+  static const patreonLogo = IconData(0xe98a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pause-fill.svg)
-  static const pause = PhosphorFlatIconData(0xe39e, 'Fill');
+  static const pause = IconData(0xe39e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pause-circle-fill.svg)
-  static const pauseCircle = PhosphorFlatIconData(0xe3a0, 'Fill');
+  static const pauseCircle = IconData(0xe3a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paw-print-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paw-print-fill.svg)
-  static const pawPrint = PhosphorFlatIconData(0xe648, 'Fill');
+  static const pawPrint = IconData(0xe648,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paypal-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/paypal-logo-fill.svg)
-  static const paypalLogo = PhosphorFlatIconData(0xe98c, 'Fill');
+  static const paypalLogo = IconData(0xe98c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![peace-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/peace-fill.svg)
-  static const peace = PhosphorFlatIconData(0xe3a2, 'Fill');
+  static const peace = IconData(0xe3a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pen-fill.svg)
-  static const pen = PhosphorFlatIconData(0xe3aa, 'Fill');
+  static const pen = IconData(0xe3aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pen-nib-fill.svg)
-  static const penNib = PhosphorFlatIconData(0xe3ac, 'Fill');
+  static const penNib = IconData(0xe3ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-straight-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pen-nib-straight-fill.svg)
-  static const penNibStraight = PhosphorFlatIconData(0xe64a, 'Fill');
+  static const penNibStraight = IconData(0xe64a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pencil-fill.svg)
-  static const pencil = PhosphorFlatIconData(0xe3ae, 'Fill');
+  static const pencil = IconData(0xe3ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pencil-circle-fill.svg)
-  static const pencilCircle = PhosphorFlatIconData(0xe3b0, 'Fill');
+  static const pencilCircle = IconData(0xe3b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-line-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pencil-line-fill.svg)
-  static const pencilLine = PhosphorFlatIconData(0xe3b2, 'Fill');
+  static const pencilLine = IconData(0xe3b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-ruler-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pencil-ruler-fill.svg)
-  static const pencilRuler = PhosphorFlatIconData(0xe906, 'Fill');
+  static const pencilRuler = IconData(0xe906,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pencil-simple-fill.svg)
-  static const pencilSimple = PhosphorFlatIconData(0xe3b4, 'Fill');
+  static const pencilSimple = IconData(0xe3b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-line-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pencil-simple-line-fill.svg)
-  static const pencilSimpleLine = PhosphorFlatIconData(0xebc6, 'Fill');
+  static const pencilSimpleLine = IconData(0xebc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pencil-simple-slash-fill.svg)
-  static const pencilSimpleSlash = PhosphorFlatIconData(0xecf6, 'Fill');
+  static const pencilSimpleSlash = IconData(0xecf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pencil-slash-fill.svg)
-  static const pencilSlash = PhosphorFlatIconData(0xecf8, 'Fill');
+  static const pencilSlash = IconData(0xecf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pentagon-fill.svg)
-  static const pentagon = PhosphorFlatIconData(0xec7e, 'Fill');
+  static const pentagon = IconData(0xec7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagram-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pentagram-fill.svg)
-  static const pentagram = PhosphorFlatIconData(0xec5c, 'Fill');
+  static const pentagram = IconData(0xec5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pepper-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pepper-fill.svg)
-  static const pepper = PhosphorFlatIconData(0xe94a, 'Fill');
+  static const pepper = IconData(0xe94a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![percent-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/percent-fill.svg)
-  static const percent = PhosphorFlatIconData(0xe3b6, 'Fill');
+  static const percent = IconData(0xe3b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-fill.svg)
-  static const person = PhosphorFlatIconData(0xe3a8, 'Fill');
+  static const person = IconData(0xe3a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-arms-spread-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-arms-spread-fill.svg)
-  static const personArmsSpread = PhosphorFlatIconData(0xecfe, 'Fill');
+  static const personArmsSpread = IconData(0xecfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-fill.svg)
-  static const personSimple = PhosphorFlatIconData(0xe72e, 'Fill');
+  static const personSimple = IconData(0xe72e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-bike-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-bike-fill.svg)
-  static const personSimpleBike = PhosphorFlatIconData(0xe734, 'Fill');
+  static const personSimpleBike = IconData(0xe734,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-circle-fill.svg)
-  static const personSimpleCircle = PhosphorFlatIconData(0xee58, 'Fill');
+  static const personSimpleCircle = IconData(0xee58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-hike-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-hike-fill.svg)
-  static const personSimpleHike = PhosphorFlatIconData(0xed54, 'Fill');
+  static const personSimpleHike = IconData(0xed54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-run-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-run-fill.svg)
-  static const personSimpleRun = PhosphorFlatIconData(0xe730, 'Fill');
+  static const personSimpleRun = IconData(0xe730,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-ski-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-ski-fill.svg)
-  static const personSimpleSki = PhosphorFlatIconData(0xe71c, 'Fill');
+  static const personSimpleSki = IconData(0xe71c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-snowboard-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-snowboard-fill.svg)
-  static const personSimpleSnowboard = PhosphorFlatIconData(0xe71e, 'Fill');
+  static const personSimpleSnowboard = IconData(0xe71e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-swim-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-swim-fill.svg)
-  static const personSimpleSwim = PhosphorFlatIconData(0xe736, 'Fill');
+  static const personSimpleSwim = IconData(0xe736,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-tai-chi-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-tai-chi-fill.svg)
-  static const personSimpleTaiChi = PhosphorFlatIconData(0xed5c, 'Fill');
+  static const personSimpleTaiChi = IconData(0xed5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-throw-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-throw-fill.svg)
-  static const personSimpleThrow = PhosphorFlatIconData(0xe732, 'Fill');
+  static const personSimpleThrow = IconData(0xe732,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-walk-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/person-simple-walk-fill.svg)
-  static const personSimpleWalk = PhosphorFlatIconData(0xe73a, 'Fill');
+  static const personSimpleWalk = IconData(0xe73a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![perspective-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/perspective-fill.svg)
-  static const perspective = PhosphorFlatIconData(0xebe6, 'Fill');
+  static const perspective = IconData(0xebe6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-fill.svg)
-  static const phone = PhosphorFlatIconData(0xe3b8, 'Fill');
+  static const phone = IconData(0xe3b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-call-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-call-fill.svg)
-  static const phoneCall = PhosphorFlatIconData(0xe3ba, 'Fill');
+  static const phoneCall = IconData(0xe3ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-disconnect-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-disconnect-fill.svg)
-  static const phoneDisconnect = PhosphorFlatIconData(0xe3bc, 'Fill');
+  static const phoneDisconnect = IconData(0xe3bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-incoming-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-incoming-fill.svg)
-  static const phoneIncoming = PhosphorFlatIconData(0xe3be, 'Fill');
+  static const phoneIncoming = IconData(0xe3be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-list-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-list-fill.svg)
-  static const phoneList = PhosphorFlatIconData(0xe3cc, 'Fill');
+  static const phoneList = IconData(0xe3cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-outgoing-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-outgoing-fill.svg)
-  static const phoneOutgoing = PhosphorFlatIconData(0xe3c0, 'Fill');
+  static const phoneOutgoing = IconData(0xe3c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-pause-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-pause-fill.svg)
-  static const phonePause = PhosphorFlatIconData(0xe3ca, 'Fill');
+  static const phonePause = IconData(0xe3ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-plus-fill.svg)
-  static const phonePlus = PhosphorFlatIconData(0xec56, 'Fill');
+  static const phonePlus = IconData(0xec56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-slash-fill.svg)
-  static const phoneSlash = PhosphorFlatIconData(0xe3c2, 'Fill');
+  static const phoneSlash = IconData(0xe3c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-transfer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-transfer-fill.svg)
-  static const phoneTransfer = PhosphorFlatIconData(0xe3c6, 'Fill');
+  static const phoneTransfer = IconData(0xe3c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phone-x-fill.svg)
-  static const phoneX = PhosphorFlatIconData(0xe3c4, 'Fill');
+  static const phoneX = IconData(0xe3c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phosphor-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/phosphor-logo-fill.svg)
-  static const phosphorLogo = PhosphorFlatIconData(0xe3ce, 'Fill');
+  static const phosphorLogo = IconData(0xe3ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pi-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pi-fill.svg)
-  static const pi = PhosphorFlatIconData(0xec80, 'Fill');
+  static const pi = IconData(0xec80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piano-keys-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/piano-keys-fill.svg)
-  static const pianoKeys = PhosphorFlatIconData(0xe9c8, 'Fill');
+  static const pianoKeys = IconData(0xe9c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picnic-table-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/picnic-table-fill.svg)
-  static const picnicTable = PhosphorFlatIconData(0xee26, 'Fill');
+  static const picnicTable = IconData(0xee26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picture-in-picture-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/picture-in-picture-fill.svg)
-  static const pictureInpicture = PhosphorFlatIconData(0xe64c, 'Fill');
+  static const pictureInpicture = IconData(0xe64c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piggy-bank-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/piggy-bank-fill.svg)
-  static const piggyBank = PhosphorFlatIconData(0xea04, 'Fill');
+  static const piggyBank = IconData(0xea04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pill-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pill-fill.svg)
-  static const pill = PhosphorFlatIconData(0xe700, 'Fill');
+  static const pill = IconData(0xe700,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ping-pong-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ping-pong-fill.svg)
-  static const pingPong = PhosphorFlatIconData(0xea42, 'Fill');
+  static const pingPong = IconData(0xea42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pint-glass-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pint-glass-fill.svg)
-  static const pintGlass = PhosphorFlatIconData(0xedd0, 'Fill');
+  static const pintGlass = IconData(0xedd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinterest-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pinterest-logo-fill.svg)
-  static const pinterestLogo = PhosphorFlatIconData(0xe64e, 'Fill');
+  static const pinterestLogo = IconData(0xe64e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinwheel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pinwheel-fill.svg)
-  static const pinwheel = PhosphorFlatIconData(0xeb9c, 'Fill');
+  static const pinwheel = IconData(0xeb9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pipe-fill.svg)
-  static const pipe = PhosphorFlatIconData(0xed86, 'Fill');
+  static const pipe = IconData(0xed86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-wrench-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pipe-wrench-fill.svg)
-  static const pipeWrench = PhosphorFlatIconData(0xed88, 'Fill');
+  static const pipeWrench = IconData(0xed88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pix-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pix-logo-fill.svg)
-  static const pixLogo = PhosphorFlatIconData(0xecc2, 'Fill');
+  static const pixLogo = IconData(0xecc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pizza-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pizza-fill.svg)
-  static const pizza = PhosphorFlatIconData(0xe796, 'Fill');
+  static const pizza = IconData(0xe796,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![placeholder-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/placeholder-fill.svg)
-  static const placeholder = PhosphorFlatIconData(0xe650, 'Fill');
+  static const placeholder = IconData(0xe650,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![planet-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/planet-fill.svg)
-  static const planet = PhosphorFlatIconData(0xe652, 'Fill');
+  static const planet = IconData(0xe652,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plant-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plant-fill.svg)
-  static const plant = PhosphorFlatIconData(0xebae, 'Fill');
+  static const plant = IconData(0xebae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/play-fill.svg)
-  static const play = PhosphorFlatIconData(0xe3d0, 'Fill');
+  static const play = IconData(0xe3d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/play-circle-fill.svg)
-  static const playCircle = PhosphorFlatIconData(0xe3d2, 'Fill');
+  static const playCircle = IconData(0xe3d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-pause-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/play-pause-fill.svg)
-  static const playPause = PhosphorFlatIconData(0xe8be, 'Fill');
+  static const playPause = IconData(0xe8be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![playlist-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/playlist-fill.svg)
-  static const playlist = PhosphorFlatIconData(0xe6aa, 'Fill');
+  static const playlist = IconData(0xe6aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plug-fill.svg)
-  static const plug = PhosphorFlatIconData(0xe946, 'Fill');
+  static const plug = IconData(0xe946,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-charging-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plug-charging-fill.svg)
-  static const plugCharging = PhosphorFlatIconData(0xeb5c, 'Fill');
+  static const plugCharging = IconData(0xeb5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plugs-fill.svg)
-  static const plugs = PhosphorFlatIconData(0xeb56, 'Fill');
+  static const plugs = IconData(0xeb56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-connected-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plugs-connected-fill.svg)
-  static const plugsConnected = PhosphorFlatIconData(0xeb5a, 'Fill');
+  static const plugsConnected = IconData(0xeb5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plus-fill.svg)
-  static const plus = PhosphorFlatIconData(0xe3d4, 'Fill');
+  static const plus = IconData(0xe3d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plus-circle-fill.svg)
-  static const plusCircle = PhosphorFlatIconData(0xe3d6, 'Fill');
+  static const plusCircle = IconData(0xe3d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plus-minus-fill.svg)
-  static const plusMinus = PhosphorFlatIconData(0xe3d8, 'Fill');
+  static const plusMinus = IconData(0xe3d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/plus-square-fill.svg)
-  static const plusSquare = PhosphorFlatIconData(0xed4a, 'Fill');
+  static const plusSquare = IconData(0xed4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![poker-chip-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/poker-chip-fill.svg)
-  static const pokerChip = PhosphorFlatIconData(0xe594, 'Fill');
+  static const pokerChip = IconData(0xe594,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![police-car-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/police-car-fill.svg)
-  static const policeCar = PhosphorFlatIconData(0xec4a, 'Fill');
+  static const policeCar = IconData(0xec4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![polygon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/polygon-fill.svg)
-  static const polygon = PhosphorFlatIconData(0xe6d0, 'Fill');
+  static const polygon = IconData(0xe6d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popcorn-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/popcorn-fill.svg)
-  static const popcorn = PhosphorFlatIconData(0xeb4e, 'Fill');
+  static const popcorn = IconData(0xeb4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popsicle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/popsicle-fill.svg)
-  static const popsicle = PhosphorFlatIconData(0xebbe, 'Fill');
+  static const popsicle = IconData(0xebbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![potted-plant-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/potted-plant-fill.svg)
-  static const pottedPlant = PhosphorFlatIconData(0xec22, 'Fill');
+  static const pottedPlant = IconData(0xec22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![power-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/power-fill.svg)
-  static const power = PhosphorFlatIconData(0xe3da, 'Fill');
+  static const power = IconData(0xe3da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prescription-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/prescription-fill.svg)
-  static const prescription = PhosphorFlatIconData(0xe7a2, 'Fill');
+  static const prescription = IconData(0xe7a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/presentation-fill.svg)
-  static const presentation = PhosphorFlatIconData(0xe654, 'Fill');
+  static const presentation = IconData(0xe654,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-chart-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/presentation-chart-fill.svg)
-  static const presentationChart = PhosphorFlatIconData(0xe656, 'Fill');
+  static const presentationChart = IconData(0xe656,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![printer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/printer-fill.svg)
-  static const printer = PhosphorFlatIconData(0xe3dc, 'Fill');
+  static const printer = IconData(0xe3dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/prohibit-fill.svg)
-  static const prohibit = PhosphorFlatIconData(0xe3de, 'Fill');
+  static const prohibit = IconData(0xe3de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-inset-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/prohibit-inset-fill.svg)
-  static const prohibitInset = PhosphorFlatIconData(0xe3e0, 'Fill');
+  static const prohibitInset = IconData(0xe3e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/projector-screen-fill.svg)
-  static const projectorScreen = PhosphorFlatIconData(0xe658, 'Fill');
+  static const projectorScreen = IconData(0xe658,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-chart-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/projector-screen-chart-fill.svg)
-  static const projectorScreenChart = PhosphorFlatIconData(0xe65a, 'Fill');
+  static const projectorScreenChart = IconData(0xe65a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pulse-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/pulse-fill.svg)
-  static const pulse = PhosphorFlatIconData(0xe000, 'Fill');
+  static const pulse = IconData(0xe000,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/push-pin-fill.svg)
-  static const pushPin = PhosphorFlatIconData(0xe3e2, 'Fill');
+  static const pushPin = IconData(0xe3e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/push-pin-simple-fill.svg)
-  static const pushPinSimple = PhosphorFlatIconData(0xe65c, 'Fill');
+  static const pushPinSimple = IconData(0xe65c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/push-pin-simple-slash-fill.svg)
-  static const pushPinSimpleSlash = PhosphorFlatIconData(0xe65e, 'Fill');
+  static const pushPinSimpleSlash = IconData(0xe65e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/push-pin-slash-fill.svg)
-  static const pushPinSlash = PhosphorFlatIconData(0xe3e4, 'Fill');
+  static const pushPinSlash = IconData(0xe3e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![puzzle-piece-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/puzzle-piece-fill.svg)
-  static const puzzlePiece = PhosphorFlatIconData(0xe596, 'Fill');
+  static const puzzlePiece = IconData(0xe596,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![qr-code-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/qr-code-fill.svg)
-  static const qrCode = PhosphorFlatIconData(0xe3e6, 'Fill');
+  static const qrCode = IconData(0xe3e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/question-fill.svg)
-  static const question = PhosphorFlatIconData(0xe3e8, 'Fill');
+  static const question = IconData(0xe3e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-mark-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/question-mark-fill.svg)
-  static const questionMark = PhosphorFlatIconData(0xe3e9, 'Fill');
+  static const questionMark = IconData(0xe3e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![queue-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/queue-fill.svg)
-  static const queue = PhosphorFlatIconData(0xe6ac, 'Fill');
+  static const queue = IconData(0xe6ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![quotes-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/quotes-fill.svg)
-  static const quotes = PhosphorFlatIconData(0xe660, 'Fill');
+  static const quotes = IconData(0xe660,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rabbit-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rabbit-fill.svg)
-  static const rabbit = PhosphorFlatIconData(0xeac2, 'Fill');
+  static const rabbit = IconData(0xeac2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![racquet-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/racquet-fill.svg)
-  static const racquet = PhosphorFlatIconData(0xee02, 'Fill');
+  static const racquet = IconData(0xee02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/radical-fill.svg)
-  static const radical = PhosphorFlatIconData(0xe3ea, 'Fill');
+  static const radical = IconData(0xe3ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/radio-fill.svg)
-  static const radio = PhosphorFlatIconData(0xe77e, 'Fill');
+  static const radio = IconData(0xe77e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-button-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/radio-button-fill.svg)
-  static const radioButton = PhosphorFlatIconData(0xeb08, 'Fill');
+  static const radioButton = IconData(0xeb08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radioactive-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/radioactive-fill.svg)
-  static const radioactive = PhosphorFlatIconData(0xe9dc, 'Fill');
+  static const radioactive = IconData(0xe9dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rainbow-fill.svg)
-  static const rainbow = PhosphorFlatIconData(0xe598, 'Fill');
+  static const rainbow = IconData(0xe598,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-cloud-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rainbow-cloud-fill.svg)
-  static const rainbowCloud = PhosphorFlatIconData(0xe59a, 'Fill');
+  static const rainbowCloud = IconData(0xe59a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ranking-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ranking-fill.svg)
-  static const ranking = PhosphorFlatIconData(0xed62, 'Fill');
+  static const ranking = IconData(0xed62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![read-cv-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/read-cv-logo-fill.svg)
-  static const readCvLogo = PhosphorFlatIconData(0xed0c, 'Fill');
+  static const readCvLogo = IconData(0xed0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/receipt-fill.svg)
-  static const receipt = PhosphorFlatIconData(0xe3ec, 'Fill');
+  static const receipt = IconData(0xe3ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/receipt-x-fill.svg)
-  static const receiptX = PhosphorFlatIconData(0xed40, 'Fill');
+  static const receiptX = IconData(0xed40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![record-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/record-fill.svg)
-  static const record = PhosphorFlatIconData(0xe3ee, 'Fill');
+  static const record = IconData(0xe3ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rectangle-fill.svg)
-  static const rectangle = PhosphorFlatIconData(0xe3f0, 'Fill');
+  static const rectangle = IconData(0xe3f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-dashed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rectangle-dashed-fill.svg)
-  static const rectangleDashed = PhosphorFlatIconData(0xe3f2, 'Fill');
+  static const rectangleDashed = IconData(0xe3f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![recycle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/recycle-fill.svg)
-  static const recycle = PhosphorFlatIconData(0xe75a, 'Fill');
+  static const recycle = IconData(0xe75a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![reddit-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/reddit-logo-fill.svg)
-  static const redditLogo = PhosphorFlatIconData(0xe59c, 'Fill');
+  static const redditLogo = IconData(0xe59c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/repeat-fill.svg)
-  static const repeat = PhosphorFlatIconData(0xe3f6, 'Fill');
+  static const repeat = IconData(0xe3f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-once-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/repeat-once-fill.svg)
-  static const repeatOnce = PhosphorFlatIconData(0xe3f8, 'Fill');
+  static const repeatOnce = IconData(0xe3f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![replit-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/replit-logo-fill.svg)
-  static const replitLogo = PhosphorFlatIconData(0xeb8a, 'Fill');
+  static const replitLogo = IconData(0xeb8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![resize-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/resize-fill.svg)
-  static const resize = PhosphorFlatIconData(0xed6e, 'Fill');
+  static const resize = IconData(0xed6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rewind-fill.svg)
-  static const rewind = PhosphorFlatIconData(0xe6a8, 'Fill');
+  static const rewind = IconData(0xe6a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rewind-circle-fill.svg)
-  static const rewindCircle = PhosphorFlatIconData(0xe3fa, 'Fill');
+  static const rewindCircle = IconData(0xe3fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![road-horizon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/road-horizon-fill.svg)
-  static const roadHorizon = PhosphorFlatIconData(0xe838, 'Fill');
+  static const roadHorizon = IconData(0xe838,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![robot-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/robot-fill.svg)
-  static const robot = PhosphorFlatIconData(0xe762, 'Fill');
+  static const robot = IconData(0xe762,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rocket-fill.svg)
-  static const rocket = PhosphorFlatIconData(0xe3fc, 'Fill');
+  static const rocket = IconData(0xe3fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-launch-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rocket-launch-fill.svg)
-  static const rocketLaunch = PhosphorFlatIconData(0xe3fe, 'Fill');
+  static const rocketLaunch = IconData(0xe3fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rows-fill.svg)
-  static const rows = PhosphorFlatIconData(0xe5a2, 'Fill');
+  static const rows = IconData(0xe5a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-bottom-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rows-plus-bottom-fill.svg)
-  static const rowsPlusBottom = PhosphorFlatIconData(0xe59e, 'Fill');
+  static const rowsPlusBottom = IconData(0xe59e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-top-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rows-plus-top-fill.svg)
-  static const rowsPlusTop = PhosphorFlatIconData(0xe5a0, 'Fill');
+  static const rowsPlusTop = IconData(0xe5a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rss-fill.svg)
-  static const rss = PhosphorFlatIconData(0xe400, 'Fill');
+  static const rss = IconData(0xe400,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rss-simple-fill.svg)
-  static const rssSimple = PhosphorFlatIconData(0xe402, 'Fill');
+  static const rssSimple = IconData(0xe402,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rug-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/rug-fill.svg)
-  static const rug = PhosphorFlatIconData(0xea1a, 'Fill');
+  static const rug = IconData(0xea1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ruler-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ruler-fill.svg)
-  static const ruler = PhosphorFlatIconData(0xe6b8, 'Fill');
+  static const ruler = IconData(0xe6b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sailboat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sailboat-fill.svg)
-  static const sailboat = PhosphorFlatIconData(0xe78a, 'Fill');
+  static const sailboat = IconData(0xe78a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scales-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/scales-fill.svg)
-  static const scales = PhosphorFlatIconData(0xe750, 'Fill');
+  static const scales = IconData(0xe750,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/scan-fill.svg)
-  static const scan = PhosphorFlatIconData(0xebb6, 'Fill');
+  static const scan = IconData(0xebb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-smiley-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/scan-smiley-fill.svg)
-  static const scanSmiley = PhosphorFlatIconData(0xebb4, 'Fill');
+  static const scanSmiley = IconData(0xebb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scissors-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/scissors-fill.svg)
-  static const scissors = PhosphorFlatIconData(0xeae0, 'Fill');
+  static const scissors = IconData(0xeae0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scooter-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/scooter-fill.svg)
-  static const scooter = PhosphorFlatIconData(0xe820, 'Fill');
+  static const scooter = IconData(0xe820,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screencast-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/screencast-fill.svg)
-  static const screencast = PhosphorFlatIconData(0xe404, 'Fill');
+  static const screencast = IconData(0xe404,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screwdriver-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/screwdriver-fill.svg)
-  static const screwdriver = PhosphorFlatIconData(0xe86e, 'Fill');
+  static const screwdriver = IconData(0xe86e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/scribble-fill.svg)
-  static const scribble = PhosphorFlatIconData(0xe806, 'Fill');
+  static const scribble = IconData(0xe806,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-loop-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/scribble-loop-fill.svg)
-  static const scribbleLoop = PhosphorFlatIconData(0xe662, 'Fill');
+  static const scribbleLoop = IconData(0xe662,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scroll-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/scroll-fill.svg)
-  static const scroll = PhosphorFlatIconData(0xeb7a, 'Fill');
+  static const scroll = IconData(0xeb7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/seal-fill.svg)
-  static const seal = PhosphorFlatIconData(0xe604, 'Fill');
+  static const seal = IconData(0xe604,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-check-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/seal-check-fill.svg)
-  static const sealCheck = PhosphorFlatIconData(0xe606, 'Fill');
+  static const sealCheck = IconData(0xe606,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-percent-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/seal-percent-fill.svg)
-  static const sealPercent = PhosphorFlatIconData(0xe60a, 'Fill');
+  static const sealPercent = IconData(0xe60a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-question-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/seal-question-fill.svg)
-  static const sealQuestion = PhosphorFlatIconData(0xe608, 'Fill');
+  static const sealQuestion = IconData(0xe608,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-warning-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/seal-warning-fill.svg)
-  static const sealWarning = PhosphorFlatIconData(0xe60c, 'Fill');
+  static const sealWarning = IconData(0xe60c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/seat-fill.svg)
-  static const seat = PhosphorFlatIconData(0xeb8e, 'Fill');
+  static const seat = IconData(0xeb8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seatbelt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/seatbelt-fill.svg)
-  static const seatbelt = PhosphorFlatIconData(0xedfe, 'Fill');
+  static const seatbelt = IconData(0xedfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![security-camera-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/security-camera-fill.svg)
-  static const securityCamera = PhosphorFlatIconData(0xeca4, 'Fill');
+  static const securityCamera = IconData(0xeca4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/selection-fill.svg)
-  static const selection = PhosphorFlatIconData(0xe69a, 'Fill');
+  static const selection = IconData(0xe69a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-all-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/selection-all-fill.svg)
-  static const selectionAll = PhosphorFlatIconData(0xe746, 'Fill');
+  static const selectionAll = IconData(0xe746,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-background-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/selection-background-fill.svg)
-  static const selectionBackground = PhosphorFlatIconData(0xeaf8, 'Fill');
+  static const selectionBackground = IconData(0xeaf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-foreground-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/selection-foreground-fill.svg)
-  static const selectionForeground = PhosphorFlatIconData(0xeaf6, 'Fill');
+  static const selectionForeground = IconData(0xeaf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-inverse-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/selection-inverse-fill.svg)
-  static const selectionInverse = PhosphorFlatIconData(0xe744, 'Fill');
+  static const selectionInverse = IconData(0xe744,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/selection-plus-fill.svg)
-  static const selectionPlus = PhosphorFlatIconData(0xe69c, 'Fill');
+  static const selectionPlus = IconData(0xe69c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/selection-slash-fill.svg)
-  static const selectionSlash = PhosphorFlatIconData(0xe69e, 'Fill');
+  static const selectionSlash = IconData(0xe69e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shapes-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shapes-fill.svg)
-  static const shapes = PhosphorFlatIconData(0xec5e, 'Fill');
+  static const shapes = IconData(0xec5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/share-fill.svg)
-  static const share = PhosphorFlatIconData(0xe406, 'Fill');
+  static const share = IconData(0xe406,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-fat-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/share-fat-fill.svg)
-  static const shareFat = PhosphorFlatIconData(0xed52, 'Fill');
+  static const shareFat = IconData(0xed52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-network-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/share-network-fill.svg)
-  static const shareNetwork = PhosphorFlatIconData(0xe408, 'Fill');
+  static const shareNetwork = IconData(0xe408,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shield-fill.svg)
-  static const shield = PhosphorFlatIconData(0xe40a, 'Fill');
+  static const shield = IconData(0xe40a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-check-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shield-check-fill.svg)
-  static const shieldCheck = PhosphorFlatIconData(0xe40c, 'Fill');
+  static const shieldCheck = IconData(0xe40c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-checkered-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shield-checkered-fill.svg)
-  static const shieldCheckered = PhosphorFlatIconData(0xe708, 'Fill');
+  static const shieldCheckered = IconData(0xe708,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-chevron-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shield-chevron-fill.svg)
-  static const shieldChevron = PhosphorFlatIconData(0xe40e, 'Fill');
+  static const shieldChevron = IconData(0xe40e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shield-plus-fill.svg)
-  static const shieldPlus = PhosphorFlatIconData(0xe706, 'Fill');
+  static const shieldPlus = IconData(0xe706,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shield-slash-fill.svg)
-  static const shieldSlash = PhosphorFlatIconData(0xe410, 'Fill');
+  static const shieldSlash = IconData(0xe410,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-star-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shield-star-fill.svg)
-  static const shieldStar = PhosphorFlatIconData(0xec34, 'Fill');
+  static const shieldStar = IconData(0xec34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-warning-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shield-warning-fill.svg)
-  static const shieldWarning = PhosphorFlatIconData(0xe412, 'Fill');
+  static const shieldWarning = IconData(0xe412,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shipping-container-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shipping-container-fill.svg)
-  static const shippingContainer = PhosphorFlatIconData(0xe78c, 'Fill');
+  static const shippingContainer = IconData(0xe78c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shirt-folded-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shirt-folded-fill.svg)
-  static const shirtFolded = PhosphorFlatIconData(0xea92, 'Fill');
+  static const shirtFolded = IconData(0xea92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shooting-star-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shooting-star-fill.svg)
-  static const shootingStar = PhosphorFlatIconData(0xecfa, 'Fill');
+  static const shootingStar = IconData(0xecfa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shopping-bag-fill.svg)
-  static const shoppingBag = PhosphorFlatIconData(0xe416, 'Fill');
+  static const shoppingBag = IconData(0xe416,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-open-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shopping-bag-open-fill.svg)
-  static const shoppingBagOpen = PhosphorFlatIconData(0xe418, 'Fill');
+  static const shoppingBagOpen = IconData(0xe418,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shopping-cart-fill.svg)
-  static const shoppingCart = PhosphorFlatIconData(0xe41e, 'Fill');
+  static const shoppingCart = IconData(0xe41e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shopping-cart-simple-fill.svg)
-  static const shoppingCartSimple = PhosphorFlatIconData(0xe420, 'Fill');
+  static const shoppingCartSimple = IconData(0xe420,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shovel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shovel-fill.svg)
-  static const shovel = PhosphorFlatIconData(0xe9e6, 'Fill');
+  static const shovel = IconData(0xe9e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shower-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shower-fill.svg)
-  static const shower = PhosphorFlatIconData(0xe776, 'Fill');
+  static const shower = IconData(0xe776,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shrimp-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shrimp-fill.svg)
-  static const shrimp = PhosphorFlatIconData(0xeab4, 'Fill');
+  static const shrimp = IconData(0xeab4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shuffle-fill.svg)
-  static const shuffle = PhosphorFlatIconData(0xe422, 'Fill');
+  static const shuffle = IconData(0xe422,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-angular-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shuffle-angular-fill.svg)
-  static const shuffleAngular = PhosphorFlatIconData(0xe424, 'Fill');
+  static const shuffleAngular = IconData(0xe424,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/shuffle-simple-fill.svg)
-  static const shuffleSimple = PhosphorFlatIconData(0xe426, 'Fill');
+  static const shuffleSimple = IconData(0xe426,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sidebar-fill.svg)
-  static const sidebar = PhosphorFlatIconData(0xeab6, 'Fill');
+  static const sidebar = IconData(0xeab6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sidebar-simple-fill.svg)
-  static const sidebarSimple = PhosphorFlatIconData(0xec24, 'Fill');
+  static const sidebarSimple = IconData(0xec24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sigma-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sigma-fill.svg)
-  static const sigma = PhosphorFlatIconData(0xeab8, 'Fill');
+  static const sigma = IconData(0xeab8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-in-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sign-in-fill.svg)
-  static const signIn = PhosphorFlatIconData(0xe428, 'Fill');
+  static const signIn = IconData(0xe428,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-out-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sign-out-fill.svg)
-  static const signOut = PhosphorFlatIconData(0xe42a, 'Fill');
+  static const signOut = IconData(0xe42a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signature-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/signature-fill.svg)
-  static const signature = PhosphorFlatIconData(0xebac, 'Fill');
+  static const signature = IconData(0xebac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signpost-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/signpost-fill.svg)
-  static const signpost = PhosphorFlatIconData(0xe89c, 'Fill');
+  static const signpost = IconData(0xe89c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sim-card-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sim-card-fill.svg)
-  static const simCard = PhosphorFlatIconData(0xe664, 'Fill');
+  static const simCard = IconData(0xe664,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![siren-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/siren-fill.svg)
-  static const siren = PhosphorFlatIconData(0xe9b8, 'Fill');
+  static const siren = IconData(0xe9b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sketch-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sketch-logo-fill.svg)
-  static const sketchLogo = PhosphorFlatIconData(0xe42c, 'Fill');
+  static const sketchLogo = IconData(0xe42c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/skip-back-fill.svg)
-  static const skipBack = PhosphorFlatIconData(0xe5a4, 'Fill');
+  static const skipBack = IconData(0xe5a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/skip-back-circle-fill.svg)
-  static const skipBackCircle = PhosphorFlatIconData(0xe42e, 'Fill');
+  static const skipBackCircle = IconData(0xe42e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/skip-forward-fill.svg)
-  static const skipForward = PhosphorFlatIconData(0xe5a6, 'Fill');
+  static const skipForward = IconData(0xe5a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/skip-forward-circle-fill.svg)
-  static const skipForwardCircle = PhosphorFlatIconData(0xe430, 'Fill');
+  static const skipForwardCircle = IconData(0xe430,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skull-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/skull-fill.svg)
-  static const skull = PhosphorFlatIconData(0xe916, 'Fill');
+  static const skull = IconData(0xe916,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skype-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/skype-logo-fill.svg)
-  static const skypeLogo = PhosphorFlatIconData(0xe8dc, 'Fill');
+  static const skypeLogo = IconData(0xe8dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slack-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/slack-logo-fill.svg)
-  static const slackLogo = PhosphorFlatIconData(0xe5a8, 'Fill');
+  static const slackLogo = IconData(0xe5a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sliders-fill.svg)
-  static const sliders = PhosphorFlatIconData(0xe432, 'Fill');
+  static const sliders = IconData(0xe432,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sliders-horizontal-fill.svg)
-  static const slidersHorizontal = PhosphorFlatIconData(0xe434, 'Fill');
+  static const slidersHorizontal = IconData(0xe434,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slideshow-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/slideshow-fill.svg)
-  static const slideshow = PhosphorFlatIconData(0xed32, 'Fill');
+  static const slideshow = IconData(0xed32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-fill.svg)
-  static const smiley = PhosphorFlatIconData(0xe436, 'Fill');
+  static const smiley = IconData(0xe436,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-angry-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-angry-fill.svg)
-  static const smileyAngry = PhosphorFlatIconData(0xec62, 'Fill');
+  static const smileyAngry = IconData(0xec62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-blank-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-blank-fill.svg)
-  static const smileyBlank = PhosphorFlatIconData(0xe438, 'Fill');
+  static const smileyBlank = IconData(0xe438,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-meh-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-meh-fill.svg)
-  static const smileyMeh = PhosphorFlatIconData(0xe43a, 'Fill');
+  static const smileyMeh = IconData(0xe43a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-melting-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-melting-fill.svg)
-  static const smileyMelting = PhosphorFlatIconData(0xee56, 'Fill');
+  static const smileyMelting = IconData(0xee56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-nervous-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-nervous-fill.svg)
-  static const smileyNervous = PhosphorFlatIconData(0xe43c, 'Fill');
+  static const smileyNervous = IconData(0xe43c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sad-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-sad-fill.svg)
-  static const smileySad = PhosphorFlatIconData(0xe43e, 'Fill');
+  static const smileySad = IconData(0xe43e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sticker-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-sticker-fill.svg)
-  static const smileySticker = PhosphorFlatIconData(0xe440, 'Fill');
+  static const smileySticker = IconData(0xe440,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-wink-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-wink-fill.svg)
-  static const smileyWink = PhosphorFlatIconData(0xe666, 'Fill');
+  static const smileyWink = IconData(0xe666,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-x-eyes-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/smiley-x-eyes-fill.svg)
-  static const smileyXEyes = PhosphorFlatIconData(0xe442, 'Fill');
+  static const smileyXEyes = IconData(0xe442,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snapchat-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/snapchat-logo-fill.svg)
-  static const snapchatLogo = PhosphorFlatIconData(0xe668, 'Fill');
+  static const snapchatLogo = IconData(0xe668,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sneaker-fill.svg)
-  static const sneaker = PhosphorFlatIconData(0xe80c, 'Fill');
+  static const sneaker = IconData(0xe80c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-move-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sneaker-move-fill.svg)
-  static const sneakerMove = PhosphorFlatIconData(0xed60, 'Fill');
+  static const sneakerMove = IconData(0xed60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snowflake-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/snowflake-fill.svg)
-  static const snowflake = PhosphorFlatIconData(0xe5aa, 'Fill');
+  static const snowflake = IconData(0xe5aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soccer-ball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/soccer-ball-fill.svg)
-  static const soccerBall = PhosphorFlatIconData(0xe716, 'Fill');
+  static const soccerBall = IconData(0xe716,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sock-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sock-fill.svg)
-  static const sock = PhosphorFlatIconData(0xecce, 'Fill');
+  static const sock = IconData(0xecce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-panel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/solar-panel-fill.svg)
-  static const solarPanel = PhosphorFlatIconData(0xed7a, 'Fill');
+  static const solarPanel = IconData(0xed7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-roof-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/solar-roof-fill.svg)
-  static const solarRoof = PhosphorFlatIconData(0xed7b, 'Fill');
+  static const solarRoof = IconData(0xed7b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-ascending-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sort-ascending-fill.svg)
-  static const sortAscending = PhosphorFlatIconData(0xe444, 'Fill');
+  static const sortAscending = IconData(0xe444,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-descending-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sort-descending-fill.svg)
-  static const sortDescending = PhosphorFlatIconData(0xe446, 'Fill');
+  static const sortDescending = IconData(0xe446,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soundcloud-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/soundcloud-logo-fill.svg)
-  static const soundcloudLogo = PhosphorFlatIconData(0xe8de, 'Fill');
+  static const soundcloudLogo = IconData(0xe8de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spade-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/spade-fill.svg)
-  static const spade = PhosphorFlatIconData(0xe448, 'Fill');
+  static const spade = IconData(0xe448,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sparkle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sparkle-fill.svg)
-  static const sparkle = PhosphorFlatIconData(0xe6a2, 'Fill');
+  static const sparkle = IconData(0xe6a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-hifi-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-hifi-fill.svg)
-  static const speakerHifi = PhosphorFlatIconData(0xea08, 'Fill');
+  static const speakerHifi = IconData(0xea08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-high-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-high-fill.svg)
-  static const speakerHigh = PhosphorFlatIconData(0xe44a, 'Fill');
+  static const speakerHigh = IconData(0xe44a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-low-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-low-fill.svg)
-  static const speakerLow = PhosphorFlatIconData(0xe44c, 'Fill');
+  static const speakerLow = IconData(0xe44c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-none-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-none-fill.svg)
-  static const speakerNone = PhosphorFlatIconData(0xe44e, 'Fill');
+  static const speakerNone = IconData(0xe44e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-high-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-simple-high-fill.svg)
-  static const speakerSimpleHigh = PhosphorFlatIconData(0xe450, 'Fill');
+  static const speakerSimpleHigh = IconData(0xe450,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-low-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-simple-low-fill.svg)
-  static const speakerSimpleLow = PhosphorFlatIconData(0xe452, 'Fill');
+  static const speakerSimpleLow = IconData(0xe452,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-none-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-simple-none-fill.svg)
-  static const speakerSimpleNone = PhosphorFlatIconData(0xe454, 'Fill');
+  static const speakerSimpleNone = IconData(0xe454,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-simple-slash-fill.svg)
-  static const speakerSimpleSlash = PhosphorFlatIconData(0xe456, 'Fill');
+  static const speakerSimpleSlash = IconData(0xe456,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-simple-x-fill.svg)
-  static const speakerSimpleX = PhosphorFlatIconData(0xe458, 'Fill');
+  static const speakerSimpleX = IconData(0xe458,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-slash-fill.svg)
-  static const speakerSlash = PhosphorFlatIconData(0xe45a, 'Fill');
+  static const speakerSlash = IconData(0xe45a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speaker-x-fill.svg)
-  static const speakerX = PhosphorFlatIconData(0xe45c, 'Fill');
+  static const speakerX = IconData(0xe45c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speedometer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/speedometer-fill.svg)
-  static const speedometer = PhosphorFlatIconData(0xee74, 'Fill');
+  static const speedometer = IconData(0xee74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sphere-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sphere-fill.svg)
-  static const sphere = PhosphorFlatIconData(0xee66, 'Fill');
+  static const sphere = IconData(0xee66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/spinner-fill.svg)
-  static const spinner = PhosphorFlatIconData(0xe66a, 'Fill');
+  static const spinner = IconData(0xe66a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-ball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/spinner-ball-fill.svg)
-  static const spinnerBall = PhosphorFlatIconData(0xee28, 'Fill');
+  static const spinnerBall = IconData(0xee28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-gap-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/spinner-gap-fill.svg)
-  static const spinnerGap = PhosphorFlatIconData(0xe66c, 'Fill');
+  static const spinnerGap = IconData(0xe66c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spiral-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/spiral-fill.svg)
-  static const spiral = PhosphorFlatIconData(0xe9fa, 'Fill');
+  static const spiral = IconData(0xe9fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/split-horizontal-fill.svg)
-  static const splitHorizontal = PhosphorFlatIconData(0xe872, 'Fill');
+  static const splitHorizontal = IconData(0xe872,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/split-vertical-fill.svg)
-  static const splitVertical = PhosphorFlatIconData(0xe876, 'Fill');
+  static const splitVertical = IconData(0xe876,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spotify-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/spotify-logo-fill.svg)
-  static const spotifyLogo = PhosphorFlatIconData(0xe66e, 'Fill');
+  static const spotifyLogo = IconData(0xe66e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spray-bottle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/spray-bottle-fill.svg)
-  static const sprayBottle = PhosphorFlatIconData(0xe7e4, 'Fill');
+  static const sprayBottle = IconData(0xe7e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/square-fill.svg)
-  static const square = PhosphorFlatIconData(0xe45e, 'Fill');
+  static const square = IconData(0xe45e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/square-half-fill.svg)
-  static const squareHalf = PhosphorFlatIconData(0xe462, 'Fill');
+  static const squareHalf = IconData(0xe462,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-bottom-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/square-half-bottom-fill.svg)
-  static const squareHalfBottom = PhosphorFlatIconData(0xeb16, 'Fill');
+  static const squareHalfBottom = IconData(0xeb16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/square-logo-fill.svg)
-  static const squareLogo = PhosphorFlatIconData(0xe690, 'Fill');
+  static const squareLogo = IconData(0xe690,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-horizontal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/square-split-horizontal-fill.svg)
-  static const squareSplitHorizontal = PhosphorFlatIconData(0xe870, 'Fill');
+  static const squareSplitHorizontal = IconData(0xe870,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-vertical-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/square-split-vertical-fill.svg)
-  static const squareSplitVertical = PhosphorFlatIconData(0xe874, 'Fill');
+  static const squareSplitVertical = IconData(0xe874,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![squares-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/squares-four-fill.svg)
-  static const squaresFour = PhosphorFlatIconData(0xe464, 'Fill');
+  static const squaresFour = IconData(0xe464,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stack-fill.svg)
-  static const stack = PhosphorFlatIconData(0xe466, 'Fill');
+  static const stack = IconData(0xe466,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stack-minus-fill.svg)
-  static const stackMinus = PhosphorFlatIconData(0xedf4, 'Fill');
+  static const stackMinus = IconData(0xedf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-overflow-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stack-overflow-logo-fill.svg)
-  static const stackOverflowLogo = PhosphorFlatIconData(0xeb78, 'Fill');
+  static const stackOverflowLogo = IconData(0xeb78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stack-plus-fill.svg)
-  static const stackPlus = PhosphorFlatIconData(0xedf6, 'Fill');
+  static const stackPlus = IconData(0xedf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stack-simple-fill.svg)
-  static const stackSimple = PhosphorFlatIconData(0xe468, 'Fill');
+  static const stackSimple = IconData(0xe468,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stairs-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stairs-fill.svg)
-  static const stairs = PhosphorFlatIconData(0xe8ec, 'Fill');
+  static const stairs = IconData(0xe8ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stamp-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stamp-fill.svg)
-  static const stamp = PhosphorFlatIconData(0xea48, 'Fill');
+  static const stamp = IconData(0xea48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![standard-definition-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/standard-definition-fill.svg)
-  static const standardDefinition = PhosphorFlatIconData(0xea90, 'Fill');
+  static const standardDefinition = IconData(0xea90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/star-fill.svg)
-  static const star = PhosphorFlatIconData(0xe46a, 'Fill');
+  static const star = IconData(0xe46a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-and-crescent-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/star-and-crescent-fill.svg)
-  static const starAndCrescent = PhosphorFlatIconData(0xecf4, 'Fill');
+  static const starAndCrescent = IconData(0xecf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/star-four-fill.svg)
-  static const starFour = PhosphorFlatIconData(0xe6a4, 'Fill');
+  static const starFour = IconData(0xe6a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-half-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/star-half-fill.svg)
-  static const starHalf = PhosphorFlatIconData(0xe70a, 'Fill');
+  static const starHalf = IconData(0xe70a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-of-david-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/star-of-david-fill.svg)
-  static const starOfDavid = PhosphorFlatIconData(0xe89e, 'Fill');
+  static const starOfDavid = IconData(0xe89e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steam-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/steam-logo-fill.svg)
-  static const steamLogo = PhosphorFlatIconData(0xead4, 'Fill');
+  static const steamLogo = IconData(0xead4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steering-wheel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/steering-wheel-fill.svg)
-  static const steeringWheel = PhosphorFlatIconData(0xe9ac, 'Fill');
+  static const steeringWheel = IconData(0xe9ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steps-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/steps-fill.svg)
-  static const steps = PhosphorFlatIconData(0xecbe, 'Fill');
+  static const steps = IconData(0xecbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stethoscope-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stethoscope-fill.svg)
-  static const stethoscope = PhosphorFlatIconData(0xe7ea, 'Fill');
+  static const stethoscope = IconData(0xe7ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sticker-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sticker-fill.svg)
-  static const sticker = PhosphorFlatIconData(0xe5ac, 'Fill');
+  static const sticker = IconData(0xe5ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stool-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stool-fill.svg)
-  static const stool = PhosphorFlatIconData(0xea44, 'Fill');
+  static const stool = IconData(0xea44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stop-fill.svg)
-  static const stop = PhosphorFlatIconData(0xe46c, 'Fill');
+  static const stop = IconData(0xe46c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stop-circle-fill.svg)
-  static const stopCircle = PhosphorFlatIconData(0xe46e, 'Fill');
+  static const stopCircle = IconData(0xe46e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![storefront-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/storefront-fill.svg)
-  static const storefront = PhosphorFlatIconData(0xe470, 'Fill');
+  static const storefront = IconData(0xe470,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![strategy-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/strategy-fill.svg)
-  static const strategy = PhosphorFlatIconData(0xea3a, 'Fill');
+  static const strategy = IconData(0xea3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stripe-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/stripe-logo-fill.svg)
-  static const stripeLogo = PhosphorFlatIconData(0xe698, 'Fill');
+  static const stripeLogo = IconData(0xe698,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![student-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/student-fill.svg)
-  static const student = PhosphorFlatIconData(0xe73e, 'Fill');
+  static const student = IconData(0xe73e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-of-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/subset-of-fill.svg)
-  static const subsetOf = PhosphorFlatIconData(0xedc0, 'Fill');
+  static const subsetOf = IconData(0xedc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-proper-of-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/subset-proper-of-fill.svg)
-  static const subsetProperOf = PhosphorFlatIconData(0xedb6, 'Fill');
+  static const subsetProperOf = IconData(0xedb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/subtitles-fill.svg)
-  static const subtitles = PhosphorFlatIconData(0xe1a8, 'Fill');
+  static const subtitles = IconData(0xe1a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/subtitles-slash-fill.svg)
-  static const subtitlesSlash = PhosphorFlatIconData(0xe1a6, 'Fill');
+  static const subtitlesSlash = IconData(0xe1a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/subtract-fill.svg)
-  static const subtract = PhosphorFlatIconData(0xebd6, 'Fill');
+  static const subtract = IconData(0xebd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/subtract-square-fill.svg)
-  static const subtractSquare = PhosphorFlatIconData(0xebd4, 'Fill');
+  static const subtractSquare = IconData(0xebd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subway-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/subway-fill.svg)
-  static const subway = PhosphorFlatIconData(0xe498, 'Fill');
+  static const subway = IconData(0xe498,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/suitcase-fill.svg)
-  static const suitcase = PhosphorFlatIconData(0xe5ae, 'Fill');
+  static const suitcase = IconData(0xe5ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-rolling-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/suitcase-rolling-fill.svg)
-  static const suitcaseRolling = PhosphorFlatIconData(0xe9b0, 'Fill');
+  static const suitcaseRolling = IconData(0xe9b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/suitcase-simple-fill.svg)
-  static const suitcaseSimple = PhosphorFlatIconData(0xe5b0, 'Fill');
+  static const suitcaseSimple = IconData(0xe5b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sun-fill.svg)
-  static const sun = PhosphorFlatIconData(0xe472, 'Fill');
+  static const sun = IconData(0xe472,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-dim-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sun-dim-fill.svg)
-  static const sunDim = PhosphorFlatIconData(0xe474, 'Fill');
+  static const sunDim = IconData(0xe474,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-horizon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sun-horizon-fill.svg)
-  static const sunHorizon = PhosphorFlatIconData(0xe5b6, 'Fill');
+  static const sunHorizon = IconData(0xe5b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sunglasses-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sunglasses-fill.svg)
-  static const sunglasses = PhosphorFlatIconData(0xe816, 'Fill');
+  static const sunglasses = IconData(0xe816,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-of-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/superset-of-fill.svg)
-  static const supersetOf = PhosphorFlatIconData(0xedb8, 'Fill');
+  static const supersetOf = IconData(0xedb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-proper-of-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/superset-proper-of-fill.svg)
-  static const supersetProperOf = PhosphorFlatIconData(0xedb4, 'Fill');
+  static const supersetProperOf = IconData(0xedb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swap-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/swap-fill.svg)
-  static const swap = PhosphorFlatIconData(0xe83c, 'Fill');
+  static const swap = IconData(0xe83c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swatches-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/swatches-fill.svg)
-  static const swatches = PhosphorFlatIconData(0xe5b8, 'Fill');
+  static const swatches = IconData(0xe5b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swimming-pool-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/swimming-pool-fill.svg)
-  static const swimmingPool = PhosphorFlatIconData(0xecb6, 'Fill');
+  static const swimmingPool = IconData(0xecb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sword-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/sword-fill.svg)
-  static const sword = PhosphorFlatIconData(0xe5ba, 'Fill');
+  static const sword = IconData(0xe5ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![synagogue-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/synagogue-fill.svg)
-  static const synagogue = PhosphorFlatIconData(0xecec, 'Fill');
+  static const synagogue = IconData(0xecec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![syringe-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/syringe-fill.svg)
-  static const syringe = PhosphorFlatIconData(0xe968, 'Fill');
+  static const syringe = IconData(0xe968,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![t-shirt-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/t-shirt-fill.svg)
-  static const tShirt = PhosphorFlatIconData(0xe670, 'Fill');
+  static const tShirt = IconData(0xe670,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![table-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/table-fill.svg)
-  static const table = PhosphorFlatIconData(0xe476, 'Fill');
+  static const table = IconData(0xe476,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tabs-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tabs-fill.svg)
-  static const tabs = PhosphorFlatIconData(0xe778, 'Fill');
+  static const tabs = IconData(0xe778,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tag-fill.svg)
-  static const tag = PhosphorFlatIconData(0xe478, 'Fill');
+  static const tag = IconData(0xe478,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-chevron-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tag-chevron-fill.svg)
-  static const tagChevron = PhosphorFlatIconData(0xe672, 'Fill');
+  static const tagChevron = IconData(0xe672,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tag-simple-fill.svg)
-  static const tagSimple = PhosphorFlatIconData(0xe47a, 'Fill');
+  static const tagSimple = IconData(0xe47a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![target-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/target-fill.svg)
-  static const target = PhosphorFlatIconData(0xe47c, 'Fill');
+  static const target = IconData(0xe47c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![taxi-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/taxi-fill.svg)
-  static const taxi = PhosphorFlatIconData(0xe902, 'Fill');
+  static const taxi = IconData(0xe902,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tea-bag-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tea-bag-fill.svg)
-  static const teaBag = PhosphorFlatIconData(0xe8e6, 'Fill');
+  static const teaBag = IconData(0xe8e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![telegram-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/telegram-logo-fill.svg)
-  static const telegramLogo = PhosphorFlatIconData(0xe5bc, 'Fill');
+  static const telegramLogo = IconData(0xe5bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/television-fill.svg)
-  static const television = PhosphorFlatIconData(0xe754, 'Fill');
+  static const television = IconData(0xe754,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/television-simple-fill.svg)
-  static const televisionSimple = PhosphorFlatIconData(0xeae6, 'Fill');
+  static const televisionSimple = IconData(0xeae6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tennis-ball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tennis-ball-fill.svg)
-  static const tennisBall = PhosphorFlatIconData(0xe720, 'Fill');
+  static const tennisBall = IconData(0xe720,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tent-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tent-fill.svg)
-  static const tent = PhosphorFlatIconData(0xe8ba, 'Fill');
+  static const tent = IconData(0xe8ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/terminal-fill.svg)
-  static const terminal = PhosphorFlatIconData(0xe47e, 'Fill');
+  static const terminal = IconData(0xe47e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-window-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/terminal-window-fill.svg)
-  static const terminalWindow = PhosphorFlatIconData(0xeae8, 'Fill');
+  static const terminalWindow = IconData(0xeae8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![test-tube-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/test-tube-fill.svg)
-  static const testTube = PhosphorFlatIconData(0xe7a0, 'Fill');
+  static const testTube = IconData(0xe7a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-a-underline-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-a-underline-fill.svg)
-  static const textAUnderline = PhosphorFlatIconData(0xed34, 'Fill');
+  static const textAUnderline = IconData(0xed34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-aa-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-aa-fill.svg)
-  static const textAa = PhosphorFlatIconData(0xe6ee, 'Fill');
+  static const textAa = IconData(0xe6ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-center-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-align-center-fill.svg)
-  static const textAlignCenter = PhosphorFlatIconData(0xe480, 'Fill');
+  static const textAlignCenter = IconData(0xe480,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-justify-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-align-justify-fill.svg)
-  static const textAlignJustify = PhosphorFlatIconData(0xe482, 'Fill');
+  static const textAlignJustify = IconData(0xe482,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-align-left-fill.svg)
-  static const textAlignLeft = PhosphorFlatIconData(0xe484, 'Fill');
+  static const textAlignLeft = IconData(0xe484,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-align-right-fill.svg)
-  static const textAlignRight = PhosphorFlatIconData(0xe486, 'Fill');
+  static const textAlignRight = IconData(0xe486,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-b-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-b-fill.svg)
-  static const textB = PhosphorFlatIconData(0xe5be, 'Fill');
+  static const textB = IconData(0xe5be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-columns-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-columns-fill.svg)
-  static const textColumns = PhosphorFlatIconData(0xec96, 'Fill');
+  static const textColumns = IconData(0xec96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-h-fill.svg)
-  static const textH = PhosphorFlatIconData(0xe6ba, 'Fill');
+  static const textH = IconData(0xe6ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-five-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-h-five-fill.svg)
-  static const textHFive = PhosphorFlatIconData(0xe6c4, 'Fill');
+  static const textHFive = IconData(0xe6c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-h-four-fill.svg)
-  static const textHFour = PhosphorFlatIconData(0xe6c2, 'Fill');
+  static const textHFour = IconData(0xe6c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-one-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-h-one-fill.svg)
-  static const textHOne = PhosphorFlatIconData(0xe6bc, 'Fill');
+  static const textHOne = IconData(0xe6bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-six-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-h-six-fill.svg)
-  static const textHSix = PhosphorFlatIconData(0xe6c6, 'Fill');
+  static const textHSix = IconData(0xe6c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-h-three-fill.svg)
-  static const textHThree = PhosphorFlatIconData(0xe6c0, 'Fill');
+  static const textHThree = IconData(0xe6c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-two-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-h-two-fill.svg)
-  static const textHTwo = PhosphorFlatIconData(0xe6be, 'Fill');
+  static const textHTwo = IconData(0xe6be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-indent-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-indent-fill.svg)
-  static const textIndent = PhosphorFlatIconData(0xea1e, 'Fill');
+  static const textIndent = IconData(0xea1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-italic-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-italic-fill.svg)
-  static const textItalic = PhosphorFlatIconData(0xe5c0, 'Fill');
+  static const textItalic = IconData(0xe5c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-outdent-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-outdent-fill.svg)
-  static const textOutdent = PhosphorFlatIconData(0xea1c, 'Fill');
+  static const textOutdent = IconData(0xea1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-strikethrough-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-strikethrough-fill.svg)
-  static const textStrikethrough = PhosphorFlatIconData(0xe5c2, 'Fill');
+  static const textStrikethrough = IconData(0xe5c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-subscript-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-subscript-fill.svg)
-  static const textSubscript = PhosphorFlatIconData(0xec98, 'Fill');
+  static const textSubscript = IconData(0xec98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-superscript-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-superscript-fill.svg)
-  static const textSuperscript = PhosphorFlatIconData(0xec9a, 'Fill');
+  static const textSuperscript = IconData(0xec9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-t-fill.svg)
-  static const textT = PhosphorFlatIconData(0xe48a, 'Fill');
+  static const textT = IconData(0xe48a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-t-slash-fill.svg)
-  static const textTSlash = PhosphorFlatIconData(0xe488, 'Fill');
+  static const textTSlash = IconData(0xe488,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-underline-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/text-underline-fill.svg)
-  static const textUnderline = PhosphorFlatIconData(0xe5c4, 'Fill');
+  static const textUnderline = IconData(0xe5c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![textbox-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/textbox-fill.svg)
-  static const textbox = PhosphorFlatIconData(0xeb0a, 'Fill');
+  static const textbox = IconData(0xeb0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/thermometer-fill.svg)
-  static const thermometer = PhosphorFlatIconData(0xe5c6, 'Fill');
+  static const thermometer = IconData(0xe5c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-cold-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/thermometer-cold-fill.svg)
-  static const thermometerCold = PhosphorFlatIconData(0xe5c8, 'Fill');
+  static const thermometerCold = IconData(0xe5c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-hot-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/thermometer-hot-fill.svg)
-  static const thermometerHot = PhosphorFlatIconData(0xe5ca, 'Fill');
+  static const thermometerHot = IconData(0xe5ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/thermometer-simple-fill.svg)
-  static const thermometerSimple = PhosphorFlatIconData(0xe5cc, 'Fill');
+  static const thermometerSimple = IconData(0xe5cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![threads-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/threads-logo-fill.svg)
-  static const threadsLogo = PhosphorFlatIconData(0xed9e, 'Fill');
+  static const threadsLogo = IconData(0xed9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![three-d-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/three-d-fill.svg)
-  static const threeD = PhosphorFlatIconData(0xea5a, 'Fill');
+  static const threeD = IconData(0xea5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/thumbs-down-fill.svg)
-  static const thumbsDown = PhosphorFlatIconData(0xe48c, 'Fill');
+  static const thumbsDown = IconData(0xe48c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/thumbs-up-fill.svg)
-  static const thumbsUp = PhosphorFlatIconData(0xe48e, 'Fill');
+  static const thumbsUp = IconData(0xe48e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ticket-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/ticket-fill.svg)
-  static const ticket = PhosphorFlatIconData(0xe490, 'Fill');
+  static const ticket = IconData(0xe490,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tidal-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tidal-logo-fill.svg)
-  static const tidalLogo = PhosphorFlatIconData(0xed1c, 'Fill');
+  static const tidalLogo = IconData(0xed1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tiktok-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tiktok-logo-fill.svg)
-  static const tiktokLogo = PhosphorFlatIconData(0xeaf2, 'Fill');
+  static const tiktokLogo = IconData(0xeaf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tilde-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tilde-fill.svg)
-  static const tilde = PhosphorFlatIconData(0xeda8, 'Fill');
+  static const tilde = IconData(0xeda8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![timer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/timer-fill.svg)
-  static const timer = PhosphorFlatIconData(0xe492, 'Fill');
+  static const timer = IconData(0xe492,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tip-jar-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tip-jar-fill.svg)
-  static const tipJar = PhosphorFlatIconData(0xe7e2, 'Fill');
+  static const tipJar = IconData(0xe7e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tipi-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tipi-fill.svg)
-  static const tipi = PhosphorFlatIconData(0xed30, 'Fill');
+  static const tipi = IconData(0xed30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tire-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tire-fill.svg)
-  static const tire = PhosphorFlatIconData(0xedd2, 'Fill');
+  static const tire = IconData(0xedd2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-left-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/toggle-left-fill.svg)
-  static const toggleLeft = PhosphorFlatIconData(0xe674, 'Fill');
+  static const toggleLeft = IconData(0xe674,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-right-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/toggle-right-fill.svg)
-  static const toggleRight = PhosphorFlatIconData(0xe676, 'Fill');
+  static const toggleRight = IconData(0xe676,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/toilet-fill.svg)
-  static const toilet = PhosphorFlatIconData(0xe79a, 'Fill');
+  static const toilet = IconData(0xe79a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-paper-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/toilet-paper-fill.svg)
-  static const toiletPaper = PhosphorFlatIconData(0xe79c, 'Fill');
+  static const toiletPaper = IconData(0xe79c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toolbox-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/toolbox-fill.svg)
-  static const toolbox = PhosphorFlatIconData(0xeca0, 'Fill');
+  static const toolbox = IconData(0xeca0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tooth-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tooth-fill.svg)
-  static const tooth = PhosphorFlatIconData(0xe9cc, 'Fill');
+  static const tooth = IconData(0xe9cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tornado-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tornado-fill.svg)
-  static const tornado = PhosphorFlatIconData(0xe88c, 'Fill');
+  static const tornado = IconData(0xe88c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tote-fill.svg)
-  static const tote = PhosphorFlatIconData(0xe494, 'Fill');
+  static const tote = IconData(0xe494,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tote-simple-fill.svg)
-  static const toteSimple = PhosphorFlatIconData(0xe678, 'Fill');
+  static const toteSimple = IconData(0xe678,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![towel-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/towel-fill.svg)
-  static const towel = PhosphorFlatIconData(0xede6, 'Fill');
+  static const towel = IconData(0xede6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tractor-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tractor-fill.svg)
-  static const tractor = PhosphorFlatIconData(0xec6e, 'Fill');
+  static const tractor = IconData(0xec6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trademark-fill.svg)
-  static const trademark = PhosphorFlatIconData(0xe9f0, 'Fill');
+  static const trademark = IconData(0xe9f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-registered-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trademark-registered-fill.svg)
-  static const trademarkRegistered = PhosphorFlatIconData(0xe3f4, 'Fill');
+  static const trademarkRegistered = IconData(0xe3f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-cone-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/traffic-cone-fill.svg)
-  static const trafficCone = PhosphorFlatIconData(0xe9a8, 'Fill');
+  static const trafficCone = IconData(0xe9a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-sign-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/traffic-sign-fill.svg)
-  static const trafficSign = PhosphorFlatIconData(0xe67a, 'Fill');
+  static const trafficSign = IconData(0xe67a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-signal-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/traffic-signal-fill.svg)
-  static const trafficSignal = PhosphorFlatIconData(0xe9aa, 'Fill');
+  static const trafficSignal = IconData(0xe9aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/train-fill.svg)
-  static const train = PhosphorFlatIconData(0xe496, 'Fill');
+  static const train = IconData(0xe496,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-regional-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/train-regional-fill.svg)
-  static const trainRegional = PhosphorFlatIconData(0xe49e, 'Fill');
+  static const trainRegional = IconData(0xe49e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/train-simple-fill.svg)
-  static const trainSimple = PhosphorFlatIconData(0xe4a0, 'Fill');
+  static const trainSimple = IconData(0xe4a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tram-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tram-fill.svg)
-  static const tram = PhosphorFlatIconData(0xe9ec, 'Fill');
+  static const tram = IconData(0xe9ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![translate-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/translate-fill.svg)
-  static const translate = PhosphorFlatIconData(0xe4a2, 'Fill');
+  static const translate = IconData(0xe4a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trash-fill.svg)
-  static const trash = PhosphorFlatIconData(0xe4a6, 'Fill');
+  static const trash = IconData(0xe4a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trash-simple-fill.svg)
-  static const trashSimple = PhosphorFlatIconData(0xe4a8, 'Fill');
+  static const trashSimple = IconData(0xe4a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tray-fill.svg)
-  static const tray = PhosphorFlatIconData(0xe4aa, 'Fill');
+  static const tray = IconData(0xe4aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tray-arrow-down-fill.svg)
-  static const trayArrowDown = PhosphorFlatIconData(0xe010, 'Fill');
+  static const trayArrowDown = IconData(0xe010,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tray-arrow-up-fill.svg)
-  static const trayArrowUp = PhosphorFlatIconData(0xee52, 'Fill');
+  static const trayArrowUp = IconData(0xee52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![treasure-chest-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/treasure-chest-fill.svg)
-  static const treasureChest = PhosphorFlatIconData(0xede2, 'Fill');
+  static const treasureChest = IconData(0xede2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tree-fill.svg)
-  static const tree = PhosphorFlatIconData(0xe6da, 'Fill');
+  static const tree = IconData(0xe6da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-evergreen-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tree-evergreen-fill.svg)
-  static const treeEvergreen = PhosphorFlatIconData(0xe6dc, 'Fill');
+  static const treeEvergreen = IconData(0xe6dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-palm-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tree-palm-fill.svg)
-  static const treePalm = PhosphorFlatIconData(0xe91a, 'Fill');
+  static const treePalm = IconData(0xe91a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-structure-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tree-structure-fill.svg)
-  static const treeStructure = PhosphorFlatIconData(0xe67c, 'Fill');
+  static const treeStructure = IconData(0xe67c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-view-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tree-view-fill.svg)
-  static const treeView = PhosphorFlatIconData(0xee48, 'Fill');
+  static const treeView = IconData(0xee48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-down-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trend-down-fill.svg)
-  static const trendDown = PhosphorFlatIconData(0xe4ac, 'Fill');
+  static const trendDown = IconData(0xe4ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-up-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trend-up-fill.svg)
-  static const trendUp = PhosphorFlatIconData(0xe4ae, 'Fill');
+  static const trendUp = IconData(0xe4ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/triangle-fill.svg)
-  static const triangle = PhosphorFlatIconData(0xe4b0, 'Fill');
+  static const triangle = IconData(0xe4b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-dashed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/triangle-dashed-fill.svg)
-  static const triangleDashed = PhosphorFlatIconData(0xe4b2, 'Fill');
+  static const triangleDashed = IconData(0xe4b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trolley-fill.svg)
-  static const trolley = PhosphorFlatIconData(0xe5b2, 'Fill');
+  static const trolley = IconData(0xe5b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-suitcase-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trolley-suitcase-fill.svg)
-  static const trolleySuitcase = PhosphorFlatIconData(0xe5b4, 'Fill');
+  static const trolleySuitcase = IconData(0xe5b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trophy-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/trophy-fill.svg)
-  static const trophy = PhosphorFlatIconData(0xe67e, 'Fill');
+  static const trophy = IconData(0xe67e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/truck-fill.svg)
-  static const truck = PhosphorFlatIconData(0xe4b4, 'Fill');
+  static const truck = IconData(0xe4b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-trailer-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/truck-trailer-fill.svg)
-  static const truckTrailer = PhosphorFlatIconData(0xe4b6, 'Fill');
+  static const truckTrailer = IconData(0xe4b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tumblr-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/tumblr-logo-fill.svg)
-  static const tumblrLogo = PhosphorFlatIconData(0xe8d4, 'Fill');
+  static const tumblrLogo = IconData(0xe8d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitch-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/twitch-logo-fill.svg)
-  static const twitchLogo = PhosphorFlatIconData(0xe5ce, 'Fill');
+  static const twitchLogo = IconData(0xe5ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitter-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/twitter-logo-fill.svg)
-  static const twitterLogo = PhosphorFlatIconData(0xe4ba, 'Fill');
+  static const twitterLogo = IconData(0xe4ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/umbrella-fill.svg)
-  static const umbrella = PhosphorFlatIconData(0xe684, 'Fill');
+  static const umbrella = IconData(0xe684,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/umbrella-simple-fill.svg)
-  static const umbrellaSimple = PhosphorFlatIconData(0xe686, 'Fill');
+  static const umbrellaSimple = IconData(0xe686,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![union-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/union-fill.svg)
-  static const union = PhosphorFlatIconData(0xedbe, 'Fill');
+  static const union = IconData(0xedbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/unite-fill.svg)
-  static const unite = PhosphorFlatIconData(0xe87e, 'Fill');
+  static const unite = IconData(0xe87e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/unite-square-fill.svg)
-  static const uniteSquare = PhosphorFlatIconData(0xe878, 'Fill');
+  static const uniteSquare = IconData(0xe878,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/upload-fill.svg)
-  static const upload = PhosphorFlatIconData(0xe4be, 'Fill');
+  static const upload = IconData(0xe4be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-simple-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/upload-simple-fill.svg)
-  static const uploadSimple = PhosphorFlatIconData(0xe4c0, 'Fill');
+  static const uploadSimple = IconData(0xe4c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![usb-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/usb-fill.svg)
-  static const usb = PhosphorFlatIconData(0xe956, 'Fill');
+  static const usb = IconData(0xe956,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-fill.svg)
-  static const user = PhosphorFlatIconData(0xe4c2, 'Fill');
+  static const user = IconData(0xe4c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-check-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-check-fill.svg)
-  static const userCheck = PhosphorFlatIconData(0xeafa, 'Fill');
+  static const userCheck = IconData(0xeafa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-circle-fill.svg)
-  static const userCircle = PhosphorFlatIconData(0xe4c4, 'Fill');
+  static const userCircle = IconData(0xe4c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-check-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-circle-check-fill.svg)
-  static const userCircleCheck = PhosphorFlatIconData(0xec38, 'Fill');
+  static const userCircleCheck = IconData(0xec38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-dashed-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-circle-dashed-fill.svg)
-  static const userCircleDashed = PhosphorFlatIconData(0xec36, 'Fill');
+  static const userCircleDashed = IconData(0xec36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-gear-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-circle-gear-fill.svg)
-  static const userCircleGear = PhosphorFlatIconData(0xe4c6, 'Fill');
+  static const userCircleGear = IconData(0xe4c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-circle-minus-fill.svg)
-  static const userCircleMinus = PhosphorFlatIconData(0xe4c8, 'Fill');
+  static const userCircleMinus = IconData(0xe4c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-circle-plus-fill.svg)
-  static const userCirclePlus = PhosphorFlatIconData(0xe4ca, 'Fill');
+  static const userCirclePlus = IconData(0xe4ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-focus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-focus-fill.svg)
-  static const userFocus = PhosphorFlatIconData(0xe6fc, 'Fill');
+  static const userFocus = IconData(0xe6fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-gear-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-gear-fill.svg)
-  static const userGear = PhosphorFlatIconData(0xe4cc, 'Fill');
+  static const userGear = IconData(0xe4cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-list-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-list-fill.svg)
-  static const userList = PhosphorFlatIconData(0xe73c, 'Fill');
+  static const userList = IconData(0xe73c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-minus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-minus-fill.svg)
-  static const userMinus = PhosphorFlatIconData(0xe4ce, 'Fill');
+  static const userMinus = IconData(0xe4ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-plus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-plus-fill.svg)
-  static const userPlus = PhosphorFlatIconData(0xe4d0, 'Fill');
+  static const userPlus = IconData(0xe4d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-rectangle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-rectangle-fill.svg)
-  static const userRectangle = PhosphorFlatIconData(0xe4d2, 'Fill');
+  static const userRectangle = IconData(0xe4d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-sound-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-sound-fill.svg)
-  static const userSound = PhosphorFlatIconData(0xeca8, 'Fill');
+  static const userSound = IconData(0xeca8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-square-fill.svg)
-  static const userSquare = PhosphorFlatIconData(0xe4d4, 'Fill');
+  static const userSquare = IconData(0xe4d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-switch-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/user-switch-fill.svg)
-  static const userSwitch = PhosphorFlatIconData(0xe756, 'Fill');
+  static const userSwitch = IconData(0xe756,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/users-fill.svg)
-  static const users = PhosphorFlatIconData(0xe4d6, 'Fill');
+  static const users = IconData(0xe4d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-four-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/users-four-fill.svg)
-  static const usersFour = PhosphorFlatIconData(0xe68c, 'Fill');
+  static const usersFour = IconData(0xe68c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/users-three-fill.svg)
-  static const usersThree = PhosphorFlatIconData(0xe68e, 'Fill');
+  static const usersThree = IconData(0xe68e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![van-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/van-fill.svg)
-  static const van = PhosphorFlatIconData(0xe826, 'Fill');
+  static const van = IconData(0xe826,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vault-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/vault-fill.svg)
-  static const vault = PhosphorFlatIconData(0xe76e, 'Fill');
+  static const vault = IconData(0xe76e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-three-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/vector-three-fill.svg)
-  static const vectorThree = PhosphorFlatIconData(0xee62, 'Fill');
+  static const vectorThree = IconData(0xee62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-two-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/vector-two-fill.svg)
-  static const vectorTwo = PhosphorFlatIconData(0xee64, 'Fill');
+  static const vectorTwo = IconData(0xee64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vibrate-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/vibrate-fill.svg)
-  static const vibrate = PhosphorFlatIconData(0xe4d8, 'Fill');
+  static const vibrate = IconData(0xe4d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/video-fill.svg)
-  static const video = PhosphorFlatIconData(0xe740, 'Fill');
+  static const video = IconData(0xe740,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/video-camera-fill.svg)
-  static const videoCamera = PhosphorFlatIconData(0xe4da, 'Fill');
+  static const videoCamera = IconData(0xe4da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/video-camera-slash-fill.svg)
-  static const videoCameraSlash = PhosphorFlatIconData(0xe4dc, 'Fill');
+  static const videoCameraSlash = IconData(0xe4dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-conference-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/video-conference-fill.svg)
-  static const videoConference = PhosphorFlatIconData(0xedce, 'Fill');
+  static const videoConference = IconData(0xedce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vignette-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/vignette-fill.svg)
-  static const vignette = PhosphorFlatIconData(0xeba2, 'Fill');
+  static const vignette = IconData(0xeba2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vinyl-record-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/vinyl-record-fill.svg)
-  static const vinylRecord = PhosphorFlatIconData(0xecac, 'Fill');
+  static const vinylRecord = IconData(0xecac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virtual-reality-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/virtual-reality-fill.svg)
-  static const virtualReality = PhosphorFlatIconData(0xe7b8, 'Fill');
+  static const virtualReality = IconData(0xe7b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virus-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/virus-fill.svg)
-  static const virus = PhosphorFlatIconData(0xe7d6, 'Fill');
+  static const virus = IconData(0xe7d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![visor-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/visor-fill.svg)
-  static const visor = PhosphorFlatIconData(0xee2a, 'Fill');
+  static const visor = IconData(0xee2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![voicemail-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/voicemail-fill.svg)
-  static const voicemail = PhosphorFlatIconData(0xe4de, 'Fill');
+  static const voicemail = IconData(0xe4de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![volleyball-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/volleyball-fill.svg)
-  static const volleyball = PhosphorFlatIconData(0xe726, 'Fill');
+  static const volleyball = IconData(0xe726,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wall-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wall-fill.svg)
-  static const wall = PhosphorFlatIconData(0xe688, 'Fill');
+  static const wall = IconData(0xe688,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wallet-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wallet-fill.svg)
-  static const wallet = PhosphorFlatIconData(0xe68a, 'Fill');
+  static const wallet = IconData(0xe68a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warehouse-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/warehouse-fill.svg)
-  static const warehouse = PhosphorFlatIconData(0xecd4, 'Fill');
+  static const warehouse = IconData(0xecd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/warning-fill.svg)
-  static const warning = PhosphorFlatIconData(0xe4e0, 'Fill');
+  static const warning = IconData(0xe4e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/warning-circle-fill.svg)
-  static const warningCircle = PhosphorFlatIconData(0xe4e2, 'Fill');
+  static const warningCircle = IconData(0xe4e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-diamond-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/warning-diamond-fill.svg)
-  static const warningDiamond = PhosphorFlatIconData(0xe7fc, 'Fill');
+  static const warningDiamond = IconData(0xe7fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-octagon-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/warning-octagon-fill.svg)
-  static const warningOctagon = PhosphorFlatIconData(0xe4e4, 'Fill');
+  static const warningOctagon = IconData(0xe4e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![washing-machine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/washing-machine-fill.svg)
-  static const washingMachine = PhosphorFlatIconData(0xede8, 'Fill');
+  static const washingMachine = IconData(0xede8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![watch-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/watch-fill.svg)
-  static const watch = PhosphorFlatIconData(0xe4e6, 'Fill');
+  static const watch = IconData(0xe4e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sawtooth-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wave-sawtooth-fill.svg)
-  static const waveSawtooth = PhosphorFlatIconData(0xea9c, 'Fill');
+  static const waveSawtooth = IconData(0xea9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wave-sine-fill.svg)
-  static const waveSine = PhosphorFlatIconData(0xea9a, 'Fill');
+  static const waveSine = IconData(0xea9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wave-square-fill.svg)
-  static const waveSquare = PhosphorFlatIconData(0xea9e, 'Fill');
+  static const waveSquare = IconData(0xea9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-triangle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wave-triangle-fill.svg)
-  static const waveTriangle = PhosphorFlatIconData(0xeaa0, 'Fill');
+  static const waveTriangle = IconData(0xeaa0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/waveform-fill.svg)
-  static const waveform = PhosphorFlatIconData(0xe802, 'Fill');
+  static const waveform = IconData(0xe802,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/waveform-slash-fill.svg)
-  static const waveformSlash = PhosphorFlatIconData(0xe800, 'Fill');
+  static const waveformSlash = IconData(0xe800,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waves-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/waves-fill.svg)
-  static const waves = PhosphorFlatIconData(0xe6de, 'Fill');
+  static const waves = IconData(0xe6de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/webcam-fill.svg)
-  static const webcam = PhosphorFlatIconData(0xe9b2, 'Fill');
+  static const webcam = IconData(0xe9b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/webcam-slash-fill.svg)
-  static const webcamSlash = PhosphorFlatIconData(0xecdc, 'Fill');
+  static const webcamSlash = IconData(0xecdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webhooks-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/webhooks-logo-fill.svg)
-  static const webhooksLogo = PhosphorFlatIconData(0xecae, 'Fill');
+  static const webhooksLogo = IconData(0xecae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wechat-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wechat-logo-fill.svg)
-  static const wechatLogo = PhosphorFlatIconData(0xe8d2, 'Fill');
+  static const wechatLogo = IconData(0xe8d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![whatsapp-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/whatsapp-logo-fill.svg)
-  static const whatsappLogo = PhosphorFlatIconData(0xe5d0, 'Fill');
+  static const whatsappLogo = IconData(0xe5d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wheelchair-fill.svg)
-  static const wheelchair = PhosphorFlatIconData(0xe4e8, 'Fill');
+  static const wheelchair = IconData(0xe4e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-motion-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wheelchair-motion-fill.svg)
-  static const wheelchairMotion = PhosphorFlatIconData(0xe89a, 'Fill');
+  static const wheelchairMotion = IconData(0xe89a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-high-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wifi-high-fill.svg)
-  static const wifiHigh = PhosphorFlatIconData(0xe4ea, 'Fill');
+  static const wifiHigh = IconData(0xe4ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-low-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wifi-low-fill.svg)
-  static const wifiLow = PhosphorFlatIconData(0xe4ec, 'Fill');
+  static const wifiLow = IconData(0xe4ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-medium-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wifi-medium-fill.svg)
-  static const wifiMedium = PhosphorFlatIconData(0xe4ee, 'Fill');
+  static const wifiMedium = IconData(0xe4ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-none-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wifi-none-fill.svg)
-  static const wifiNone = PhosphorFlatIconData(0xe4f0, 'Fill');
+  static const wifiNone = IconData(0xe4f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-slash-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wifi-slash-fill.svg)
-  static const wifiSlash = PhosphorFlatIconData(0xe4f2, 'Fill');
+  static const wifiSlash = IconData(0xe4f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wifi-x-fill.svg)
-  static const wifiX = PhosphorFlatIconData(0xe4f4, 'Fill');
+  static const wifiX = IconData(0xe4f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wind-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wind-fill.svg)
-  static const wind = PhosphorFlatIconData(0xe5d2, 'Fill');
+  static const wind = IconData(0xe5d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windmill-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/windmill-fill.svg)
-  static const windmill = PhosphorFlatIconData(0xe9f8, 'Fill');
+  static const windmill = IconData(0xe9f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windows-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/windows-logo-fill.svg)
-  static const windowsLogo = PhosphorFlatIconData(0xe692, 'Fill');
+  static const windowsLogo = IconData(0xe692,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wine-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wine-fill.svg)
-  static const wine = PhosphorFlatIconData(0xe6b2, 'Fill');
+  static const wine = IconData(0xe6b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wrench-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/wrench-fill.svg)
-  static const wrench = PhosphorFlatIconData(0xe5d4, 'Fill');
+  static const wrench = IconData(0xe5d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/x-fill.svg)
-  static const x = PhosphorFlatIconData(0xe4f6, 'Fill');
+  static const x = IconData(0xe4f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-circle-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/x-circle-fill.svg)
-  static const xCircle = PhosphorFlatIconData(0xe4f8, 'Fill');
+  static const xCircle = IconData(0xe4f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/x-logo-fill.svg)
-  static const xLogo = PhosphorFlatIconData(0xe4bc, 'Fill');
+  static const xLogo = IconData(0xe4bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-square-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/x-square-fill.svg)
-  static const xSquare = PhosphorFlatIconData(0xe4fa, 'Fill');
+  static const xSquare = IconData(0xe4fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yarn-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/yarn-fill.svg)
-  static const yarn = PhosphorFlatIconData(0xed9a, 'Fill');
+  static const yarn = IconData(0xed9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yin-yang-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/yin-yang-fill.svg)
-  static const yinYang = PhosphorFlatIconData(0xe92a, 'Fill');
+  static const yinYang = IconData(0xe92a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![youtube-logo-fill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/fill/youtube-logo-fill.svg)
-  static const youtubeLogo = PhosphorFlatIconData(0xe4fc, 'Fill');
+  static const youtubeLogo = IconData(0xe4fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 }

--- a/lib/src/phosphor_icons_light.dart
+++ b/lib/src/phosphor_icons_light.dart
@@ -1,4549 +1,6060 @@
 // Auto generated File
 // DON'T EDIT BY HAND
 
-import 'package:phosphor_flutter/src/phosphor_icon_data.dart';
 import 'package:flutter/widgets.dart';
+
+const String _f = 'PhosphorLight';
+const String _p = 'phosphor_flutter';
 
 @staticIconProvider
 class PhosphorIconsLight {
   const PhosphorIconsLight();
 
   /// ![acorn-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/acorn-light.svg)
-  static const acorn = PhosphorFlatIconData(0xeb9a, 'Light');
+  static const acorn = IconData(0xeb9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/address-book-light.svg)
-  static const addressBook = PhosphorFlatIconData(0xe6f8, 'Light');
+  static const addressBook = IconData(0xe6f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-tabs-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/address-book-tabs-light.svg)
-  static const addressBookTabs = PhosphorFlatIconData(0xee4e, 'Light');
+  static const addressBookTabs = IconData(0xee4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![air-traffic-control-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/air-traffic-control-light.svg)
-  static const airTrafficControl = PhosphorFlatIconData(0xecd8, 'Light');
+  static const airTrafficControl = IconData(0xecd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/airplane-light.svg)
-  static const airplane = PhosphorFlatIconData(0xe002, 'Light');
+  static const airplane = IconData(0xe002,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-in-flight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/airplane-in-flight-light.svg)
-  static const airplaneInFlight = PhosphorFlatIconData(0xe4fe, 'Light');
+  static const airplaneInFlight = IconData(0xe4fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-landing-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/airplane-landing-light.svg)
-  static const airplaneLanding = PhosphorFlatIconData(0xe502, 'Light');
+  static const airplaneLanding = IconData(0xe502,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-takeoff-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/airplane-takeoff-light.svg)
-  static const airplaneTakeoff = PhosphorFlatIconData(0xe504, 'Light');
+  static const airplaneTakeoff = IconData(0xe504,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-taxiing-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/airplane-taxiing-light.svg)
-  static const airplaneTaxiing = PhosphorFlatIconData(0xe500, 'Light');
+  static const airplaneTaxiing = IconData(0xe500,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-tilt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/airplane-tilt-light.svg)
-  static const airplaneTilt = PhosphorFlatIconData(0xe5d6, 'Light');
+  static const airplaneTilt = IconData(0xe5d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplay-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/airplay-light.svg)
-  static const airplay = PhosphorFlatIconData(0xe004, 'Light');
+  static const airplay = IconData(0xe004,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alarm-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/alarm-light.svg)
-  static const alarm = PhosphorFlatIconData(0xe006, 'Light');
+  static const alarm = IconData(0xe006,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alien-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/alien-light.svg)
-  static const alien = PhosphorFlatIconData(0xe8a6, 'Light');
+  static const alien = IconData(0xe8a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-bottom-light.svg)
-  static const alignBottom = PhosphorFlatIconData(0xe506, 'Light');
+  static const alignBottom = IconData(0xe506,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-bottom-simple-light.svg)
-  static const alignBottomSimple = PhosphorFlatIconData(0xeb0c, 'Light');
+  static const alignBottomSimple = IconData(0xeb0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-center-horizontal-light.svg)
-  static const alignCenterHorizontal = PhosphorFlatIconData(0xe50a, 'Light');
+  static const alignCenterHorizontal = IconData(0xe50a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-center-horizontal-simple-light.svg)
-  static const alignCenterHorizontalSimple =
-      PhosphorFlatIconData(0xeb0e, 'Light');
+  static const alignCenterHorizontalSimple = IconData(0xeb0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-center-vertical-light.svg)
-  static const alignCenterVertical = PhosphorFlatIconData(0xe50c, 'Light');
+  static const alignCenterVertical = IconData(0xe50c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-center-vertical-simple-light.svg)
-  static const alignCenterVerticalSimple =
-      PhosphorFlatIconData(0xeb10, 'Light');
+  static const alignCenterVerticalSimple = IconData(0xeb10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-left-light.svg)
-  static const alignLeft = PhosphorFlatIconData(0xe50e, 'Light');
+  static const alignLeft = IconData(0xe50e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-left-simple-light.svg)
-  static const alignLeftSimple = PhosphorFlatIconData(0xeaee, 'Light');
+  static const alignLeftSimple = IconData(0xeaee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-right-light.svg)
-  static const alignRight = PhosphorFlatIconData(0xe510, 'Light');
+  static const alignRight = IconData(0xe510,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-right-simple-light.svg)
-  static const alignRightSimple = PhosphorFlatIconData(0xeb12, 'Light');
+  static const alignRightSimple = IconData(0xeb12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-top-light.svg)
-  static const alignTop = PhosphorFlatIconData(0xe512, 'Light');
+  static const alignTop = IconData(0xe512,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/align-top-simple-light.svg)
-  static const alignTopSimple = PhosphorFlatIconData(0xeb14, 'Light');
+  static const alignTopSimple = IconData(0xeb14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![amazon-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/amazon-logo-light.svg)
-  static const amazonLogo = PhosphorFlatIconData(0xe96c, 'Light');
+  static const amazonLogo = IconData(0xe96c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ambulance-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ambulance-light.svg)
-  static const ambulance = PhosphorFlatIconData(0xe572, 'Light');
+  static const ambulance = IconData(0xe572,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/anchor-light.svg)
-  static const anchor = PhosphorFlatIconData(0xe514, 'Light');
+  static const anchor = IconData(0xe514,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/anchor-simple-light.svg)
-  static const anchorSimple = PhosphorFlatIconData(0xe5d8, 'Light');
+  static const anchorSimple = IconData(0xe5d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![android-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/android-logo-light.svg)
-  static const androidLogo = PhosphorFlatIconData(0xe008, 'Light');
+  static const androidLogo = IconData(0xe008,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/angle-light.svg)
-  static const angle = PhosphorFlatIconData(0xe7bc, 'Light');
+  static const angle = IconData(0xe7bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angular-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/angular-logo-light.svg)
-  static const angularLogo = PhosphorFlatIconData(0xeb80, 'Light');
+  static const angularLogo = IconData(0xeb80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![aperture-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/aperture-light.svg)
-  static const aperture = PhosphorFlatIconData(0xe00a, 'Light');
+  static const aperture = IconData(0xe00a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-store-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/app-store-logo-light.svg)
-  static const appStoreLogo = PhosphorFlatIconData(0xe974, 'Light');
+  static const appStoreLogo = IconData(0xe974,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-window-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/app-window-light.svg)
-  static const appWindow = PhosphorFlatIconData(0xe5da, 'Light');
+  static const appWindow = IconData(0xe5da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/apple-logo-light.svg)
-  static const appleLogo = PhosphorFlatIconData(0xe516, 'Light');
+  static const appleLogo = IconData(0xe516,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-podcasts-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/apple-podcasts-logo-light.svg)
-  static const applePodcastsLogo = PhosphorFlatIconData(0xeb96, 'Light');
+  static const applePodcastsLogo = IconData(0xeb96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![approximate-equals-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/approximate-equals-light.svg)
-  static const approximateEquals = PhosphorFlatIconData(0xedaa, 'Light');
+  static const approximateEquals = IconData(0xedaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![archive-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/archive-light.svg)
-  static const archive = PhosphorFlatIconData(0xe00c, 'Light');
+  static const archive = IconData(0xe00c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![armchair-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/armchair-light.svg)
-  static const armchair = PhosphorFlatIconData(0xe012, 'Light');
+  static const armchair = IconData(0xe012,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-arc-left-light.svg)
-  static const arrowArcLeft = PhosphorFlatIconData(0xe014, 'Light');
+  static const arrowArcLeft = IconData(0xe014,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-arc-right-light.svg)
-  static const arrowArcRight = PhosphorFlatIconData(0xe016, 'Light');
+  static const arrowArcRight = IconData(0xe016,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-double-up-left-light.svg)
-  static const arrowBendDoubleUpLeft = PhosphorFlatIconData(0xe03a, 'Light');
+  static const arrowBendDoubleUpLeft = IconData(0xe03a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-double-up-right-light.svg)
-  static const arrowBendDoubleUpRight = PhosphorFlatIconData(0xe03c, 'Light');
+  static const arrowBendDoubleUpRight = IconData(0xe03c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-down-left-light.svg)
-  static const arrowBendDownLeft = PhosphorFlatIconData(0xe018, 'Light');
+  static const arrowBendDownLeft = IconData(0xe018,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-down-right-light.svg)
-  static const arrowBendDownRight = PhosphorFlatIconData(0xe01a, 'Light');
+  static const arrowBendDownRight = IconData(0xe01a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-left-down-light.svg)
-  static const arrowBendLeftDown = PhosphorFlatIconData(0xe01c, 'Light');
+  static const arrowBendLeftDown = IconData(0xe01c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-left-up-light.svg)
-  static const arrowBendLeftUp = PhosphorFlatIconData(0xe01e, 'Light');
+  static const arrowBendLeftUp = IconData(0xe01e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-right-down-light.svg)
-  static const arrowBendRightDown = PhosphorFlatIconData(0xe020, 'Light');
+  static const arrowBendRightDown = IconData(0xe020,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-right-up-light.svg)
-  static const arrowBendRightUp = PhosphorFlatIconData(0xe022, 'Light');
+  static const arrowBendRightUp = IconData(0xe022,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-up-left-light.svg)
-  static const arrowBendUpLeft = PhosphorFlatIconData(0xe024, 'Light');
+  static const arrowBendUpLeft = IconData(0xe024,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-bend-up-right-light.svg)
-  static const arrowBendUpRight = PhosphorFlatIconData(0xe026, 'Light');
+  static const arrowBendUpRight = IconData(0xe026,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-circle-down-light.svg)
-  static const arrowCircleDown = PhosphorFlatIconData(0xe028, 'Light');
+  static const arrowCircleDown = IconData(0xe028,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-circle-down-left-light.svg)
-  static const arrowCircleDownLeft = PhosphorFlatIconData(0xe02a, 'Light');
+  static const arrowCircleDownLeft = IconData(0xe02a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-circle-down-right-light.svg)
-  static const arrowCircleDownRight = PhosphorFlatIconData(0xe02c, 'Light');
+  static const arrowCircleDownRight = IconData(0xe02c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-circle-left-light.svg)
-  static const arrowCircleLeft = PhosphorFlatIconData(0xe05a, 'Light');
+  static const arrowCircleLeft = IconData(0xe05a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-circle-right-light.svg)
-  static const arrowCircleRight = PhosphorFlatIconData(0xe02e, 'Light');
+  static const arrowCircleRight = IconData(0xe02e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-circle-up-light.svg)
-  static const arrowCircleUp = PhosphorFlatIconData(0xe030, 'Light');
+  static const arrowCircleUp = IconData(0xe030,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-circle-up-left-light.svg)
-  static const arrowCircleUpLeft = PhosphorFlatIconData(0xe032, 'Light');
+  static const arrowCircleUpLeft = IconData(0xe032,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-circle-up-right-light.svg)
-  static const arrowCircleUpRight = PhosphorFlatIconData(0xe034, 'Light');
+  static const arrowCircleUpRight = IconData(0xe034,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-clockwise-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-clockwise-light.svg)
-  static const arrowClockwise = PhosphorFlatIconData(0xe036, 'Light');
+  static const arrowClockwise = IconData(0xe036,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-counter-clockwise-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-counter-clockwise-light.svg)
-  static const arrowCounterClockwise = PhosphorFlatIconData(0xe038, 'Light');
+  static const arrowCounterClockwise = IconData(0xe038,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-down-light.svg)
-  static const arrowDown = PhosphorFlatIconData(0xe03e, 'Light');
+  static const arrowDown = IconData(0xe03e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-down-left-light.svg)
-  static const arrowDownLeft = PhosphorFlatIconData(0xe040, 'Light');
+  static const arrowDownLeft = IconData(0xe040,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-down-right-light.svg)
-  static const arrowDownRight = PhosphorFlatIconData(0xe042, 'Light');
+  static const arrowDownRight = IconData(0xe042,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-down-left-light.svg)
-  static const arrowElbowDownLeft = PhosphorFlatIconData(0xe044, 'Light');
+  static const arrowElbowDownLeft = IconData(0xe044,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-down-right-light.svg)
-  static const arrowElbowDownRight = PhosphorFlatIconData(0xe046, 'Light');
+  static const arrowElbowDownRight = IconData(0xe046,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-left-light.svg)
-  static const arrowElbowLeft = PhosphorFlatIconData(0xe048, 'Light');
+  static const arrowElbowLeft = IconData(0xe048,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-left-down-light.svg)
-  static const arrowElbowLeftDown = PhosphorFlatIconData(0xe04a, 'Light');
+  static const arrowElbowLeftDown = IconData(0xe04a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-left-up-light.svg)
-  static const arrowElbowLeftUp = PhosphorFlatIconData(0xe04c, 'Light');
+  static const arrowElbowLeftUp = IconData(0xe04c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-right-light.svg)
-  static const arrowElbowRight = PhosphorFlatIconData(0xe04e, 'Light');
+  static const arrowElbowRight = IconData(0xe04e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-right-down-light.svg)
-  static const arrowElbowRightDown = PhosphorFlatIconData(0xe050, 'Light');
+  static const arrowElbowRightDown = IconData(0xe050,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-right-up-light.svg)
-  static const arrowElbowRightUp = PhosphorFlatIconData(0xe052, 'Light');
+  static const arrowElbowRightUp = IconData(0xe052,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-up-left-light.svg)
-  static const arrowElbowUpLeft = PhosphorFlatIconData(0xe054, 'Light');
+  static const arrowElbowUpLeft = IconData(0xe054,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-elbow-up-right-light.svg)
-  static const arrowElbowUpRight = PhosphorFlatIconData(0xe056, 'Light');
+  static const arrowElbowUpRight = IconData(0xe056,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-down-light.svg)
-  static const arrowFatDown = PhosphorFlatIconData(0xe518, 'Light');
+  static const arrowFatDown = IconData(0xe518,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-left-light.svg)
-  static const arrowFatLeft = PhosphorFlatIconData(0xe51a, 'Light');
+  static const arrowFatLeft = IconData(0xe51a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-line-down-light.svg)
-  static const arrowFatLineDown = PhosphorFlatIconData(0xe51c, 'Light');
+  static const arrowFatLineDown = IconData(0xe51c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-line-left-light.svg)
-  static const arrowFatLineLeft = PhosphorFlatIconData(0xe51e, 'Light');
+  static const arrowFatLineLeft = IconData(0xe51e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-line-right-light.svg)
-  static const arrowFatLineRight = PhosphorFlatIconData(0xe520, 'Light');
+  static const arrowFatLineRight = IconData(0xe520,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-line-up-light.svg)
-  static const arrowFatLineUp = PhosphorFlatIconData(0xe522, 'Light');
+  static const arrowFatLineUp = IconData(0xe522,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-lines-down-light.svg)
-  static const arrowFatLinesDown = PhosphorFlatIconData(0xe524, 'Light');
+  static const arrowFatLinesDown = IconData(0xe524,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-lines-left-light.svg)
-  static const arrowFatLinesLeft = PhosphorFlatIconData(0xe526, 'Light');
+  static const arrowFatLinesLeft = IconData(0xe526,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-lines-right-light.svg)
-  static const arrowFatLinesRight = PhosphorFlatIconData(0xe528, 'Light');
+  static const arrowFatLinesRight = IconData(0xe528,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-lines-up-light.svg)
-  static const arrowFatLinesUp = PhosphorFlatIconData(0xe52a, 'Light');
+  static const arrowFatLinesUp = IconData(0xe52a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-right-light.svg)
-  static const arrowFatRight = PhosphorFlatIconData(0xe52c, 'Light');
+  static const arrowFatRight = IconData(0xe52c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-fat-up-light.svg)
-  static const arrowFatUp = PhosphorFlatIconData(0xe52e, 'Light');
+  static const arrowFatUp = IconData(0xe52e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-left-light.svg)
-  static const arrowLeft = PhosphorFlatIconData(0xe058, 'Light');
+  static const arrowLeft = IconData(0xe058,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-line-down-light.svg)
-  static const arrowLineDown = PhosphorFlatIconData(0xe05c, 'Light');
+  static const arrowLineDown = IconData(0xe05c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-line-down-left-light.svg)
-  static const arrowLineDownLeft = PhosphorFlatIconData(0xe05e, 'Light');
+  static const arrowLineDownLeft = IconData(0xe05e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-line-down-right-light.svg)
-  static const arrowLineDownRight = PhosphorFlatIconData(0xe060, 'Light');
+  static const arrowLineDownRight = IconData(0xe060,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-line-left-light.svg)
-  static const arrowLineLeft = PhosphorFlatIconData(0xe062, 'Light');
+  static const arrowLineLeft = IconData(0xe062,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-line-right-light.svg)
-  static const arrowLineRight = PhosphorFlatIconData(0xe064, 'Light');
+  static const arrowLineRight = IconData(0xe064,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-line-up-light.svg)
-  static const arrowLineUp = PhosphorFlatIconData(0xe066, 'Light');
+  static const arrowLineUp = IconData(0xe066,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-line-up-left-light.svg)
-  static const arrowLineUpLeft = PhosphorFlatIconData(0xe068, 'Light');
+  static const arrowLineUpLeft = IconData(0xe068,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-line-up-right-light.svg)
-  static const arrowLineUpRight = PhosphorFlatIconData(0xe06a, 'Light');
+  static const arrowLineUpRight = IconData(0xe06a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-right-light.svg)
-  static const arrowRight = PhosphorFlatIconData(0xe06c, 'Light');
+  static const arrowRight = IconData(0xe06c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-down-light.svg)
-  static const arrowSquareDown = PhosphorFlatIconData(0xe06e, 'Light');
+  static const arrowSquareDown = IconData(0xe06e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-down-left-light.svg)
-  static const arrowSquareDownLeft = PhosphorFlatIconData(0xe070, 'Light');
+  static const arrowSquareDownLeft = IconData(0xe070,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-down-right-light.svg)
-  static const arrowSquareDownRight = PhosphorFlatIconData(0xe072, 'Light');
+  static const arrowSquareDownRight = IconData(0xe072,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-in-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-in-light.svg)
-  static const arrowSquareIn = PhosphorFlatIconData(0xe5dc, 'Light');
+  static const arrowSquareIn = IconData(0xe5dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-left-light.svg)
-  static const arrowSquareLeft = PhosphorFlatIconData(0xe074, 'Light');
+  static const arrowSquareLeft = IconData(0xe074,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-out-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-out-light.svg)
-  static const arrowSquareOut = PhosphorFlatIconData(0xe5de, 'Light');
+  static const arrowSquareOut = IconData(0xe5de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-right-light.svg)
-  static const arrowSquareRight = PhosphorFlatIconData(0xe076, 'Light');
+  static const arrowSquareRight = IconData(0xe076,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-up-light.svg)
-  static const arrowSquareUp = PhosphorFlatIconData(0xe078, 'Light');
+  static const arrowSquareUp = IconData(0xe078,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-up-left-light.svg)
-  static const arrowSquareUpLeft = PhosphorFlatIconData(0xe07a, 'Light');
+  static const arrowSquareUpLeft = IconData(0xe07a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-square-up-right-light.svg)
-  static const arrowSquareUpRight = PhosphorFlatIconData(0xe07c, 'Light');
+  static const arrowSquareUpRight = IconData(0xe07c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-u-down-left-light.svg)
-  static const arrowUDownLeft = PhosphorFlatIconData(0xe07e, 'Light');
+  static const arrowUDownLeft = IconData(0xe07e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-u-down-right-light.svg)
-  static const arrowUDownRight = PhosphorFlatIconData(0xe080, 'Light');
+  static const arrowUDownRight = IconData(0xe080,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-u-left-down-light.svg)
-  static const arrowULeftDown = PhosphorFlatIconData(0xe082, 'Light');
+  static const arrowULeftDown = IconData(0xe082,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-u-left-up-light.svg)
-  static const arrowULeftUp = PhosphorFlatIconData(0xe084, 'Light');
+  static const arrowULeftUp = IconData(0xe084,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-u-right-down-light.svg)
-  static const arrowURightDown = PhosphorFlatIconData(0xe086, 'Light');
+  static const arrowURightDown = IconData(0xe086,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-u-right-up-light.svg)
-  static const arrowURightUp = PhosphorFlatIconData(0xe088, 'Light');
+  static const arrowURightUp = IconData(0xe088,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-u-up-left-light.svg)
-  static const arrowUUpLeft = PhosphorFlatIconData(0xe08a, 'Light');
+  static const arrowUUpLeft = IconData(0xe08a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-u-up-right-light.svg)
-  static const arrowUUpRight = PhosphorFlatIconData(0xe08c, 'Light');
+  static const arrowUUpRight = IconData(0xe08c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-up-light.svg)
-  static const arrowUp = PhosphorFlatIconData(0xe08e, 'Light');
+  static const arrowUp = IconData(0xe08e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-up-left-light.svg)
-  static const arrowUpLeft = PhosphorFlatIconData(0xe090, 'Light');
+  static const arrowUpLeft = IconData(0xe090,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrow-up-right-light.svg)
-  static const arrowUpRight = PhosphorFlatIconData(0xe092, 'Light');
+  static const arrowUpRight = IconData(0xe092,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-clockwise-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-clockwise-light.svg)
-  static const arrowsClockwise = PhosphorFlatIconData(0xe094, 'Light');
+  static const arrowsClockwise = IconData(0xe094,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-counter-clockwise-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-counter-clockwise-light.svg)
-  static const arrowsCounterClockwise = PhosphorFlatIconData(0xe096, 'Light');
+  static const arrowsCounterClockwise = IconData(0xe096,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-down-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-down-up-light.svg)
-  static const arrowsDownUp = PhosphorFlatIconData(0xe098, 'Light');
+  static const arrowsDownUp = IconData(0xe098,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-horizontal-light.svg)
-  static const arrowsHorizontal = PhosphorFlatIconData(0xeb06, 'Light');
+  static const arrowsHorizontal = IconData(0xeb06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-in-light.svg)
-  static const arrowsIn = PhosphorFlatIconData(0xe09a, 'Light');
+  static const arrowsIn = IconData(0xe09a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-cardinal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-in-cardinal-light.svg)
-  static const arrowsInCardinal = PhosphorFlatIconData(0xe09c, 'Light');
+  static const arrowsInCardinal = IconData(0xe09c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-in-line-horizontal-light.svg)
-  static const arrowsInLineHorizontal = PhosphorFlatIconData(0xe530, 'Light');
+  static const arrowsInLineHorizontal = IconData(0xe530,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-in-line-vertical-light.svg)
-  static const arrowsInLineVertical = PhosphorFlatIconData(0xe532, 'Light');
+  static const arrowsInLineVertical = IconData(0xe532,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-in-simple-light.svg)
-  static const arrowsInSimple = PhosphorFlatIconData(0xe09e, 'Light');
+  static const arrowsInSimple = IconData(0xe09e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-left-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-left-right-light.svg)
-  static const arrowsLeftRight = PhosphorFlatIconData(0xe0a0, 'Light');
+  static const arrowsLeftRight = IconData(0xe0a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-merge-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-merge-light.svg)
-  static const arrowsMerge = PhosphorFlatIconData(0xed3e, 'Light');
+  static const arrowsMerge = IconData(0xed3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-out-light.svg)
-  static const arrowsOut = PhosphorFlatIconData(0xe0a2, 'Light');
+  static const arrowsOut = IconData(0xe0a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-cardinal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-out-cardinal-light.svg)
-  static const arrowsOutCardinal = PhosphorFlatIconData(0xe0a4, 'Light');
+  static const arrowsOutCardinal = IconData(0xe0a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-out-line-horizontal-light.svg)
-  static const arrowsOutLineHorizontal = PhosphorFlatIconData(0xe534, 'Light');
+  static const arrowsOutLineHorizontal = IconData(0xe534,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-out-line-vertical-light.svg)
-  static const arrowsOutLineVertical = PhosphorFlatIconData(0xe536, 'Light');
+  static const arrowsOutLineVertical = IconData(0xe536,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-out-simple-light.svg)
-  static const arrowsOutSimple = PhosphorFlatIconData(0xe0a6, 'Light');
+  static const arrowsOutSimple = IconData(0xe0a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-split-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-split-light.svg)
-  static const arrowsSplit = PhosphorFlatIconData(0xed3c, 'Light');
+  static const arrowsSplit = IconData(0xed3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/arrows-vertical-light.svg)
-  static const arrowsVertical = PhosphorFlatIconData(0xeb04, 'Light');
+  static const arrowsVertical = IconData(0xeb04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/article-light.svg)
-  static const article = PhosphorFlatIconData(0xe0a8, 'Light');
+  static const article = IconData(0xe0a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-medium-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/article-medium-light.svg)
-  static const articleMedium = PhosphorFlatIconData(0xe5e0, 'Light');
+  static const articleMedium = IconData(0xe5e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-ny-times-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/article-ny-times-light.svg)
-  static const articleNyTimes = PhosphorFlatIconData(0xe5e2, 'Light');
+  static const articleNyTimes = IconData(0xe5e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asclepius-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/asclepius-light.svg)
-  static const asclepius = PhosphorFlatIconData(0xee34, 'Light');
+  static const asclepius = IconData(0xee34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/asterisk-light.svg)
-  static const asterisk = PhosphorFlatIconData(0xe0aa, 'Light');
+  static const asterisk = IconData(0xe0aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/asterisk-simple-light.svg)
-  static const asteriskSimple = PhosphorFlatIconData(0xe832, 'Light');
+  static const asteriskSimple = IconData(0xe832,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![at-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/at-light.svg)
-  static const at = PhosphorFlatIconData(0xe0ac, 'Light');
+  static const at = IconData(0xe0ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![atom-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/atom-light.svg)
-  static const atom = PhosphorFlatIconData(0xe5e4, 'Light');
+  static const atom = IconData(0xe5e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![avocado-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/avocado-light.svg)
-  static const avocado = PhosphorFlatIconData(0xee04, 'Light');
+  static const avocado = IconData(0xee04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![axe-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/axe-light.svg)
-  static const axe = PhosphorFlatIconData(0xe9fc, 'Light');
+  static const axe = IconData(0xe9fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/baby-light.svg)
-  static const baby = PhosphorFlatIconData(0xe774, 'Light');
+  static const baby = IconData(0xe774,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-carriage-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/baby-carriage-light.svg)
-  static const babyCarriage = PhosphorFlatIconData(0xe818, 'Light');
+  static const babyCarriage = IconData(0xe818,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backpack-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/backpack-light.svg)
-  static const backpack = PhosphorFlatIconData(0xe922, 'Light');
+  static const backpack = IconData(0xe922,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backspace-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/backspace-light.svg)
-  static const backspace = PhosphorFlatIconData(0xe0ae, 'Light');
+  static const backspace = IconData(0xe0ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bag-light.svg)
-  static const bag = PhosphorFlatIconData(0xe0b0, 'Light');
+  static const bag = IconData(0xe0b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bag-simple-light.svg)
-  static const bagSimple = PhosphorFlatIconData(0xe5e6, 'Light');
+  static const bagSimple = IconData(0xe5e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![balloon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/balloon-light.svg)
-  static const balloon = PhosphorFlatIconData(0xe76c, 'Light');
+  static const balloon = IconData(0xe76c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bandaids-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bandaids-light.svg)
-  static const bandaids = PhosphorFlatIconData(0xe0b2, 'Light');
+  static const bandaids = IconData(0xe0b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bank-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bank-light.svg)
-  static const bank = PhosphorFlatIconData(0xe0b4, 'Light');
+  static const bank = IconData(0xe0b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barbell-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/barbell-light.svg)
-  static const barbell = PhosphorFlatIconData(0xe0b6, 'Light');
+  static const barbell = IconData(0xe0b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barcode-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/barcode-light.svg)
-  static const barcode = PhosphorFlatIconData(0xe0b8, 'Light');
+  static const barcode = IconData(0xe0b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barn-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/barn-light.svg)
-  static const barn = PhosphorFlatIconData(0xec72, 'Light');
+  static const barn = IconData(0xec72,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barricade-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/barricade-light.svg)
-  static const barricade = PhosphorFlatIconData(0xe948, 'Light');
+  static const barricade = IconData(0xe948,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/baseball-light.svg)
-  static const baseball = PhosphorFlatIconData(0xe71a, 'Light');
+  static const baseball = IconData(0xe71a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-cap-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/baseball-cap-light.svg)
-  static const baseballCap = PhosphorFlatIconData(0xea28, 'Light');
+  static const baseballCap = IconData(0xea28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-helmet-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/baseball-helmet-light.svg)
-  static const baseballHelmet = PhosphorFlatIconData(0xee4a, 'Light');
+  static const baseballHelmet = IconData(0xee4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basket-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/basket-light.svg)
-  static const basket = PhosphorFlatIconData(0xe964, 'Light');
+  static const basket = IconData(0xe964,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basketball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/basketball-light.svg)
-  static const basketball = PhosphorFlatIconData(0xe724, 'Light');
+  static const basketball = IconData(0xe724,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bathtub-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bathtub-light.svg)
-  static const bathtub = PhosphorFlatIconData(0xe81e, 'Light');
+  static const bathtub = IconData(0xe81e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-charging-light.svg)
-  static const batteryCharging = PhosphorFlatIconData(0xe0ba, 'Light');
+  static const batteryCharging = IconData(0xe0ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-charging-vertical-light.svg)
-  static const batteryChargingVertical = PhosphorFlatIconData(0xe0bc, 'Light');
+  static const batteryChargingVertical = IconData(0xe0bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-empty-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-empty-light.svg)
-  static const batteryEmpty = PhosphorFlatIconData(0xe0be, 'Light');
+  static const batteryEmpty = IconData(0xe0be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-full-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-full-light.svg)
-  static const batteryFull = PhosphorFlatIconData(0xe0c0, 'Light');
+  static const batteryFull = IconData(0xe0c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-high-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-high-light.svg)
-  static const batteryHigh = PhosphorFlatIconData(0xe0c2, 'Light');
+  static const batteryHigh = IconData(0xe0c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-low-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-low-light.svg)
-  static const batteryLow = PhosphorFlatIconData(0xe0c4, 'Light');
+  static const batteryLow = IconData(0xe0c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-medium-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-medium-light.svg)
-  static const batteryMedium = PhosphorFlatIconData(0xe0c6, 'Light');
+  static const batteryMedium = IconData(0xe0c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-plus-light.svg)
-  static const batteryPlus = PhosphorFlatIconData(0xe808, 'Light');
+  static const batteryPlus = IconData(0xe808,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-plus-vertical-light.svg)
-  static const batteryPlusVertical = PhosphorFlatIconData(0xec50, 'Light');
+  static const batteryPlusVertical = IconData(0xec50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-empty-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-vertical-empty-light.svg)
-  static const batteryVerticalEmpty = PhosphorFlatIconData(0xe7c6, 'Light');
+  static const batteryVerticalEmpty = IconData(0xe7c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-full-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-vertical-full-light.svg)
-  static const batteryVerticalFull = PhosphorFlatIconData(0xe7c4, 'Light');
+  static const batteryVerticalFull = IconData(0xe7c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-high-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-vertical-high-light.svg)
-  static const batteryVerticalHigh = PhosphorFlatIconData(0xe7c2, 'Light');
+  static const batteryVerticalHigh = IconData(0xe7c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-low-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-vertical-low-light.svg)
-  static const batteryVerticalLow = PhosphorFlatIconData(0xe7be, 'Light');
+  static const batteryVerticalLow = IconData(0xe7be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-medium-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-vertical-medium-light.svg)
-  static const batteryVerticalMedium = PhosphorFlatIconData(0xe7c0, 'Light');
+  static const batteryVerticalMedium = IconData(0xe7c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-warning-light.svg)
-  static const batteryWarning = PhosphorFlatIconData(0xe0c8, 'Light');
+  static const batteryWarning = IconData(0xe0c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/battery-warning-vertical-light.svg)
-  static const batteryWarningVertical = PhosphorFlatIconData(0xe0ca, 'Light');
+  static const batteryWarningVertical = IconData(0xe0ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beach-ball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/beach-ball-light.svg)
-  static const beachBall = PhosphorFlatIconData(0xed24, 'Light');
+  static const beachBall = IconData(0xed24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beanie-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/beanie-light.svg)
-  static const beanie = PhosphorFlatIconData(0xea2a, 'Light');
+  static const beanie = IconData(0xea2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bed-light.svg)
-  static const bed = PhosphorFlatIconData(0xe0cc, 'Light');
+  static const bed = IconData(0xe0cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-bottle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/beer-bottle-light.svg)
-  static const beerBottle = PhosphorFlatIconData(0xe7b0, 'Light');
+  static const beerBottle = IconData(0xe7b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-stein-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/beer-stein-light.svg)
-  static const beerStein = PhosphorFlatIconData(0xeb62, 'Light');
+  static const beerStein = IconData(0xeb62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![behance-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/behance-logo-light.svg)
-  static const behanceLogo = PhosphorFlatIconData(0xe7f4, 'Light');
+  static const behanceLogo = IconData(0xe7f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bell-light.svg)
-  static const bell = PhosphorFlatIconData(0xe0ce, 'Light');
+  static const bell = IconData(0xe0ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-ringing-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bell-ringing-light.svg)
-  static const bellRinging = PhosphorFlatIconData(0xe5e8, 'Light');
+  static const bellRinging = IconData(0xe5e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bell-simple-light.svg)
-  static const bellSimple = PhosphorFlatIconData(0xe0d0, 'Light');
+  static const bellSimple = IconData(0xe0d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-ringing-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bell-simple-ringing-light.svg)
-  static const bellSimpleRinging = PhosphorFlatIconData(0xe5ea, 'Light');
+  static const bellSimpleRinging = IconData(0xe5ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bell-simple-slash-light.svg)
-  static const bellSimpleSlash = PhosphorFlatIconData(0xe0d2, 'Light');
+  static const bellSimpleSlash = IconData(0xe0d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-z-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bell-simple-z-light.svg)
-  static const bellSimpleZ = PhosphorFlatIconData(0xe5ec, 'Light');
+  static const bellSimpleZ = IconData(0xe5ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bell-slash-light.svg)
-  static const bellSlash = PhosphorFlatIconData(0xe0d4, 'Light');
+  static const bellSlash = IconData(0xe0d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-z-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bell-z-light.svg)
-  static const bellZ = PhosphorFlatIconData(0xe5ee, 'Light');
+  static const bellZ = IconData(0xe5ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![belt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/belt-light.svg)
-  static const belt = PhosphorFlatIconData(0xea2c, 'Light');
+  static const belt = IconData(0xea2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bezier-curve-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bezier-curve-light.svg)
-  static const bezierCurve = PhosphorFlatIconData(0xeb00, 'Light');
+  static const bezierCurve = IconData(0xeb00,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bicycle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bicycle-light.svg)
-  static const bicycle = PhosphorFlatIconData(0xe0d6, 'Light');
+  static const bicycle = IconData(0xe0d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binary-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/binary-light.svg)
-  static const binary = PhosphorFlatIconData(0xee60, 'Light');
+  static const binary = IconData(0xee60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binoculars-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/binoculars-light.svg)
-  static const binoculars = PhosphorFlatIconData(0xea64, 'Light');
+  static const binoculars = IconData(0xea64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![biohazard-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/biohazard-light.svg)
-  static const biohazard = PhosphorFlatIconData(0xe9e0, 'Light');
+  static const biohazard = IconData(0xe9e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bird-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bird-light.svg)
-  static const bird = PhosphorFlatIconData(0xe72c, 'Light');
+  static const bird = IconData(0xe72c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![blueprint-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/blueprint-light.svg)
-  static const blueprint = PhosphorFlatIconData(0xeda0, 'Light');
+  static const blueprint = IconData(0xeda0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bluetooth-light.svg)
-  static const bluetooth = PhosphorFlatIconData(0xe0da, 'Light');
+  static const bluetooth = IconData(0xe0da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-connected-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bluetooth-connected-light.svg)
-  static const bluetoothConnected = PhosphorFlatIconData(0xe0dc, 'Light');
+  static const bluetoothConnected = IconData(0xe0dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bluetooth-slash-light.svg)
-  static const bluetoothSlash = PhosphorFlatIconData(0xe0de, 'Light');
+  static const bluetoothSlash = IconData(0xe0de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bluetooth-x-light.svg)
-  static const bluetoothX = PhosphorFlatIconData(0xe0e0, 'Light');
+  static const bluetoothX = IconData(0xe0e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/boat-light.svg)
-  static const boat = PhosphorFlatIconData(0xe786, 'Light');
+  static const boat = IconData(0xe786,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bomb-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bomb-light.svg)
-  static const bomb = PhosphorFlatIconData(0xee0a, 'Light');
+  static const bomb = IconData(0xee0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bone-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bone-light.svg)
-  static const bone = PhosphorFlatIconData(0xe7f2, 'Light');
+  static const bone = IconData(0xe7f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/book-light.svg)
-  static const book = PhosphorFlatIconData(0xe0e2, 'Light');
+  static const book = IconData(0xe0e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-bookmark-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/book-bookmark-light.svg)
-  static const bookBookmark = PhosphorFlatIconData(0xe0e4, 'Light');
+  static const bookBookmark = IconData(0xe0e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/book-open-light.svg)
-  static const bookOpen = PhosphorFlatIconData(0xe0e6, 'Light');
+  static const bookOpen = IconData(0xe0e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-text-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/book-open-text-light.svg)
-  static const bookOpenText = PhosphorFlatIconData(0xe8f2, 'Light');
+  static const bookOpenText = IconData(0xe8f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-user-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/book-open-user-light.svg)
-  static const bookOpenUser = PhosphorFlatIconData(0xede0, 'Light');
+  static const bookOpenUser = IconData(0xede0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bookmark-light.svg)
-  static const bookmark = PhosphorFlatIconData(0xe0e8, 'Light');
+  static const bookmark = IconData(0xe0e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bookmark-simple-light.svg)
-  static const bookmarkSimple = PhosphorFlatIconData(0xe0ea, 'Light');
+  static const bookmarkSimple = IconData(0xe0ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bookmarks-light.svg)
-  static const bookmarks = PhosphorFlatIconData(0xe0ec, 'Light');
+  static const bookmarks = IconData(0xe0ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bookmarks-simple-light.svg)
-  static const bookmarksSimple = PhosphorFlatIconData(0xe5f0, 'Light');
+  static const bookmarksSimple = IconData(0xe5f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![books-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/books-light.svg)
-  static const books = PhosphorFlatIconData(0xe758, 'Light');
+  static const books = IconData(0xe758,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boot-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/boot-light.svg)
-  static const boot = PhosphorFlatIconData(0xecca, 'Light');
+  static const boot = IconData(0xecca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boules-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/boules-light.svg)
-  static const boules = PhosphorFlatIconData(0xe722, 'Light');
+  static const boules = IconData(0xe722,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bounding-box-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bounding-box-light.svg)
-  static const boundingBox = PhosphorFlatIconData(0xe6ce, 'Light');
+  static const boundingBox = IconData(0xe6ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-food-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bowl-food-light.svg)
-  static const bowlFood = PhosphorFlatIconData(0xeaa4, 'Light');
+  static const bowlFood = IconData(0xeaa4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-steam-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bowl-steam-light.svg)
-  static const bowlSteam = PhosphorFlatIconData(0xe8e4, 'Light');
+  static const bowlSteam = IconData(0xe8e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowling-ball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bowling-ball-light.svg)
-  static const bowlingBall = PhosphorFlatIconData(0xea34, 'Light');
+  static const bowlingBall = IconData(0xea34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/box-arrow-down-light.svg)
-  static const boxArrowDown = PhosphorFlatIconData(0xe00e, 'Light');
+  static const boxArrowDown = IconData(0xe00e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/box-arrow-up-light.svg)
-  static const boxArrowUp = PhosphorFlatIconData(0xee54, 'Light');
+  static const boxArrowUp = IconData(0xee54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boxing-glove-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/boxing-glove-light.svg)
-  static const boxingGlove = PhosphorFlatIconData(0xea36, 'Light');
+  static const boxingGlove = IconData(0xea36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-angle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/brackets-angle-light.svg)
-  static const bracketsAngle = PhosphorFlatIconData(0xe862, 'Light');
+  static const bracketsAngle = IconData(0xe862,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-curly-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/brackets-curly-light.svg)
-  static const bracketsCurly = PhosphorFlatIconData(0xe860, 'Light');
+  static const bracketsCurly = IconData(0xe860,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-round-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/brackets-round-light.svg)
-  static const bracketsRound = PhosphorFlatIconData(0xe864, 'Light');
+  static const bracketsRound = IconData(0xe864,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/brackets-square-light.svg)
-  static const bracketsSquare = PhosphorFlatIconData(0xe85e, 'Light');
+  static const bracketsSquare = IconData(0xe85e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brain-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/brain-light.svg)
-  static const brain = PhosphorFlatIconData(0xe74e, 'Light');
+  static const brain = IconData(0xe74e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brandy-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/brandy-light.svg)
-  static const brandy = PhosphorFlatIconData(0xe6b4, 'Light');
+  static const brandy = IconData(0xe6b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bread-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bread-light.svg)
-  static const bread = PhosphorFlatIconData(0xe81c, 'Light');
+  static const bread = IconData(0xe81c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bridge-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bridge-light.svg)
-  static const bridge = PhosphorFlatIconData(0xea68, 'Light');
+  static const bridge = IconData(0xea68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/briefcase-light.svg)
-  static const briefcase = PhosphorFlatIconData(0xe0ee, 'Light');
+  static const briefcase = IconData(0xe0ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-metal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/briefcase-metal-light.svg)
-  static const briefcaseMetal = PhosphorFlatIconData(0xe5f2, 'Light');
+  static const briefcaseMetal = IconData(0xe5f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broadcast-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/broadcast-light.svg)
-  static const broadcast = PhosphorFlatIconData(0xe0f2, 'Light');
+  static const broadcast = IconData(0xe0f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broom-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/broom-light.svg)
-  static const broom = PhosphorFlatIconData(0xec54, 'Light');
+  static const broom = IconData(0xec54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browser-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/browser-light.svg)
-  static const browser = PhosphorFlatIconData(0xe0f4, 'Light');
+  static const browser = IconData(0xe0f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browsers-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/browsers-light.svg)
-  static const browsers = PhosphorFlatIconData(0xe0f6, 'Light');
+  static const browsers = IconData(0xe0f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bug-light.svg)
-  static const bug = PhosphorFlatIconData(0xe5f4, 'Light');
+  static const bug = IconData(0xe5f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-beetle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bug-beetle-light.svg)
-  static const bugBeetle = PhosphorFlatIconData(0xe5f6, 'Light');
+  static const bugBeetle = IconData(0xe5f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-droid-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bug-droid-light.svg)
-  static const bugDroid = PhosphorFlatIconData(0xe5f8, 'Light');
+  static const bugDroid = IconData(0xe5f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/building-light.svg)
-  static const building = PhosphorFlatIconData(0xe100, 'Light');
+  static const building = IconData(0xe100,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-apartment-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/building-apartment-light.svg)
-  static const buildingApartment = PhosphorFlatIconData(0xe0fe, 'Light');
+  static const buildingApartment = IconData(0xe0fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-office-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/building-office-light.svg)
-  static const buildingOffice = PhosphorFlatIconData(0xe0ff, 'Light');
+  static const buildingOffice = IconData(0xe0ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![buildings-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/buildings-light.svg)
-  static const buildings = PhosphorFlatIconData(0xe102, 'Light');
+  static const buildings = IconData(0xe102,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bulldozer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bulldozer-light.svg)
-  static const bulldozer = PhosphorFlatIconData(0xec6c, 'Light');
+  static const bulldozer = IconData(0xec6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/bus-light.svg)
-  static const bus = PhosphorFlatIconData(0xe106, 'Light');
+  static const bus = IconData(0xe106,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![butterfly-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/butterfly-light.svg)
-  static const butterfly = PhosphorFlatIconData(0xea6e, 'Light');
+  static const butterfly = IconData(0xea6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cable-car-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cable-car-light.svg)
-  static const cableCar = PhosphorFlatIconData(0xe49c, 'Light');
+  static const cableCar = IconData(0xe49c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cactus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cactus-light.svg)
-  static const cactus = PhosphorFlatIconData(0xe918, 'Light');
+  static const cactus = IconData(0xe918,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cake-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cake-light.svg)
-  static const cake = PhosphorFlatIconData(0xe780, 'Light');
+  static const cake = IconData(0xe780,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calculator-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calculator-light.svg)
-  static const calculator = PhosphorFlatIconData(0xe538, 'Light');
+  static const calculator = IconData(0xe538,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-light.svg)
-  static const calendar = PhosphorFlatIconData(0xe108, 'Light');
+  static const calendar = IconData(0xe108,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-blank-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-blank-light.svg)
-  static const calendarBlank = PhosphorFlatIconData(0xe10a, 'Light');
+  static const calendarBlank = IconData(0xe10a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-check-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-check-light.svg)
-  static const calendarCheck = PhosphorFlatIconData(0xe712, 'Light');
+  static const calendarCheck = IconData(0xe712,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dot-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-dot-light.svg)
-  static const calendarDot = PhosphorFlatIconData(0xe7b2, 'Light');
+  static const calendarDot = IconData(0xe7b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dots-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-dots-light.svg)
-  static const calendarDots = PhosphorFlatIconData(0xe7b4, 'Light');
+  static const calendarDots = IconData(0xe7b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-heart-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-heart-light.svg)
-  static const calendarHeart = PhosphorFlatIconData(0xe8b0, 'Light');
+  static const calendarHeart = IconData(0xe8b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-minus-light.svg)
-  static const calendarMinus = PhosphorFlatIconData(0xea14, 'Light');
+  static const calendarMinus = IconData(0xea14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-plus-light.svg)
-  static const calendarPlus = PhosphorFlatIconData(0xe714, 'Light');
+  static const calendarPlus = IconData(0xe714,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-slash-light.svg)
-  static const calendarSlash = PhosphorFlatIconData(0xea12, 'Light');
+  static const calendarSlash = IconData(0xea12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-star-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-star-light.svg)
-  static const calendarStar = PhosphorFlatIconData(0xe8b2, 'Light');
+  static const calendarStar = IconData(0xe8b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/calendar-x-light.svg)
-  static const calendarX = PhosphorFlatIconData(0xe10c, 'Light');
+  static const calendarX = IconData(0xe10c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![call-bell-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/call-bell-light.svg)
-  static const callBell = PhosphorFlatIconData(0xe7de, 'Light');
+  static const callBell = IconData(0xe7de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/camera-light.svg)
-  static const camera = PhosphorFlatIconData(0xe10e, 'Light');
+  static const camera = IconData(0xe10e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/camera-plus-light.svg)
-  static const cameraPlus = PhosphorFlatIconData(0xec58, 'Light');
+  static const cameraPlus = IconData(0xec58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-rotate-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/camera-rotate-light.svg)
-  static const cameraRotate = PhosphorFlatIconData(0xe7a4, 'Light');
+  static const cameraRotate = IconData(0xe7a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/camera-slash-light.svg)
-  static const cameraSlash = PhosphorFlatIconData(0xe110, 'Light');
+  static const cameraSlash = IconData(0xe110,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![campfire-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/campfire-light.svg)
-  static const campfire = PhosphorFlatIconData(0xe9d8, 'Light');
+  static const campfire = IconData(0xe9d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/car-light.svg)
-  static const car = PhosphorFlatIconData(0xe112, 'Light');
+  static const car = IconData(0xe112,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-battery-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/car-battery-light.svg)
-  static const carBattery = PhosphorFlatIconData(0xee30, 'Light');
+  static const carBattery = IconData(0xee30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-profile-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/car-profile-light.svg)
-  static const carProfile = PhosphorFlatIconData(0xe8cc, 'Light');
+  static const carProfile = IconData(0xe8cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/car-simple-light.svg)
-  static const carSimple = PhosphorFlatIconData(0xe114, 'Light');
+  static const carSimple = IconData(0xe114,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cardholder-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cardholder-light.svg)
-  static const cardholder = PhosphorFlatIconData(0xe5fa, 'Light');
+  static const cardholder = IconData(0xe5fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cards-light.svg)
-  static const cards = PhosphorFlatIconData(0xe0f8, 'Light');
+  static const cards = IconData(0xe0f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cards-three-light.svg)
-  static const cardsThree = PhosphorFlatIconData(0xee50, 'Light');
+  static const cardsThree = IconData(0xee50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-double-down-light.svg)
-  static const caretCircleDoubleDown = PhosphorFlatIconData(0xe116, 'Light');
+  static const caretCircleDoubleDown = IconData(0xe116,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-double-left-light.svg)
-  static const caretCircleDoubleLeft = PhosphorFlatIconData(0xe118, 'Light');
+  static const caretCircleDoubleLeft = IconData(0xe118,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-double-right-light.svg)
-  static const caretCircleDoubleRight = PhosphorFlatIconData(0xe11a, 'Light');
+  static const caretCircleDoubleRight = IconData(0xe11a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-double-up-light.svg)
-  static const caretCircleDoubleUp = PhosphorFlatIconData(0xe11c, 'Light');
+  static const caretCircleDoubleUp = IconData(0xe11c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-down-light.svg)
-  static const caretCircleDown = PhosphorFlatIconData(0xe11e, 'Light');
+  static const caretCircleDown = IconData(0xe11e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-left-light.svg)
-  static const caretCircleLeft = PhosphorFlatIconData(0xe120, 'Light');
+  static const caretCircleLeft = IconData(0xe120,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-right-light.svg)
-  static const caretCircleRight = PhosphorFlatIconData(0xe122, 'Light');
+  static const caretCircleRight = IconData(0xe122,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-up-light.svg)
-  static const caretCircleUp = PhosphorFlatIconData(0xe124, 'Light');
+  static const caretCircleUp = IconData(0xe124,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-circle-up-down-light.svg)
-  static const caretCircleUpDown = PhosphorFlatIconData(0xe13e, 'Light');
+  static const caretCircleUpDown = IconData(0xe13e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-double-down-light.svg)
-  static const caretDoubleDown = PhosphorFlatIconData(0xe126, 'Light');
+  static const caretDoubleDown = IconData(0xe126,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-double-left-light.svg)
-  static const caretDoubleLeft = PhosphorFlatIconData(0xe128, 'Light');
+  static const caretDoubleLeft = IconData(0xe128,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-double-right-light.svg)
-  static const caretDoubleRight = PhosphorFlatIconData(0xe12a, 'Light');
+  static const caretDoubleRight = IconData(0xe12a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-double-up-light.svg)
-  static const caretDoubleUp = PhosphorFlatIconData(0xe12c, 'Light');
+  static const caretDoubleUp = IconData(0xe12c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-down-light.svg)
-  static const caretDown = PhosphorFlatIconData(0xe136, 'Light');
+  static const caretDown = IconData(0xe136,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-left-light.svg)
-  static const caretLeft = PhosphorFlatIconData(0xe138, 'Light');
+  static const caretLeft = IconData(0xe138,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-line-down-light.svg)
-  static const caretLineDown = PhosphorFlatIconData(0xe134, 'Light');
+  static const caretLineDown = IconData(0xe134,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-line-left-light.svg)
-  static const caretLineLeft = PhosphorFlatIconData(0xe132, 'Light');
+  static const caretLineLeft = IconData(0xe132,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-line-right-light.svg)
-  static const caretLineRight = PhosphorFlatIconData(0xe130, 'Light');
+  static const caretLineRight = IconData(0xe130,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-line-up-light.svg)
-  static const caretLineUp = PhosphorFlatIconData(0xe12e, 'Light');
+  static const caretLineUp = IconData(0xe12e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-right-light.svg)
-  static const caretRight = PhosphorFlatIconData(0xe13a, 'Light');
+  static const caretRight = IconData(0xe13a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-up-light.svg)
-  static const caretUp = PhosphorFlatIconData(0xe13c, 'Light');
+  static const caretUp = IconData(0xe13c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/caret-up-down-light.svg)
-  static const caretUpDown = PhosphorFlatIconData(0xe140, 'Light');
+  static const caretUpDown = IconData(0xe140,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![carrot-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/carrot-light.svg)
-  static const carrot = PhosphorFlatIconData(0xed38, 'Light');
+  static const carrot = IconData(0xed38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cash-register-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cash-register-light.svg)
-  static const cashRegister = PhosphorFlatIconData(0xed80, 'Light');
+  static const cashRegister = IconData(0xed80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cassette-tape-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cassette-tape-light.svg)
-  static const cassetteTape = PhosphorFlatIconData(0xed2e, 'Light');
+  static const cassetteTape = IconData(0xed2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![castle-turret-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/castle-turret-light.svg)
-  static const castleTurret = PhosphorFlatIconData(0xe9d0, 'Light');
+  static const castleTurret = IconData(0xe9d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cat-light.svg)
-  static const cat = PhosphorFlatIconData(0xe748, 'Light');
+  static const cat = IconData(0xe748,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-full-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cell-signal-full-light.svg)
-  static const cellSignalFull = PhosphorFlatIconData(0xe142, 'Light');
+  static const cellSignalFull = IconData(0xe142,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-high-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cell-signal-high-light.svg)
-  static const cellSignalHigh = PhosphorFlatIconData(0xe144, 'Light');
+  static const cellSignalHigh = IconData(0xe144,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-low-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cell-signal-low-light.svg)
-  static const cellSignalLow = PhosphorFlatIconData(0xe146, 'Light');
+  static const cellSignalLow = IconData(0xe146,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-medium-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cell-signal-medium-light.svg)
-  static const cellSignalMedium = PhosphorFlatIconData(0xe148, 'Light');
+  static const cellSignalMedium = IconData(0xe148,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-none-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cell-signal-none-light.svg)
-  static const cellSignalNone = PhosphorFlatIconData(0xe14a, 'Light');
+  static const cellSignalNone = IconData(0xe14a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cell-signal-slash-light.svg)
-  static const cellSignalSlash = PhosphorFlatIconData(0xe14c, 'Light');
+  static const cellSignalSlash = IconData(0xe14c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cell-signal-x-light.svg)
-  static const cellSignalX = PhosphorFlatIconData(0xe14e, 'Light');
+  static const cellSignalX = IconData(0xe14e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-tower-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cell-tower-light.svg)
-  static const cellTower = PhosphorFlatIconData(0xebaa, 'Light');
+  static const cellTower = IconData(0xebaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![certificate-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/certificate-light.svg)
-  static const certificate = PhosphorFlatIconData(0xe766, 'Light');
+  static const certificate = IconData(0xe766,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chair-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chair-light.svg)
-  static const chair = PhosphorFlatIconData(0xe950, 'Light');
+  static const chair = IconData(0xe950,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chalkboard-light.svg)
-  static const chalkboard = PhosphorFlatIconData(0xe5fc, 'Light');
+  static const chalkboard = IconData(0xe5fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chalkboard-simple-light.svg)
-  static const chalkboardSimple = PhosphorFlatIconData(0xe5fe, 'Light');
+  static const chalkboardSimple = IconData(0xe5fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-teacher-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chalkboard-teacher-light.svg)
-  static const chalkboardTeacher = PhosphorFlatIconData(0xe600, 'Light');
+  static const chalkboardTeacher = IconData(0xe600,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![champagne-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/champagne-light.svg)
-  static const champagne = PhosphorFlatIconData(0xeaca, 'Light');
+  static const champagne = IconData(0xeaca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![charging-station-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/charging-station-light.svg)
-  static const chargingStation = PhosphorFlatIconData(0xe8d0, 'Light');
+  static const chargingStation = IconData(0xe8d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-bar-light.svg)
-  static const chartBar = PhosphorFlatIconData(0xe150, 'Light');
+  static const chartBar = IconData(0xe150,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-bar-horizontal-light.svg)
-  static const chartBarHorizontal = PhosphorFlatIconData(0xe152, 'Light');
+  static const chartBarHorizontal = IconData(0xe152,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-donut-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-donut-light.svg)
-  static const chartDonut = PhosphorFlatIconData(0xeaa6, 'Light');
+  static const chartDonut = IconData(0xeaa6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-line-light.svg)
-  static const chartLine = PhosphorFlatIconData(0xe154, 'Light');
+  static const chartLine = IconData(0xe154,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-line-down-light.svg)
-  static const chartLineDown = PhosphorFlatIconData(0xe8b6, 'Light');
+  static const chartLineDown = IconData(0xe8b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-line-up-light.svg)
-  static const chartLineUp = PhosphorFlatIconData(0xe156, 'Light');
+  static const chartLineUp = IconData(0xe156,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-pie-light.svg)
-  static const chartPie = PhosphorFlatIconData(0xe158, 'Light');
+  static const chartPie = IconData(0xe158,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-slice-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-pie-slice-light.svg)
-  static const chartPieSlice = PhosphorFlatIconData(0xe15a, 'Light');
+  static const chartPieSlice = IconData(0xe15a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-polar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-polar-light.svg)
-  static const chartPolar = PhosphorFlatIconData(0xeaa8, 'Light');
+  static const chartPolar = IconData(0xeaa8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-scatter-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chart-scatter-light.svg)
-  static const chartScatter = PhosphorFlatIconData(0xeaac, 'Light');
+  static const chartScatter = IconData(0xeaac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-light.svg)
-  static const chat = PhosphorFlatIconData(0xe15c, 'Light');
+  static const chat = IconData(0xe15c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-centered-light.svg)
-  static const chatCentered = PhosphorFlatIconData(0xe160, 'Light');
+  static const chatCentered = IconData(0xe160,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-dots-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-centered-dots-light.svg)
-  static const chatCenteredDots = PhosphorFlatIconData(0xe164, 'Light');
+  static const chatCenteredDots = IconData(0xe164,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-centered-slash-light.svg)
-  static const chatCenteredSlash = PhosphorFlatIconData(0xe162, 'Light');
+  static const chatCenteredSlash = IconData(0xe162,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-text-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-centered-text-light.svg)
-  static const chatCenteredText = PhosphorFlatIconData(0xe166, 'Light');
+  static const chatCenteredText = IconData(0xe166,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-circle-light.svg)
-  static const chatCircle = PhosphorFlatIconData(0xe168, 'Light');
+  static const chatCircle = IconData(0xe168,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-dots-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-circle-dots-light.svg)
-  static const chatCircleDots = PhosphorFlatIconData(0xe16c, 'Light');
+  static const chatCircleDots = IconData(0xe16c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-circle-slash-light.svg)
-  static const chatCircleSlash = PhosphorFlatIconData(0xe16a, 'Light');
+  static const chatCircleSlash = IconData(0xe16a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-text-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-circle-text-light.svg)
-  static const chatCircleText = PhosphorFlatIconData(0xe16e, 'Light');
+  static const chatCircleText = IconData(0xe16e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-dots-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-dots-light.svg)
-  static const chatDots = PhosphorFlatIconData(0xe170, 'Light');
+  static const chatDots = IconData(0xe170,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-slash-light.svg)
-  static const chatSlash = PhosphorFlatIconData(0xe15e, 'Light');
+  static const chatSlash = IconData(0xe15e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-teardrop-light.svg)
-  static const chatTeardrop = PhosphorFlatIconData(0xe172, 'Light');
+  static const chatTeardrop = IconData(0xe172,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-dots-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-teardrop-dots-light.svg)
-  static const chatTeardropDots = PhosphorFlatIconData(0xe176, 'Light');
+  static const chatTeardropDots = IconData(0xe176,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-teardrop-slash-light.svg)
-  static const chatTeardropSlash = PhosphorFlatIconData(0xe174, 'Light');
+  static const chatTeardropSlash = IconData(0xe174,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-text-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-teardrop-text-light.svg)
-  static const chatTeardropText = PhosphorFlatIconData(0xe178, 'Light');
+  static const chatTeardropText = IconData(0xe178,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-text-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chat-text-light.svg)
-  static const chatText = PhosphorFlatIconData(0xe17a, 'Light');
+  static const chatText = IconData(0xe17a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chats-light.svg)
-  static const chats = PhosphorFlatIconData(0xe17c, 'Light');
+  static const chats = IconData(0xe17c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chats-circle-light.svg)
-  static const chatsCircle = PhosphorFlatIconData(0xe17e, 'Light');
+  static const chatsCircle = IconData(0xe17e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-teardrop-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chats-teardrop-light.svg)
-  static const chatsTeardrop = PhosphorFlatIconData(0xe180, 'Light');
+  static const chatsTeardrop = IconData(0xe180,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/check-light.svg)
-  static const check = PhosphorFlatIconData(0xe182, 'Light');
+  static const check = IconData(0xe182,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/check-circle-light.svg)
-  static const checkCircle = PhosphorFlatIconData(0xe184, 'Light');
+  static const checkCircle = IconData(0xe184,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-fat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/check-fat-light.svg)
-  static const checkFat = PhosphorFlatIconData(0xeba6, 'Light');
+  static const checkFat = IconData(0xeba6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/check-square-light.svg)
-  static const checkSquare = PhosphorFlatIconData(0xe186, 'Light');
+  static const checkSquare = IconData(0xe186,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-offset-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/check-square-offset-light.svg)
-  static const checkSquareOffset = PhosphorFlatIconData(0xe188, 'Light');
+  static const checkSquareOffset = IconData(0xe188,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checkerboard-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/checkerboard-light.svg)
-  static const checkerboard = PhosphorFlatIconData(0xe8c4, 'Light');
+  static const checkerboard = IconData(0xe8c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checks-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/checks-light.svg)
-  static const checks = PhosphorFlatIconData(0xe53a, 'Light');
+  static const checks = IconData(0xe53a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheers-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cheers-light.svg)
-  static const cheers = PhosphorFlatIconData(0xea4a, 'Light');
+  static const cheers = IconData(0xea4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheese-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cheese-light.svg)
-  static const cheese = PhosphorFlatIconData(0xe9fe, 'Light');
+  static const cheese = IconData(0xe9fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chef-hat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/chef-hat-light.svg)
-  static const chefHat = PhosphorFlatIconData(0xed8e, 'Light');
+  static const chefHat = IconData(0xed8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cherries-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cherries-light.svg)
-  static const cherries = PhosphorFlatIconData(0xe830, 'Light');
+  static const cherries = IconData(0xe830,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![church-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/church-light.svg)
-  static const church = PhosphorFlatIconData(0xecea, 'Light');
+  static const church = IconData(0xecea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cigarette-light.svg)
-  static const cigarette = PhosphorFlatIconData(0xed90, 'Light');
+  static const cigarette = IconData(0xed90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cigarette-slash-light.svg)
-  static const cigaretteSlash = PhosphorFlatIconData(0xed92, 'Light');
+  static const cigaretteSlash = IconData(0xed92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circle-light.svg)
-  static const circle = PhosphorFlatIconData(0xe18a, 'Light');
+  static const circle = IconData(0xe18a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-dashed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circle-dashed-light.svg)
-  static const circleDashed = PhosphorFlatIconData(0xe602, 'Light');
+  static const circleDashed = IconData(0xe602,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circle-half-light.svg)
-  static const circleHalf = PhosphorFlatIconData(0xe18c, 'Light');
+  static const circleHalf = IconData(0xe18c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-tilt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circle-half-tilt-light.svg)
-  static const circleHalfTilt = PhosphorFlatIconData(0xe18e, 'Light');
+  static const circleHalfTilt = IconData(0xe18e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-notch-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circle-notch-light.svg)
-  static const circleNotch = PhosphorFlatIconData(0xeb44, 'Light');
+  static const circleNotch = IconData(0xeb44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circles-four-light.svg)
-  static const circlesFour = PhosphorFlatIconData(0xe190, 'Light');
+  static const circlesFour = IconData(0xe190,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circles-three-light.svg)
-  static const circlesThree = PhosphorFlatIconData(0xe192, 'Light');
+  static const circlesThree = IconData(0xe192,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circles-three-plus-light.svg)
-  static const circlesThreePlus = PhosphorFlatIconData(0xe194, 'Light');
+  static const circlesThreePlus = IconData(0xe194,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circuitry-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/circuitry-light.svg)
-  static const circuitry = PhosphorFlatIconData(0xe9c2, 'Light');
+  static const circuitry = IconData(0xe9c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![city-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/city-light.svg)
-  static const city = PhosphorFlatIconData(0xea6a, 'Light');
+  static const city = IconData(0xea6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clipboard-light.svg)
-  static const clipboard = PhosphorFlatIconData(0xe196, 'Light');
+  static const clipboard = IconData(0xe196,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-text-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clipboard-text-light.svg)
-  static const clipboardText = PhosphorFlatIconData(0xe198, 'Light');
+  static const clipboardText = IconData(0xe198,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clock-light.svg)
-  static const clock = PhosphorFlatIconData(0xe19a, 'Light');
+  static const clock = IconData(0xe19a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-afternoon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clock-afternoon-light.svg)
-  static const clockAfternoon = PhosphorFlatIconData(0xe19c, 'Light');
+  static const clockAfternoon = IconData(0xe19c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-clockwise-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clock-clockwise-light.svg)
-  static const clockClockwise = PhosphorFlatIconData(0xe19e, 'Light');
+  static const clockClockwise = IconData(0xe19e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-countdown-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clock-countdown-light.svg)
-  static const clockCountdown = PhosphorFlatIconData(0xed2c, 'Light');
+  static const clockCountdown = IconData(0xed2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-counter-clockwise-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clock-counter-clockwise-light.svg)
-  static const clockCounterClockwise = PhosphorFlatIconData(0xe1a0, 'Light');
+  static const clockCounterClockwise = IconData(0xe1a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-user-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clock-user-light.svg)
-  static const clockUser = PhosphorFlatIconData(0xedec, 'Light');
+  static const clockUser = IconData(0xedec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![closed-captioning-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/closed-captioning-light.svg)
-  static const closedCaptioning = PhosphorFlatIconData(0xe1a4, 'Light');
+  static const closedCaptioning = IconData(0xe1a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-light.svg)
-  static const cloud = PhosphorFlatIconData(0xe1aa, 'Light');
+  static const cloud = IconData(0xe1aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-arrow-down-light.svg)
-  static const cloudArrowDown = PhosphorFlatIconData(0xe1ac, 'Light');
+  static const cloudArrowDown = IconData(0xe1ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-arrow-up-light.svg)
-  static const cloudArrowUp = PhosphorFlatIconData(0xe1ae, 'Light');
+  static const cloudArrowUp = IconData(0xe1ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-check-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-check-light.svg)
-  static const cloudCheck = PhosphorFlatIconData(0xe1b0, 'Light');
+  static const cloudCheck = IconData(0xe1b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-fog-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-fog-light.svg)
-  static const cloudFog = PhosphorFlatIconData(0xe53c, 'Light');
+  static const cloudFog = IconData(0xe53c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-lightning-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-lightning-light.svg)
-  static const cloudLightning = PhosphorFlatIconData(0xe1b2, 'Light');
+  static const cloudLightning = IconData(0xe1b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-moon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-moon-light.svg)
-  static const cloudMoon = PhosphorFlatIconData(0xe53e, 'Light');
+  static const cloudMoon = IconData(0xe53e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-rain-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-rain-light.svg)
-  static const cloudRain = PhosphorFlatIconData(0xe1b4, 'Light');
+  static const cloudRain = IconData(0xe1b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-slash-light.svg)
-  static const cloudSlash = PhosphorFlatIconData(0xe1b6, 'Light');
+  static const cloudSlash = IconData(0xe1b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-snow-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-snow-light.svg)
-  static const cloudSnow = PhosphorFlatIconData(0xe1b8, 'Light');
+  static const cloudSnow = IconData(0xe1b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-sun-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-sun-light.svg)
-  static const cloudSun = PhosphorFlatIconData(0xe540, 'Light');
+  static const cloudSun = IconData(0xe540,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-warning-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-warning-light.svg)
-  static const cloudWarning = PhosphorFlatIconData(0xea98, 'Light');
+  static const cloudWarning = IconData(0xea98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cloud-x-light.svg)
-  static const cloudX = PhosphorFlatIconData(0xea96, 'Light');
+  static const cloudX = IconData(0xea96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clover-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/clover-light.svg)
-  static const clover = PhosphorFlatIconData(0xedc8, 'Light');
+  static const clover = IconData(0xedc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![club-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/club-light.svg)
-  static const club = PhosphorFlatIconData(0xe1ba, 'Light');
+  static const club = IconData(0xe1ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coat-hanger-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/coat-hanger-light.svg)
-  static const coatHanger = PhosphorFlatIconData(0xe7fe, 'Light');
+  static const coatHanger = IconData(0xe7fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coda-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/coda-logo-light.svg)
-  static const codaLogo = PhosphorFlatIconData(0xe7ce, 'Light');
+  static const codaLogo = IconData(0xe7ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/code-light.svg)
-  static const code = PhosphorFlatIconData(0xe1bc, 'Light');
+  static const code = IconData(0xe1bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-block-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/code-block-light.svg)
-  static const codeBlock = PhosphorFlatIconData(0xeafe, 'Light');
+  static const codeBlock = IconData(0xeafe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/code-simple-light.svg)
-  static const codeSimple = PhosphorFlatIconData(0xe1be, 'Light');
+  static const codeSimple = IconData(0xe1be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codepen-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/codepen-logo-light.svg)
-  static const codepenLogo = PhosphorFlatIconData(0xe978, 'Light');
+  static const codepenLogo = IconData(0xe978,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codesandbox-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/codesandbox-logo-light.svg)
-  static const codesandboxLogo = PhosphorFlatIconData(0xea06, 'Light');
+  static const codesandboxLogo = IconData(0xea06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/coffee-light.svg)
-  static const coffee = PhosphorFlatIconData(0xe1c2, 'Light');
+  static const coffee = IconData(0xe1c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-bean-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/coffee-bean-light.svg)
-  static const coffeeBean = PhosphorFlatIconData(0xe1c0, 'Light');
+  static const coffeeBean = IconData(0xe1c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/coin-light.svg)
-  static const coin = PhosphorFlatIconData(0xe60e, 'Light');
+  static const coin = IconData(0xe60e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/coin-vertical-light.svg)
-  static const coinVertical = PhosphorFlatIconData(0xeb48, 'Light');
+  static const coinVertical = IconData(0xeb48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coins-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/coins-light.svg)
-  static const coins = PhosphorFlatIconData(0xe78e, 'Light');
+  static const coins = IconData(0xe78e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/columns-light.svg)
-  static const columns = PhosphorFlatIconData(0xe546, 'Light');
+  static const columns = IconData(0xe546,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/columns-plus-left-light.svg)
-  static const columnsPlusLeft = PhosphorFlatIconData(0xe544, 'Light');
+  static const columnsPlusLeft = IconData(0xe544,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/columns-plus-right-light.svg)
-  static const columnsPlusRight = PhosphorFlatIconData(0xe542, 'Light');
+  static const columnsPlusRight = IconData(0xe542,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![command-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/command-light.svg)
-  static const command = PhosphorFlatIconData(0xe1c4, 'Light');
+  static const command = IconData(0xe1c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/compass-light.svg)
-  static const compass = PhosphorFlatIconData(0xe1c8, 'Light');
+  static const compass = IconData(0xe1c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-rose-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/compass-rose-light.svg)
-  static const compassRose = PhosphorFlatIconData(0xe1c6, 'Light');
+  static const compassRose = IconData(0xe1c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-tool-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/compass-tool-light.svg)
-  static const compassTool = PhosphorFlatIconData(0xea0e, 'Light');
+  static const compassTool = IconData(0xea0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![computer-tower-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/computer-tower-light.svg)
-  static const computerTower = PhosphorFlatIconData(0xe548, 'Light');
+  static const computerTower = IconData(0xe548,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![confetti-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/confetti-light.svg)
-  static const confetti = PhosphorFlatIconData(0xe81a, 'Light');
+  static const confetti = IconData(0xe81a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![contactless-payment-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/contactless-payment-light.svg)
-  static const contactlessPayment = PhosphorFlatIconData(0xed42, 'Light');
+  static const contactlessPayment = IconData(0xed42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![control-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/control-light.svg)
-  static const control = PhosphorFlatIconData(0xeca6, 'Light');
+  static const control = IconData(0xeca6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cookie-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cookie-light.svg)
-  static const cookie = PhosphorFlatIconData(0xe6ca, 'Light');
+  static const cookie = IconData(0xe6ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cooking-pot-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cooking-pot-light.svg)
-  static const cookingPot = PhosphorFlatIconData(0xe764, 'Light');
+  static const cookingPot = IconData(0xe764,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/copy-light.svg)
-  static const copy = PhosphorFlatIconData(0xe1ca, 'Light');
+  static const copy = IconData(0xe1ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/copy-simple-light.svg)
-  static const copySimple = PhosphorFlatIconData(0xe1cc, 'Light');
+  static const copySimple = IconData(0xe1cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyleft-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/copyleft-light.svg)
-  static const copyleft = PhosphorFlatIconData(0xe86a, 'Light');
+  static const copyleft = IconData(0xe86a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyright-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/copyright-light.svg)
-  static const copyright = PhosphorFlatIconData(0xe54a, 'Light');
+  static const copyright = IconData(0xe54a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-in-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/corners-in-light.svg)
-  static const cornersIn = PhosphorFlatIconData(0xe1ce, 'Light');
+  static const cornersIn = IconData(0xe1ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-out-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/corners-out-light.svg)
-  static const cornersOut = PhosphorFlatIconData(0xe1d0, 'Light');
+  static const cornersOut = IconData(0xe1d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![couch-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/couch-light.svg)
-  static const couch = PhosphorFlatIconData(0xe7f6, 'Light');
+  static const couch = IconData(0xe7f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![court-basketball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/court-basketball-light.svg)
-  static const courtBasketball = PhosphorFlatIconData(0xee36, 'Light');
+  static const courtBasketball = IconData(0xee36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cow-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cow-light.svg)
-  static const cow = PhosphorFlatIconData(0xeabe, 'Light');
+  static const cow = IconData(0xeabe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cowboy-hat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cowboy-hat-light.svg)
-  static const cowboyHat = PhosphorFlatIconData(0xed12, 'Light');
+  static const cowboyHat = IconData(0xed12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cpu-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cpu-light.svg)
-  static const cpu = PhosphorFlatIconData(0xe610, 'Light');
+  static const cpu = IconData(0xe610,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/crane-light.svg)
-  static const crane = PhosphorFlatIconData(0xed48, 'Light');
+  static const crane = IconData(0xed48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-tower-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/crane-tower-light.svg)
-  static const craneTower = PhosphorFlatIconData(0xed49, 'Light');
+  static const craneTower = IconData(0xed49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![credit-card-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/credit-card-light.svg)
-  static const creditCard = PhosphorFlatIconData(0xe1d2, 'Light');
+  static const creditCard = IconData(0xe1d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cricket-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cricket-light.svg)
-  static const cricket = PhosphorFlatIconData(0xee12, 'Light');
+  static const cricket = IconData(0xee12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crop-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/crop-light.svg)
-  static const crop = PhosphorFlatIconData(0xe1d4, 'Light');
+  static const crop = IconData(0xe1d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cross-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cross-light.svg)
-  static const cross = PhosphorFlatIconData(0xe8a0, 'Light');
+  static const cross = IconData(0xe8a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/crosshair-light.svg)
-  static const crosshair = PhosphorFlatIconData(0xe1d6, 'Light');
+  static const crosshair = IconData(0xe1d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/crosshair-simple-light.svg)
-  static const crosshairSimple = PhosphorFlatIconData(0xe1d8, 'Light');
+  static const crosshairSimple = IconData(0xe1d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/crown-light.svg)
-  static const crown = PhosphorFlatIconData(0xe614, 'Light');
+  static const crown = IconData(0xe614,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-cross-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/crown-cross-light.svg)
-  static const crownCross = PhosphorFlatIconData(0xee5e, 'Light');
+  static const crownCross = IconData(0xee5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/crown-simple-light.svg)
-  static const crownSimple = PhosphorFlatIconData(0xe616, 'Light');
+  static const crownSimple = IconData(0xe616,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cube-light.svg)
-  static const cube = PhosphorFlatIconData(0xe1da, 'Light');
+  static const cube = IconData(0xe1da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-focus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cube-focus-light.svg)
-  static const cubeFocus = PhosphorFlatIconData(0xed0a, 'Light');
+  static const cubeFocus = IconData(0xed0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-transparent-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cube-transparent-light.svg)
-  static const cubeTransparent = PhosphorFlatIconData(0xec7c, 'Light');
+  static const cubeTransparent = IconData(0xec7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-btc-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-btc-light.svg)
-  static const currencyBtc = PhosphorFlatIconData(0xe618, 'Light');
+  static const currencyBtc = IconData(0xe618,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-circle-dollar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-circle-dollar-light.svg)
-  static const currencyCircleDollar = PhosphorFlatIconData(0xe54c, 'Light');
+  static const currencyCircleDollar = IconData(0xe54c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-cny-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-cny-light.svg)
-  static const currencyCny = PhosphorFlatIconData(0xe54e, 'Light');
+  static const currencyCny = IconData(0xe54e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-dollar-light.svg)
-  static const currencyDollar = PhosphorFlatIconData(0xe550, 'Light');
+  static const currencyDollar = IconData(0xe550,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-dollar-simple-light.svg)
-  static const currencyDollarSimple = PhosphorFlatIconData(0xe552, 'Light');
+  static const currencyDollarSimple = IconData(0xe552,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eth-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-eth-light.svg)
-  static const currencyEth = PhosphorFlatIconData(0xeada, 'Light');
+  static const currencyEth = IconData(0xeada,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eur-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-eur-light.svg)
-  static const currencyEur = PhosphorFlatIconData(0xe554, 'Light');
+  static const currencyEur = IconData(0xe554,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-gbp-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-gbp-light.svg)
-  static const currencyGbp = PhosphorFlatIconData(0xe556, 'Light');
+  static const currencyGbp = IconData(0xe556,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-inr-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-inr-light.svg)
-  static const currencyInr = PhosphorFlatIconData(0xe558, 'Light');
+  static const currencyInr = IconData(0xe558,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-jpy-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-jpy-light.svg)
-  static const currencyJpy = PhosphorFlatIconData(0xe55a, 'Light');
+  static const currencyJpy = IconData(0xe55a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-krw-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-krw-light.svg)
-  static const currencyKrw = PhosphorFlatIconData(0xe55c, 'Light');
+  static const currencyKrw = IconData(0xe55c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-kzt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-kzt-light.svg)
-  static const currencyKzt = PhosphorFlatIconData(0xec4c, 'Light');
+  static const currencyKzt = IconData(0xec4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-ngn-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-ngn-light.svg)
-  static const currencyNgn = PhosphorFlatIconData(0xeb52, 'Light');
+  static const currencyNgn = IconData(0xeb52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-rub-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/currency-rub-light.svg)
-  static const currencyRub = PhosphorFlatIconData(0xe55e, 'Light');
+  static const currencyRub = IconData(0xe55e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cursor-light.svg)
-  static const cursor = PhosphorFlatIconData(0xe1dc, 'Light');
+  static const cursor = IconData(0xe1dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-click-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cursor-click-light.svg)
-  static const cursorClick = PhosphorFlatIconData(0xe7c8, 'Light');
+  static const cursorClick = IconData(0xe7c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-text-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cursor-text-light.svg)
-  static const cursorText = PhosphorFlatIconData(0xe7d8, 'Light');
+  static const cursorText = IconData(0xe7d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cylinder-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/cylinder-light.svg)
-  static const cylinder = PhosphorFlatIconData(0xe8fc, 'Light');
+  static const cylinder = IconData(0xe8fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![database-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/database-light.svg)
-  static const database = PhosphorFlatIconData(0xe1de, 'Light');
+  static const database = IconData(0xe1de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desk-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/desk-light.svg)
-  static const desk = PhosphorFlatIconData(0xed16, 'Light');
+  static const desk = IconData(0xed16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/desktop-light.svg)
-  static const desktop = PhosphorFlatIconData(0xe560, 'Light');
+  static const desktop = IconData(0xe560,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-tower-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/desktop-tower-light.svg)
-  static const desktopTower = PhosphorFlatIconData(0xe562, 'Light');
+  static const desktopTower = IconData(0xe562,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![detective-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/detective-light.svg)
-  static const detective = PhosphorFlatIconData(0xe83e, 'Light');
+  static const detective = IconData(0xe83e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dev-to-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dev-to-logo-light.svg)
-  static const devToLogo = PhosphorFlatIconData(0xed0e, 'Light');
+  static const devToLogo = IconData(0xed0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/device-mobile-light.svg)
-  static const deviceMobile = PhosphorFlatIconData(0xe1e0, 'Light');
+  static const deviceMobile = IconData(0xe1e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-camera-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/device-mobile-camera-light.svg)
-  static const deviceMobileCamera = PhosphorFlatIconData(0xe1e2, 'Light');
+  static const deviceMobileCamera = IconData(0xe1e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/device-mobile-slash-light.svg)
-  static const deviceMobileSlash = PhosphorFlatIconData(0xee46, 'Light');
+  static const deviceMobileSlash = IconData(0xee46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-speaker-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/device-mobile-speaker-light.svg)
-  static const deviceMobileSpeaker = PhosphorFlatIconData(0xe1e4, 'Light');
+  static const deviceMobileSpeaker = IconData(0xe1e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-rotate-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/device-rotate-light.svg)
-  static const deviceRotate = PhosphorFlatIconData(0xedf2, 'Light');
+  static const deviceRotate = IconData(0xedf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/device-tablet-light.svg)
-  static const deviceTablet = PhosphorFlatIconData(0xe1e6, 'Light');
+  static const deviceTablet = IconData(0xe1e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-camera-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/device-tablet-camera-light.svg)
-  static const deviceTabletCamera = PhosphorFlatIconData(0xe1e8, 'Light');
+  static const deviceTabletCamera = IconData(0xe1e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-speaker-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/device-tablet-speaker-light.svg)
-  static const deviceTabletSpeaker = PhosphorFlatIconData(0xe1ea, 'Light');
+  static const deviceTabletSpeaker = IconData(0xe1ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![devices-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/devices-light.svg)
-  static const devices = PhosphorFlatIconData(0xeba4, 'Light');
+  static const devices = IconData(0xeba4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamond-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/diamond-light.svg)
-  static const diamond = PhosphorFlatIconData(0xe1ec, 'Light');
+  static const diamond = IconData(0xe1ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamonds-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/diamonds-four-light.svg)
-  static const diamondsFour = PhosphorFlatIconData(0xe8f4, 'Light');
+  static const diamondsFour = IconData(0xe8f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-five-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dice-five-light.svg)
-  static const diceFive = PhosphorFlatIconData(0xe1ee, 'Light');
+  static const diceFive = IconData(0xe1ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dice-four-light.svg)
-  static const diceFour = PhosphorFlatIconData(0xe1f0, 'Light');
+  static const diceFour = IconData(0xe1f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-one-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dice-one-light.svg)
-  static const diceOne = PhosphorFlatIconData(0xe1f2, 'Light');
+  static const diceOne = IconData(0xe1f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-six-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dice-six-light.svg)
-  static const diceSix = PhosphorFlatIconData(0xe1f4, 'Light');
+  static const diceSix = IconData(0xe1f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dice-three-light.svg)
-  static const diceThree = PhosphorFlatIconData(0xe1f6, 'Light');
+  static const diceThree = IconData(0xe1f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-two-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dice-two-light.svg)
-  static const diceTwo = PhosphorFlatIconData(0xe1f8, 'Light');
+  static const diceTwo = IconData(0xe1f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disc-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/disc-light.svg)
-  static const disc = PhosphorFlatIconData(0xe564, 'Light');
+  static const disc = IconData(0xe564,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disco-ball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/disco-ball-light.svg)
-  static const discoBall = PhosphorFlatIconData(0xed98, 'Light');
+  static const discoBall = IconData(0xed98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![discord-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/discord-logo-light.svg)
-  static const discordLogo = PhosphorFlatIconData(0xe61a, 'Light');
+  static const discordLogo = IconData(0xe61a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![divide-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/divide-light.svg)
-  static const divide = PhosphorFlatIconData(0xe1fa, 'Light');
+  static const divide = IconData(0xe1fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dna-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dna-light.svg)
-  static const dna = PhosphorFlatIconData(0xe924, 'Light');
+  static const dna = IconData(0xe924,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dog-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dog-light.svg)
-  static const dog = PhosphorFlatIconData(0xe74a, 'Light');
+  static const dog = IconData(0xe74a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/door-light.svg)
-  static const door = PhosphorFlatIconData(0xe61c, 'Light');
+  static const door = IconData(0xe61c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/door-open-light.svg)
-  static const doorOpen = PhosphorFlatIconData(0xe7e6, 'Light');
+  static const doorOpen = IconData(0xe7e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dot-light.svg)
-  static const dot = PhosphorFlatIconData(0xecde, 'Light');
+  static const dot = IconData(0xecde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-outline-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dot-outline-light.svg)
-  static const dotOutline = PhosphorFlatIconData(0xece0, 'Light');
+  static const dotOutline = IconData(0xece0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-nine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-nine-light.svg)
-  static const dotsNine = PhosphorFlatIconData(0xe1fc, 'Light');
+  static const dotsNine = IconData(0xe1fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-six-light.svg)
-  static const dotsSix = PhosphorFlatIconData(0xe794, 'Light');
+  static const dotsSix = IconData(0xe794,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-six-vertical-light.svg)
-  static const dotsSixVertical = PhosphorFlatIconData(0xeae2, 'Light');
+  static const dotsSixVertical = IconData(0xeae2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-three-light.svg)
-  static const dotsThree = PhosphorFlatIconData(0xe1fe, 'Light');
+  static const dotsThree = IconData(0xe1fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-three-circle-light.svg)
-  static const dotsThreeCircle = PhosphorFlatIconData(0xe200, 'Light');
+  static const dotsThreeCircle = IconData(0xe200,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-three-circle-vertical-light.svg)
-  static const dotsThreeCircleVertical = PhosphorFlatIconData(0xe202, 'Light');
+  static const dotsThreeCircleVertical = IconData(0xe202,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-three-outline-light.svg)
-  static const dotsThreeOutline = PhosphorFlatIconData(0xe204, 'Light');
+  static const dotsThreeOutline = IconData(0xe204,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-three-outline-vertical-light.svg)
-  static const dotsThreeOutlineVertical = PhosphorFlatIconData(0xe206, 'Light');
+  static const dotsThreeOutlineVertical = IconData(0xe206,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dots-three-vertical-light.svg)
-  static const dotsThreeVertical = PhosphorFlatIconData(0xe208, 'Light');
+  static const dotsThreeVertical = IconData(0xe208,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/download-light.svg)
-  static const download = PhosphorFlatIconData(0xe20a, 'Light');
+  static const download = IconData(0xe20a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/download-simple-light.svg)
-  static const downloadSimple = PhosphorFlatIconData(0xe20c, 'Light');
+  static const downloadSimple = IconData(0xe20c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dress-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dress-light.svg)
-  static const dress = PhosphorFlatIconData(0xea7e, 'Light');
+  static const dress = IconData(0xea7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dresser-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dresser-light.svg)
-  static const dresser = PhosphorFlatIconData(0xe94e, 'Light');
+  static const dresser = IconData(0xe94e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dribbble-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dribbble-logo-light.svg)
-  static const dribbbleLogo = PhosphorFlatIconData(0xe20e, 'Light');
+  static const dribbbleLogo = IconData(0xe20e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drone-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/drone-light.svg)
-  static const drone = PhosphorFlatIconData(0xed74, 'Light');
+  static const drone = IconData(0xed74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/drop-light.svg)
-  static const drop = PhosphorFlatIconData(0xe210, 'Light');
+  static const drop = IconData(0xe210,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/drop-half-light.svg)
-  static const dropHalf = PhosphorFlatIconData(0xe566, 'Light');
+  static const dropHalf = IconData(0xe566,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-bottom-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/drop-half-bottom-light.svg)
-  static const dropHalfBottom = PhosphorFlatIconData(0xeb40, 'Light');
+  static const dropHalfBottom = IconData(0xeb40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/drop-simple-light.svg)
-  static const dropSimple = PhosphorFlatIconData(0xee32, 'Light');
+  static const dropSimple = IconData(0xee32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/drop-slash-light.svg)
-  static const dropSlash = PhosphorFlatIconData(0xe954, 'Light');
+  static const dropSlash = IconData(0xe954,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dropbox-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/dropbox-logo-light.svg)
-  static const dropboxLogo = PhosphorFlatIconData(0xe7d0, 'Light');
+  static const dropboxLogo = IconData(0xe7d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ear-light.svg)
-  static const ear = PhosphorFlatIconData(0xe70c, 'Light');
+  static const ear = IconData(0xe70c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ear-slash-light.svg)
-  static const earSlash = PhosphorFlatIconData(0xe70e, 'Light');
+  static const earSlash = IconData(0xe70e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/egg-light.svg)
-  static const egg = PhosphorFlatIconData(0xe812, 'Light');
+  static const egg = IconData(0xe812,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-crack-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/egg-crack-light.svg)
-  static const eggCrack = PhosphorFlatIconData(0xeb64, 'Light');
+  static const eggCrack = IconData(0xeb64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eject-light.svg)
-  static const eject = PhosphorFlatIconData(0xe212, 'Light');
+  static const eject = IconData(0xe212,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eject-simple-light.svg)
-  static const ejectSimple = PhosphorFlatIconData(0xe6ae, 'Light');
+  static const ejectSimple = IconData(0xe6ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![elevator-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/elevator-light.svg)
-  static const elevator = PhosphorFlatIconData(0xecc0, 'Light');
+  static const elevator = IconData(0xecc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![empty-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/empty-light.svg)
-  static const empty = PhosphorFlatIconData(0xedbc, 'Light');
+  static const empty = IconData(0xedbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![engine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/engine-light.svg)
-  static const engine = PhosphorFlatIconData(0xea80, 'Light');
+  static const engine = IconData(0xea80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/envelope-light.svg)
-  static const envelope = PhosphorFlatIconData(0xe214, 'Light');
+  static const envelope = IconData(0xe214,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/envelope-open-light.svg)
-  static const envelopeOpen = PhosphorFlatIconData(0xe216, 'Light');
+  static const envelopeOpen = IconData(0xe216,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/envelope-simple-light.svg)
-  static const envelopeSimple = PhosphorFlatIconData(0xe218, 'Light');
+  static const envelopeSimple = IconData(0xe218,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/envelope-simple-open-light.svg)
-  static const envelopeSimpleOpen = PhosphorFlatIconData(0xe21a, 'Light');
+  static const envelopeSimpleOpen = IconData(0xe21a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equalizer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/equalizer-light.svg)
-  static const equalizer = PhosphorFlatIconData(0xebbc, 'Light');
+  static const equalizer = IconData(0xebbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equals-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/equals-light.svg)
-  static const equals = PhosphorFlatIconData(0xe21c, 'Light');
+  static const equals = IconData(0xe21c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eraser-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eraser-light.svg)
-  static const eraser = PhosphorFlatIconData(0xe21e, 'Light');
+  static const eraser = IconData(0xe21e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/escalator-down-light.svg)
-  static const escalatorDown = PhosphorFlatIconData(0xecba, 'Light');
+  static const escalatorDown = IconData(0xecba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/escalator-up-light.svg)
-  static const escalatorUp = PhosphorFlatIconData(0xecbc, 'Light');
+  static const escalatorUp = IconData(0xecbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exam-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/exam-light.svg)
-  static const exam = PhosphorFlatIconData(0xe742, 'Light');
+  static const exam = IconData(0xe742,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclamation-mark-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/exclamation-mark-light.svg)
-  static const exclamationMark = PhosphorFlatIconData(0xee44, 'Light');
+  static const exclamationMark = IconData(0xee44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/exclude-light.svg)
-  static const exclude = PhosphorFlatIconData(0xe882, 'Light');
+  static const exclude = IconData(0xe882,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/exclude-square-light.svg)
-  static const excludeSquare = PhosphorFlatIconData(0xe880, 'Light');
+  static const excludeSquare = IconData(0xe880,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![export-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/export-light.svg)
-  static const export = PhosphorFlatIconData(0xeaf0, 'Light');
+  static const export = IconData(0xeaf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eye-light.svg)
-  static const eye = PhosphorFlatIconData(0xe220, 'Light');
+  static const eye = IconData(0xe220,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-closed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eye-closed-light.svg)
-  static const eyeClosed = PhosphorFlatIconData(0xe222, 'Light');
+  static const eyeClosed = IconData(0xe222,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eye-slash-light.svg)
-  static const eyeSlash = PhosphorFlatIconData(0xe224, 'Light');
+  static const eyeSlash = IconData(0xe224,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eyedropper-light.svg)
-  static const eyedropper = PhosphorFlatIconData(0xe568, 'Light');
+  static const eyedropper = IconData(0xe568,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-sample-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eyedropper-sample-light.svg)
-  static const eyedropperSample = PhosphorFlatIconData(0xeac4, 'Light');
+  static const eyedropperSample = IconData(0xeac4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyeglasses-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eyeglasses-light.svg)
-  static const eyeglasses = PhosphorFlatIconData(0xe7ba, 'Light');
+  static const eyeglasses = IconData(0xe7ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyes-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/eyes-light.svg)
-  static const eyes = PhosphorFlatIconData(0xee5c, 'Light');
+  static const eyes = IconData(0xee5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![face-mask-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/face-mask-light.svg)
-  static const faceMask = PhosphorFlatIconData(0xe56a, 'Light');
+  static const faceMask = IconData(0xe56a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![facebook-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/facebook-logo-light.svg)
-  static const facebookLogo = PhosphorFlatIconData(0xe226, 'Light');
+  static const facebookLogo = IconData(0xe226,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![factory-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/factory-light.svg)
-  static const factory = PhosphorFlatIconData(0xe760, 'Light');
+  static const factory = IconData(0xe760,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/faders-light.svg)
-  static const faders = PhosphorFlatIconData(0xe228, 'Light');
+  static const faders = IconData(0xe228,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/faders-horizontal-light.svg)
-  static const fadersHorizontal = PhosphorFlatIconData(0xe22a, 'Light');
+  static const fadersHorizontal = IconData(0xe22a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fallout-shelter-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fallout-shelter-light.svg)
-  static const falloutShelter = PhosphorFlatIconData(0xe9de, 'Light');
+  static const falloutShelter = IconData(0xe9de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fan-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fan-light.svg)
-  static const fan = PhosphorFlatIconData(0xe9f2, 'Light');
+  static const fan = IconData(0xe9f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![farm-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/farm-light.svg)
-  static const farm = PhosphorFlatIconData(0xec70, 'Light');
+  static const farm = IconData(0xec70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fast-forward-light.svg)
-  static const fastForward = PhosphorFlatIconData(0xe6a6, 'Light');
+  static const fastForward = IconData(0xe6a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fast-forward-circle-light.svg)
-  static const fastForwardCircle = PhosphorFlatIconData(0xe22c, 'Light');
+  static const fastForwardCircle = IconData(0xe22c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![feather-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/feather-light.svg)
-  static const feather = PhosphorFlatIconData(0xe9c0, 'Light');
+  static const feather = IconData(0xe9c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fediverse-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fediverse-logo-light.svg)
-  static const fediverseLogo = PhosphorFlatIconData(0xed66, 'Light');
+  static const fediverseLogo = IconData(0xed66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![figma-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/figma-logo-light.svg)
-  static const figmaLogo = PhosphorFlatIconData(0xe22e, 'Light');
+  static const figmaLogo = IconData(0xe22e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-light.svg)
-  static const file = PhosphorFlatIconData(0xe230, 'Light');
+  static const file = IconData(0xe230,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-archive-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-archive-light.svg)
-  static const fileArchive = PhosphorFlatIconData(0xeb2a, 'Light');
+  static const fileArchive = IconData(0xeb2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-arrow-down-light.svg)
-  static const fileArrowDown = PhosphorFlatIconData(0xe232, 'Light');
+  static const fileArrowDown = IconData(0xe232,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-arrow-up-light.svg)
-  static const fileArrowUp = PhosphorFlatIconData(0xe61e, 'Light');
+  static const fileArrowUp = IconData(0xe61e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-audio-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-audio-light.svg)
-  static const fileAudio = PhosphorFlatIconData(0xea20, 'Light');
+  static const fileAudio = IconData(0xea20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-c-light.svg)
-  static const fileC = PhosphorFlatIconData(0xeb32, 'Light');
+  static const fileC = IconData(0xeb32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-sharp-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-c-sharp-light.svg)
-  static const fileCSharp = PhosphorFlatIconData(0xeb30, 'Light');
+  static const fileCSharp = IconData(0xeb30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cloud-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-cloud-light.svg)
-  static const fileCloud = PhosphorFlatIconData(0xe95e, 'Light');
+  static const fileCloud = IconData(0xe95e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-code-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-code-light.svg)
-  static const fileCode = PhosphorFlatIconData(0xe914, 'Light');
+  static const fileCode = IconData(0xe914,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cpp-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-cpp-light.svg)
-  static const fileCpp = PhosphorFlatIconData(0xeb2e, 'Light');
+  static const fileCpp = IconData(0xeb2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-css-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-css-light.svg)
-  static const fileCss = PhosphorFlatIconData(0xeb34, 'Light');
+  static const fileCss = IconData(0xeb34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-csv-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-csv-light.svg)
-  static const fileCsv = PhosphorFlatIconData(0xeb1c, 'Light');
+  static const fileCsv = IconData(0xeb1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-dashed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-dashed-light.svg)
-  static const fileDashed = PhosphorFlatIconData(0xe704, 'Light');
+  static const fileDashed = IconData(0xe704,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-doc-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-doc-light.svg)
-  static const fileDoc = PhosphorFlatIconData(0xeb1e, 'Light');
+  static const fileDoc = IconData(0xeb1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-html-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-html-light.svg)
-  static const fileHtml = PhosphorFlatIconData(0xeb38, 'Light');
+  static const fileHtml = IconData(0xeb38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-image-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-image-light.svg)
-  static const fileImage = PhosphorFlatIconData(0xea24, 'Light');
+  static const fileImage = IconData(0xea24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ini-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-ini-light.svg)
-  static const fileIni = PhosphorFlatIconData(0xeb33, 'Light');
+  static const fileIni = IconData(0xeb33,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jpg-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-jpg-light.svg)
-  static const fileJpg = PhosphorFlatIconData(0xeb1a, 'Light');
+  static const fileJpg = IconData(0xeb1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-js-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-js-light.svg)
-  static const fileJs = PhosphorFlatIconData(0xeb24, 'Light');
+  static const fileJs = IconData(0xeb24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jsx-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-jsx-light.svg)
-  static const fileJsx = PhosphorFlatIconData(0xeb3a, 'Light');
+  static const fileJsx = IconData(0xeb3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-lock-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-lock-light.svg)
-  static const fileLock = PhosphorFlatIconData(0xe95c, 'Light');
+  static const fileLock = IconData(0xe95c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-magnifying-glass-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-magnifying-glass-light.svg)
-  static const fileMagnifyingGlass = PhosphorFlatIconData(0xe238, 'Light');
+  static const fileMagnifyingGlass = IconData(0xe238,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-md-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-md-light.svg)
-  static const fileMd = PhosphorFlatIconData(0xed50, 'Light');
+  static const fileMd = IconData(0xed50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-minus-light.svg)
-  static const fileMinus = PhosphorFlatIconData(0xe234, 'Light');
+  static const fileMinus = IconData(0xe234,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-pdf-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-pdf-light.svg)
-  static const filePdf = PhosphorFlatIconData(0xe702, 'Light');
+  static const filePdf = IconData(0xe702,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-plus-light.svg)
-  static const filePlus = PhosphorFlatIconData(0xe236, 'Light');
+  static const filePlus = IconData(0xe236,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-png-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-png-light.svg)
-  static const filePng = PhosphorFlatIconData(0xeb18, 'Light');
+  static const filePng = IconData(0xeb18,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ppt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-ppt-light.svg)
-  static const filePpt = PhosphorFlatIconData(0xeb20, 'Light');
+  static const filePpt = IconData(0xeb20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-py-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-py-light.svg)
-  static const filePy = PhosphorFlatIconData(0xeb2c, 'Light');
+  static const filePy = IconData(0xeb2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-rs-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-rs-light.svg)
-  static const fileRs = PhosphorFlatIconData(0xeb28, 'Light');
+  static const fileRs = IconData(0xeb28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-sql-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-sql-light.svg)
-  static const fileSql = PhosphorFlatIconData(0xed4e, 'Light');
+  static const fileSql = IconData(0xed4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-svg-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-svg-light.svg)
-  static const fileSvg = PhosphorFlatIconData(0xed08, 'Light');
+  static const fileSvg = IconData(0xed08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-text-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-text-light.svg)
-  static const fileText = PhosphorFlatIconData(0xe23a, 'Light');
+  static const fileText = IconData(0xe23a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ts-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-ts-light.svg)
-  static const fileTs = PhosphorFlatIconData(0xeb26, 'Light');
+  static const fileTs = IconData(0xeb26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-tsx-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-tsx-light.svg)
-  static const fileTsx = PhosphorFlatIconData(0xeb3c, 'Light');
+  static const fileTsx = IconData(0xeb3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-txt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-txt-light.svg)
-  static const fileTxt = PhosphorFlatIconData(0xeb35, 'Light');
+  static const fileTxt = IconData(0xeb35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-video-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-video-light.svg)
-  static const fileVideo = PhosphorFlatIconData(0xea22, 'Light');
+  static const fileVideo = IconData(0xea22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-vue-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-vue-light.svg)
-  static const fileVue = PhosphorFlatIconData(0xeb3e, 'Light');
+  static const fileVue = IconData(0xeb3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-x-light.svg)
-  static const fileX = PhosphorFlatIconData(0xe23c, 'Light');
+  static const fileX = IconData(0xe23c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-xls-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-xls-light.svg)
-  static const fileXls = PhosphorFlatIconData(0xeb22, 'Light');
+  static const fileXls = IconData(0xeb22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-zip-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/file-zip-light.svg)
-  static const fileZip = PhosphorFlatIconData(0xe958, 'Light');
+  static const fileZip = IconData(0xe958,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![files-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/files-light.svg)
-  static const files = PhosphorFlatIconData(0xe710, 'Light');
+  static const files = IconData(0xe710,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-reel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/film-reel-light.svg)
-  static const filmReel = PhosphorFlatIconData(0xe8c0, 'Light');
+  static const filmReel = IconData(0xe8c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-script-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/film-script-light.svg)
-  static const filmScript = PhosphorFlatIconData(0xeb50, 'Light');
+  static const filmScript = IconData(0xeb50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-slate-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/film-slate-light.svg)
-  static const filmSlate = PhosphorFlatIconData(0xe8c2, 'Light');
+  static const filmSlate = IconData(0xe8c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-strip-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/film-strip-light.svg)
-  static const filmStrip = PhosphorFlatIconData(0xe792, 'Light');
+  static const filmStrip = IconData(0xe792,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fingerprint-light.svg)
-  static const fingerprint = PhosphorFlatIconData(0xe23e, 'Light');
+  static const fingerprint = IconData(0xe23e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fingerprint-simple-light.svg)
-  static const fingerprintSimple = PhosphorFlatIconData(0xe240, 'Light');
+  static const fingerprintSimple = IconData(0xe240,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![finn-the-human-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/finn-the-human-light.svg)
-  static const finnTheHuman = PhosphorFlatIconData(0xe56c, 'Light');
+  static const finnTheHuman = IconData(0xe56c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fire-light.svg)
-  static const fire = PhosphorFlatIconData(0xe242, 'Light');
+  static const fire = IconData(0xe242,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-extinguisher-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fire-extinguisher-light.svg)
-  static const fireExtinguisher = PhosphorFlatIconData(0xe9e8, 'Light');
+  static const fireExtinguisher = IconData(0xe9e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fire-simple-light.svg)
-  static const fireSimple = PhosphorFlatIconData(0xe620, 'Light');
+  static const fireSimple = IconData(0xe620,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-truck-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fire-truck-light.svg)
-  static const fireTruck = PhosphorFlatIconData(0xe574, 'Light');
+  static const fireTruck = IconData(0xe574,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/first-aid-light.svg)
-  static const firstAid = PhosphorFlatIconData(0xe56e, 'Light');
+  static const firstAid = IconData(0xe56e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-kit-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/first-aid-kit-light.svg)
-  static const firstAidKit = PhosphorFlatIconData(0xe570, 'Light');
+  static const firstAidKit = IconData(0xe570,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fish-light.svg)
-  static const fish = PhosphorFlatIconData(0xe728, 'Light');
+  static const fish = IconData(0xe728,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fish-simple-light.svg)
-  static const fishSimple = PhosphorFlatIconData(0xe72a, 'Light');
+  static const fishSimple = IconData(0xe72a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flag-light.svg)
-  static const flag = PhosphorFlatIconData(0xe244, 'Light');
+  static const flag = IconData(0xe244,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flag-banner-light.svg)
-  static const flagBanner = PhosphorFlatIconData(0xe622, 'Light');
+  static const flagBanner = IconData(0xe622,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-fold-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flag-banner-fold-light.svg)
-  static const flagBannerFold = PhosphorFlatIconData(0xecf2, 'Light');
+  static const flagBannerFold = IconData(0xecf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-checkered-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flag-checkered-light.svg)
-  static const flagCheckered = PhosphorFlatIconData(0xea38, 'Light');
+  static const flagCheckered = IconData(0xea38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-pennant-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flag-pennant-light.svg)
-  static const flagPennant = PhosphorFlatIconData(0xecf0, 'Light');
+  static const flagPennant = IconData(0xecf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flame-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flame-light.svg)
-  static const flame = PhosphorFlatIconData(0xe624, 'Light');
+  static const flame = IconData(0xe624,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flashlight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flashlight-light.svg)
-  static const flashlight = PhosphorFlatIconData(0xe246, 'Light');
+  static const flashlight = IconData(0xe246,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flask-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flask-light.svg)
-  static const flask = PhosphorFlatIconData(0xe79e, 'Light');
+  static const flask = IconData(0xe79e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flip-horizontal-light.svg)
-  static const flipHorizontal = PhosphorFlatIconData(0xed6a, 'Light');
+  static const flipHorizontal = IconData(0xed6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flip-vertical-light.svg)
-  static const flipVertical = PhosphorFlatIconData(0xed6c, 'Light');
+  static const flipVertical = IconData(0xed6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/floppy-disk-light.svg)
-  static const floppyDisk = PhosphorFlatIconData(0xe248, 'Light');
+  static const floppyDisk = IconData(0xe248,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-back-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/floppy-disk-back-light.svg)
-  static const floppyDiskBack = PhosphorFlatIconData(0xeaf4, 'Light');
+  static const floppyDiskBack = IconData(0xeaf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flow-arrow-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flow-arrow-light.svg)
-  static const flowArrow = PhosphorFlatIconData(0xe6ec, 'Light');
+  static const flowArrow = IconData(0xe6ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flower-light.svg)
-  static const flower = PhosphorFlatIconData(0xe75e, 'Light');
+  static const flower = IconData(0xe75e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-lotus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flower-lotus-light.svg)
-  static const flowerLotus = PhosphorFlatIconData(0xe6cc, 'Light');
+  static const flowerLotus = IconData(0xe6cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-tulip-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flower-tulip-light.svg)
-  static const flowerTulip = PhosphorFlatIconData(0xeacc, 'Light');
+  static const flowerTulip = IconData(0xeacc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flying-saucer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/flying-saucer-light.svg)
-  static const flyingSaucer = PhosphorFlatIconData(0xeb4a, 'Light');
+  static const flyingSaucer = IconData(0xeb4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-light.svg)
-  static const folder = PhosphorFlatIconData(0xe24a, 'Light');
+  static const folder = IconData(0xe24a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-dashed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-dashed-light.svg)
-  static const folderDashed = PhosphorFlatIconData(0xe8f8, 'Light');
+  static const folderDashed = IconData(0xe8f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-lock-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-lock-light.svg)
-  static const folderLock = PhosphorFlatIconData(0xea3c, 'Light');
+  static const folderLock = IconData(0xea3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-minus-light.svg)
-  static const folderMinus = PhosphorFlatIconData(0xe254, 'Light');
+  static const folderMinus = IconData(0xe254,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-open-light.svg)
-  static const folderOpen = PhosphorFlatIconData(0xe256, 'Light');
+  static const folderOpen = IconData(0xe256,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-plus-light.svg)
-  static const folderPlus = PhosphorFlatIconData(0xe258, 'Light');
+  static const folderPlus = IconData(0xe258,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-simple-light.svg)
-  static const folderSimple = PhosphorFlatIconData(0xe25a, 'Light');
+  static const folderSimple = IconData(0xe25a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-dashed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-simple-dashed-light.svg)
-  static const folderSimpleDashed = PhosphorFlatIconData(0xec2a, 'Light');
+  static const folderSimpleDashed = IconData(0xec2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-lock-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-simple-lock-light.svg)
-  static const folderSimpleLock = PhosphorFlatIconData(0xeb5e, 'Light');
+  static const folderSimpleLock = IconData(0xeb5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-simple-minus-light.svg)
-  static const folderSimpleMinus = PhosphorFlatIconData(0xe25c, 'Light');
+  static const folderSimpleMinus = IconData(0xe25c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-simple-plus-light.svg)
-  static const folderSimplePlus = PhosphorFlatIconData(0xe25e, 'Light');
+  static const folderSimplePlus = IconData(0xe25e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-star-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-simple-star-light.svg)
-  static const folderSimpleStar = PhosphorFlatIconData(0xec2e, 'Light');
+  static const folderSimpleStar = IconData(0xec2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-user-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-simple-user-light.svg)
-  static const folderSimpleUser = PhosphorFlatIconData(0xeb60, 'Light');
+  static const folderSimpleUser = IconData(0xeb60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-star-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-star-light.svg)
-  static const folderStar = PhosphorFlatIconData(0xea86, 'Light');
+  static const folderStar = IconData(0xea86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-user-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folder-user-light.svg)
-  static const folderUser = PhosphorFlatIconData(0xeb46, 'Light');
+  static const folderUser = IconData(0xeb46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folders-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/folders-light.svg)
-  static const folders = PhosphorFlatIconData(0xe260, 'Light');
+  static const folders = IconData(0xe260,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/football-light.svg)
-  static const football = PhosphorFlatIconData(0xe718, 'Light');
+  static const football = IconData(0xe718,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-helmet-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/football-helmet-light.svg)
-  static const footballHelmet = PhosphorFlatIconData(0xee4c, 'Light');
+  static const footballHelmet = IconData(0xee4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![footprints-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/footprints-light.svg)
-  static const footprints = PhosphorFlatIconData(0xea88, 'Light');
+  static const footprints = IconData(0xea88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fork-knife-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/fork-knife-light.svg)
-  static const forkKnife = PhosphorFlatIconData(0xe262, 'Light');
+  static const forkKnife = IconData(0xe262,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![four-k-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/four-k-light.svg)
-  static const fourK = PhosphorFlatIconData(0xea5c, 'Light');
+  static const fourK = IconData(0xea5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![frame-corners-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/frame-corners-light.svg)
-  static const frameCorners = PhosphorFlatIconData(0xe626, 'Light');
+  static const frameCorners = IconData(0xe626,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![framer-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/framer-logo-light.svg)
-  static const framerLogo = PhosphorFlatIconData(0xe264, 'Light');
+  static const framerLogo = IconData(0xe264,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![function-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/function-light.svg)
-  static const function = PhosphorFlatIconData(0xebe4, 'Light');
+  static const function = IconData(0xebe4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/funnel-light.svg)
-  static const funnel = PhosphorFlatIconData(0xe266, 'Light');
+  static const funnel = IconData(0xe266,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/funnel-simple-light.svg)
-  static const funnelSimple = PhosphorFlatIconData(0xe268, 'Light');
+  static const funnelSimple = IconData(0xe268,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/funnel-simple-x-light.svg)
-  static const funnelSimpleX = PhosphorFlatIconData(0xe26a, 'Light');
+  static const funnelSimpleX = IconData(0xe26a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/funnel-x-light.svg)
-  static const funnelX = PhosphorFlatIconData(0xe26c, 'Light');
+  static const funnelX = IconData(0xe26c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![game-controller-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/game-controller-light.svg)
-  static const gameController = PhosphorFlatIconData(0xe26e, 'Light');
+  static const gameController = IconData(0xe26e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![garage-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/garage-light.svg)
-  static const garage = PhosphorFlatIconData(0xecd6, 'Light');
+  static const garage = IconData(0xecd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-can-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gas-can-light.svg)
-  static const gasCan = PhosphorFlatIconData(0xe8ce, 'Light');
+  static const gasCan = IconData(0xe8ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-pump-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gas-pump-light.svg)
-  static const gasPump = PhosphorFlatIconData(0xe768, 'Light');
+  static const gasPump = IconData(0xe768,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gauge-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gauge-light.svg)
-  static const gauge = PhosphorFlatIconData(0xe628, 'Light');
+  static const gauge = IconData(0xe628,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gavel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gavel-light.svg)
-  static const gavel = PhosphorFlatIconData(0xea32, 'Light');
+  static const gavel = IconData(0xea32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gear-light.svg)
-  static const gear = PhosphorFlatIconData(0xe270, 'Light');
+  static const gear = IconData(0xe270,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-fine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gear-fine-light.svg)
-  static const gearFine = PhosphorFlatIconData(0xe87c, 'Light');
+  static const gearFine = IconData(0xe87c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-six-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gear-six-light.svg)
-  static const gearSix = PhosphorFlatIconData(0xe272, 'Light');
+  static const gearSix = IconData(0xe272,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-female-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gender-female-light.svg)
-  static const genderFemale = PhosphorFlatIconData(0xe6e0, 'Light');
+  static const genderFemale = IconData(0xe6e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-intersex-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gender-intersex-light.svg)
-  static const genderIntersex = PhosphorFlatIconData(0xe6e6, 'Light');
+  static const genderIntersex = IconData(0xe6e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-male-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gender-male-light.svg)
-  static const genderMale = PhosphorFlatIconData(0xe6e2, 'Light');
+  static const genderMale = IconData(0xe6e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-neuter-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gender-neuter-light.svg)
-  static const genderNeuter = PhosphorFlatIconData(0xe6ea, 'Light');
+  static const genderNeuter = IconData(0xe6ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-nonbinary-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gender-nonbinary-light.svg)
-  static const genderNonbinary = PhosphorFlatIconData(0xe6e4, 'Light');
+  static const genderNonbinary = IconData(0xe6e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-transgender-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gender-transgender-light.svg)
-  static const genderTransgender = PhosphorFlatIconData(0xe6e8, 'Light');
+  static const genderTransgender = IconData(0xe6e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ghost-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ghost-light.svg)
-  static const ghost = PhosphorFlatIconData(0xe62a, 'Light');
+  static const ghost = IconData(0xe62a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gif-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gif-light.svg)
-  static const gif = PhosphorFlatIconData(0xe274, 'Light');
+  static const gif = IconData(0xe274,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gift-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gift-light.svg)
-  static const gift = PhosphorFlatIconData(0xe276, 'Light');
+  static const gift = IconData(0xe276,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-branch-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/git-branch-light.svg)
-  static const gitBranch = PhosphorFlatIconData(0xe278, 'Light');
+  static const gitBranch = IconData(0xe278,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-commit-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/git-commit-light.svg)
-  static const gitCommit = PhosphorFlatIconData(0xe27a, 'Light');
+  static const gitCommit = IconData(0xe27a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-diff-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/git-diff-light.svg)
-  static const gitDiff = PhosphorFlatIconData(0xe27c, 'Light');
+  static const gitDiff = IconData(0xe27c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-fork-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/git-fork-light.svg)
-  static const gitFork = PhosphorFlatIconData(0xe27e, 'Light');
+  static const gitFork = IconData(0xe27e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-merge-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/git-merge-light.svg)
-  static const gitMerge = PhosphorFlatIconData(0xe280, 'Light');
+  static const gitMerge = IconData(0xe280,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-pull-request-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/git-pull-request-light.svg)
-  static const gitPullRequest = PhosphorFlatIconData(0xe282, 'Light');
+  static const gitPullRequest = IconData(0xe282,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![github-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/github-logo-light.svg)
-  static const githubLogo = PhosphorFlatIconData(0xe576, 'Light');
+  static const githubLogo = IconData(0xe576,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gitlab-logo-light.svg)
-  static const gitlabLogo = PhosphorFlatIconData(0xe694, 'Light');
+  static const gitlabLogo = IconData(0xe694,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gitlab-logo-simple-light.svg)
-  static const gitlabLogoSimple = PhosphorFlatIconData(0xe696, 'Light');
+  static const gitlabLogoSimple = IconData(0xe696,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/globe-light.svg)
-  static const globe = PhosphorFlatIconData(0xe288, 'Light');
+  static const globe = IconData(0xe288,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-east-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/globe-hemisphere-east-light.svg)
-  static const globeHemisphereEast = PhosphorFlatIconData(0xe28a, 'Light');
+  static const globeHemisphereEast = IconData(0xe28a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-west-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/globe-hemisphere-west-light.svg)
-  static const globeHemisphereWest = PhosphorFlatIconData(0xe28c, 'Light');
+  static const globeHemisphereWest = IconData(0xe28c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/globe-simple-light.svg)
-  static const globeSimple = PhosphorFlatIconData(0xe28e, 'Light');
+  static const globeSimple = IconData(0xe28e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/globe-simple-x-light.svg)
-  static const globeSimpleX = PhosphorFlatIconData(0xe284, 'Light');
+  static const globeSimpleX = IconData(0xe284,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-stand-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/globe-stand-light.svg)
-  static const globeStand = PhosphorFlatIconData(0xe290, 'Light');
+  static const globeStand = IconData(0xe290,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/globe-x-light.svg)
-  static const globeX = PhosphorFlatIconData(0xe286, 'Light');
+  static const globeX = IconData(0xe286,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goggles-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/goggles-light.svg)
-  static const goggles = PhosphorFlatIconData(0xecb4, 'Light');
+  static const goggles = IconData(0xecb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![golf-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/golf-light.svg)
-  static const golf = PhosphorFlatIconData(0xea3e, 'Light');
+  static const golf = IconData(0xea3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goodreads-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/goodreads-logo-light.svg)
-  static const goodreadsLogo = PhosphorFlatIconData(0xed10, 'Light');
+  static const goodreadsLogo = IconData(0xed10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-cardboard-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/google-cardboard-logo-light.svg)
-  static const googleCardboardLogo = PhosphorFlatIconData(0xe7b6, 'Light');
+  static const googleCardboardLogo = IconData(0xe7b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-chrome-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/google-chrome-logo-light.svg)
-  static const googleChromeLogo = PhosphorFlatIconData(0xe976, 'Light');
+  static const googleChromeLogo = IconData(0xe976,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-drive-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/google-drive-logo-light.svg)
-  static const googleDriveLogo = PhosphorFlatIconData(0xe8f6, 'Light');
+  static const googleDriveLogo = IconData(0xe8f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/google-logo-light.svg)
-  static const googleLogo = PhosphorFlatIconData(0xe292, 'Light');
+  static const googleLogo = IconData(0xe292,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-photos-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/google-photos-logo-light.svg)
-  static const googlePhotosLogo = PhosphorFlatIconData(0xeb92, 'Light');
+  static const googlePhotosLogo = IconData(0xeb92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-play-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/google-play-logo-light.svg)
-  static const googlePlayLogo = PhosphorFlatIconData(0xe294, 'Light');
+  static const googlePlayLogo = IconData(0xe294,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-podcasts-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/google-podcasts-logo-light.svg)
-  static const googlePodcastsLogo = PhosphorFlatIconData(0xeb94, 'Light');
+  static const googlePodcastsLogo = IconData(0xeb94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gps-light.svg)
-  static const gps = PhosphorFlatIconData(0xedd8, 'Light');
+  static const gps = IconData(0xedd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-fix-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gps-fix-light.svg)
-  static const gpsFix = PhosphorFlatIconData(0xedd6, 'Light');
+  static const gpsFix = IconData(0xedd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gps-slash-light.svg)
-  static const gpsSlash = PhosphorFlatIconData(0xedd4, 'Light');
+  static const gpsSlash = IconData(0xedd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gradient-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/gradient-light.svg)
-  static const gradient = PhosphorFlatIconData(0xeb42, 'Light');
+  static const gradient = IconData(0xeb42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graduation-cap-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/graduation-cap-light.svg)
-  static const graduationCap = PhosphorFlatIconData(0xe62c, 'Light');
+  static const graduationCap = IconData(0xe62c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/grains-light.svg)
-  static const grains = PhosphorFlatIconData(0xec68, 'Light');
+  static const grains = IconData(0xec68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/grains-slash-light.svg)
-  static const grainsSlash = PhosphorFlatIconData(0xec6a, 'Light');
+  static const grainsSlash = IconData(0xec6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graph-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/graph-light.svg)
-  static const graph = PhosphorFlatIconData(0xeb58, 'Light');
+  static const graph = IconData(0xeb58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graphics-card-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/graphics-card-light.svg)
-  static const graphicsCard = PhosphorFlatIconData(0xe612, 'Light');
+  static const graphicsCard = IconData(0xe612,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/greater-than-light.svg)
-  static const greaterThan = PhosphorFlatIconData(0xedc4, 'Light');
+  static const greaterThan = IconData(0xedc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-or-equal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/greater-than-or-equal-light.svg)
-  static const greaterThanOrEqual = PhosphorFlatIconData(0xeda2, 'Light');
+  static const greaterThanOrEqual = IconData(0xeda2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/grid-four-light.svg)
-  static const gridFour = PhosphorFlatIconData(0xe296, 'Light');
+  static const gridFour = IconData(0xe296,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-nine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/grid-nine-light.svg)
-  static const gridNine = PhosphorFlatIconData(0xec8c, 'Light');
+  static const gridNine = IconData(0xec8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![guitar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/guitar-light.svg)
-  static const guitar = PhosphorFlatIconData(0xea8a, 'Light');
+  static const guitar = IconData(0xea8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hair-dryer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hair-dryer-light.svg)
-  static const hairDryer = PhosphorFlatIconData(0xea66, 'Light');
+  static const hairDryer = IconData(0xea66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hamburger-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hamburger-light.svg)
-  static const hamburger = PhosphorFlatIconData(0xe790, 'Light');
+  static const hamburger = IconData(0xe790,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hammer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hammer-light.svg)
-  static const hammer = PhosphorFlatIconData(0xe80e, 'Light');
+  static const hammer = IconData(0xe80e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-light.svg)
-  static const hand = PhosphorFlatIconData(0xe298, 'Light');
+  static const hand = IconData(0xe298,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-arrow-down-light.svg)
-  static const handArrowDown = PhosphorFlatIconData(0xea4e, 'Light');
+  static const handArrowDown = IconData(0xea4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-arrow-up-light.svg)
-  static const handArrowUp = PhosphorFlatIconData(0xee5a, 'Light');
+  static const handArrowUp = IconData(0xee5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-coins-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-coins-light.svg)
-  static const handCoins = PhosphorFlatIconData(0xea8c, 'Light');
+  static const handCoins = IconData(0xea8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-deposit-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-deposit-light.svg)
-  static const handDeposit = PhosphorFlatIconData(0xee82, 'Light');
+  static const handDeposit = IconData(0xee82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-eye-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-eye-light.svg)
-  static const handEye = PhosphorFlatIconData(0xea4c, 'Light');
+  static const handEye = IconData(0xea4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-fist-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-fist-light.svg)
-  static const handFist = PhosphorFlatIconData(0xe57a, 'Light');
+  static const handFist = IconData(0xe57a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-grabbing-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-grabbing-light.svg)
-  static const handGrabbing = PhosphorFlatIconData(0xe57c, 'Light');
+  static const handGrabbing = IconData(0xe57c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-heart-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-heart-light.svg)
-  static const handHeart = PhosphorFlatIconData(0xe810, 'Light');
+  static const handHeart = IconData(0xe810,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-palm-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-palm-light.svg)
-  static const handPalm = PhosphorFlatIconData(0xe57e, 'Light');
+  static const handPalm = IconData(0xe57e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-peace-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-peace-light.svg)
-  static const handPeace = PhosphorFlatIconData(0xe7cc, 'Light');
+  static const handPeace = IconData(0xe7cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-pointing-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-pointing-light.svg)
-  static const handPointing = PhosphorFlatIconData(0xe29a, 'Light');
+  static const handPointing = IconData(0xe29a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-soap-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-soap-light.svg)
-  static const handSoap = PhosphorFlatIconData(0xe630, 'Light');
+  static const handSoap = IconData(0xe630,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-swipe-left-light.svg)
-  static const handSwipeLeft = PhosphorFlatIconData(0xec94, 'Light');
+  static const handSwipeLeft = IconData(0xec94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-swipe-right-light.svg)
-  static const handSwipeRight = PhosphorFlatIconData(0xec92, 'Light');
+  static const handSwipeRight = IconData(0xec92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-tap-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-tap-light.svg)
-  static const handTap = PhosphorFlatIconData(0xec90, 'Light');
+  static const handTap = IconData(0xec90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-waving-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-waving-light.svg)
-  static const handWaving = PhosphorFlatIconData(0xe580, 'Light');
+  static const handWaving = IconData(0xe580,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-withdraw-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hand-withdraw-light.svg)
-  static const handWithdraw = PhosphorFlatIconData(0xee80, 'Light');
+  static const handWithdraw = IconData(0xee80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/handbag-light.svg)
-  static const handbag = PhosphorFlatIconData(0xe29c, 'Light');
+  static const handbag = IconData(0xe29c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/handbag-simple-light.svg)
-  static const handbagSimple = PhosphorFlatIconData(0xe62e, 'Light');
+  static const handbagSimple = IconData(0xe62e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-clapping-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hands-clapping-light.svg)
-  static const handsClapping = PhosphorFlatIconData(0xe6a0, 'Light');
+  static const handsClapping = IconData(0xe6a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-praying-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hands-praying-light.svg)
-  static const handsPraying = PhosphorFlatIconData(0xecc8, 'Light');
+  static const handsPraying = IconData(0xecc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handshake-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/handshake-light.svg)
-  static const handshake = PhosphorFlatIconData(0xe582, 'Light');
+  static const handshake = IconData(0xe582,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drive-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hard-drive-light.svg)
-  static const hardDrive = PhosphorFlatIconData(0xe29e, 'Light');
+  static const hardDrive = IconData(0xe29e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drives-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hard-drives-light.svg)
-  static const hardDrives = PhosphorFlatIconData(0xe2a0, 'Light');
+  static const hardDrives = IconData(0xe2a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-hat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hard-hat-light.svg)
-  static const hardHat = PhosphorFlatIconData(0xed46, 'Light');
+  static const hardHat = IconData(0xed46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hash-light.svg)
-  static const hash = PhosphorFlatIconData(0xe2a2, 'Light');
+  static const hash = IconData(0xe2a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-straight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hash-straight-light.svg)
-  static const hashStraight = PhosphorFlatIconData(0xe2a4, 'Light');
+  static const hashStraight = IconData(0xe2a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![head-circuit-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/head-circuit-light.svg)
-  static const headCircuit = PhosphorFlatIconData(0xe7d4, 'Light');
+  static const headCircuit = IconData(0xe7d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headlights-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/headlights-light.svg)
-  static const headlights = PhosphorFlatIconData(0xe6fe, 'Light');
+  static const headlights = IconData(0xe6fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headphones-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/headphones-light.svg)
-  static const headphones = PhosphorFlatIconData(0xe2a6, 'Light');
+  static const headphones = IconData(0xe2a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headset-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/headset-light.svg)
-  static const headset = PhosphorFlatIconData(0xe584, 'Light');
+  static const headset = IconData(0xe584,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/heart-light.svg)
-  static const heart = PhosphorFlatIconData(0xe2a8, 'Light');
+  static const heart = IconData(0xe2a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-break-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/heart-break-light.svg)
-  static const heartBreak = PhosphorFlatIconData(0xebe8, 'Light');
+  static const heartBreak = IconData(0xebe8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-half-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/heart-half-light.svg)
-  static const heartHalf = PhosphorFlatIconData(0xec48, 'Light');
+  static const heartHalf = IconData(0xec48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/heart-straight-light.svg)
-  static const heartStraight = PhosphorFlatIconData(0xe2aa, 'Light');
+  static const heartStraight = IconData(0xe2aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-break-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/heart-straight-break-light.svg)
-  static const heartStraightBreak = PhosphorFlatIconData(0xeb98, 'Light');
+  static const heartStraightBreak = IconData(0xeb98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heartbeat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/heartbeat-light.svg)
-  static const heartbeat = PhosphorFlatIconData(0xe2ac, 'Light');
+  static const heartbeat = IconData(0xe2ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hexagon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hexagon-light.svg)
-  static const hexagon = PhosphorFlatIconData(0xe2ae, 'Light');
+  static const hexagon = IconData(0xe2ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-definition-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/high-definition-light.svg)
-  static const highDefinition = PhosphorFlatIconData(0xea8e, 'Light');
+  static const highDefinition = IconData(0xea8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-heel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/high-heel-light.svg)
-  static const highHeel = PhosphorFlatIconData(0xe8e8, 'Light');
+  static const highHeel = IconData(0xe8e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/highlighter-light.svg)
-  static const highlighter = PhosphorFlatIconData(0xec76, 'Light');
+  static const highlighter = IconData(0xec76,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/highlighter-circle-light.svg)
-  static const highlighterCircle = PhosphorFlatIconData(0xe632, 'Light');
+  static const highlighterCircle = IconData(0xe632,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hockey-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hockey-light.svg)
-  static const hockey = PhosphorFlatIconData(0xec86, 'Light');
+  static const hockey = IconData(0xec86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hoodie-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hoodie-light.svg)
-  static const hoodie = PhosphorFlatIconData(0xecd0, 'Light');
+  static const hoodie = IconData(0xecd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![horse-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/horse-light.svg)
-  static const horse = PhosphorFlatIconData(0xe2b0, 'Light');
+  static const horse = IconData(0xe2b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hospital-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hospital-light.svg)
-  static const hospital = PhosphorFlatIconData(0xe844, 'Light');
+  static const hospital = IconData(0xe844,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hourglass-light.svg)
-  static const hourglass = PhosphorFlatIconData(0xe2b2, 'Light');
+  static const hourglass = IconData(0xe2b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-high-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hourglass-high-light.svg)
-  static const hourglassHigh = PhosphorFlatIconData(0xe2b4, 'Light');
+  static const hourglassHigh = IconData(0xe2b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-low-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hourglass-low-light.svg)
-  static const hourglassLow = PhosphorFlatIconData(0xe2b6, 'Light');
+  static const hourglassLow = IconData(0xe2b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-medium-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hourglass-medium-light.svg)
-  static const hourglassMedium = PhosphorFlatIconData(0xe2b8, 'Light');
+  static const hourglassMedium = IconData(0xe2b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hourglass-simple-light.svg)
-  static const hourglassSimple = PhosphorFlatIconData(0xe2ba, 'Light');
+  static const hourglassSimple = IconData(0xe2ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-high-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hourglass-simple-high-light.svg)
-  static const hourglassSimpleHigh = PhosphorFlatIconData(0xe2bc, 'Light');
+  static const hourglassSimpleHigh = IconData(0xe2bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-low-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hourglass-simple-low-light.svg)
-  static const hourglassSimpleLow = PhosphorFlatIconData(0xe2be, 'Light');
+  static const hourglassSimpleLow = IconData(0xe2be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-medium-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hourglass-simple-medium-light.svg)
-  static const hourglassSimpleMedium = PhosphorFlatIconData(0xe2c0, 'Light');
+  static const hourglassSimpleMedium = IconData(0xe2c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/house-light.svg)
-  static const house = PhosphorFlatIconData(0xe2c2, 'Light');
+  static const house = IconData(0xe2c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-line-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/house-line-light.svg)
-  static const houseLine = PhosphorFlatIconData(0xe2c4, 'Light');
+  static const houseLine = IconData(0xe2c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/house-simple-light.svg)
-  static const houseSimple = PhosphorFlatIconData(0xe2c6, 'Light');
+  static const houseSimple = IconData(0xe2c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hurricane-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/hurricane-light.svg)
-  static const hurricane = PhosphorFlatIconData(0xe88e, 'Light');
+  static const hurricane = IconData(0xe88e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ice-cream-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ice-cream-light.svg)
-  static const iceCream = PhosphorFlatIconData(0xe804, 'Light');
+  static const iceCream = IconData(0xe804,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-badge-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/identification-badge-light.svg)
-  static const identificationBadge = PhosphorFlatIconData(0xe6f6, 'Light');
+  static const identificationBadge = IconData(0xe6f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-card-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/identification-card-light.svg)
-  static const identificationCard = PhosphorFlatIconData(0xe2c8, 'Light');
+  static const identificationCard = IconData(0xe2c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/image-light.svg)
-  static const image = PhosphorFlatIconData(0xe2ca, 'Light');
+  static const image = IconData(0xe2ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-broken-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/image-broken-light.svg)
-  static const imageBroken = PhosphorFlatIconData(0xe7a8, 'Light');
+  static const imageBroken = IconData(0xe7a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/image-square-light.svg)
-  static const imageSquare = PhosphorFlatIconData(0xe2cc, 'Light');
+  static const imageSquare = IconData(0xe2cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/images-light.svg)
-  static const images = PhosphorFlatIconData(0xe836, 'Light');
+  static const images = IconData(0xe836,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/images-square-light.svg)
-  static const imagesSquare = PhosphorFlatIconData(0xe834, 'Light');
+  static const imagesSquare = IconData(0xe834,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![infinity-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/infinity-light.svg)
-  static const infinity = PhosphorFlatIconData(0xe634, 'Light');
+  static const infinity = IconData(0xe634,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![info-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/info-light.svg)
-  static const info = PhosphorFlatIconData(0xe2ce, 'Light');
+  static const info = IconData(0xe2ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![instagram-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/instagram-logo-light.svg)
-  static const instagramLogo = PhosphorFlatIconData(0xe2d0, 'Light');
+  static const instagramLogo = IconData(0xe2d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/intersect-light.svg)
-  static const intersect = PhosphorFlatIconData(0xe2d2, 'Light');
+  static const intersect = IconData(0xe2d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/intersect-square-light.svg)
-  static const intersectSquare = PhosphorFlatIconData(0xe87a, 'Light');
+  static const intersectSquare = IconData(0xe87a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/intersect-three-light.svg)
-  static const intersectThree = PhosphorFlatIconData(0xecc4, 'Light');
+  static const intersectThree = IconData(0xecc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersection-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/intersection-light.svg)
-  static const intersection = PhosphorFlatIconData(0xedba, 'Light');
+  static const intersection = IconData(0xedba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![invoice-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/invoice-light.svg)
-  static const invoice = PhosphorFlatIconData(0xee42, 'Light');
+  static const invoice = IconData(0xee42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![island-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/island-light.svg)
-  static const island = PhosphorFlatIconData(0xee06, 'Light');
+  static const island = IconData(0xee06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/jar-light.svg)
-  static const jar = PhosphorFlatIconData(0xe7e0, 'Light');
+  static const jar = IconData(0xe7e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-label-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/jar-label-light.svg)
-  static const jarLabel = PhosphorFlatIconData(0xe7e1, 'Light');
+  static const jarLabel = IconData(0xe7e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jeep-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/jeep-light.svg)
-  static const jeep = PhosphorFlatIconData(0xe2d4, 'Light');
+  static const jeep = IconData(0xe2d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![joystick-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/joystick-light.svg)
-  static const joystick = PhosphorFlatIconData(0xea5e, 'Light');
+  static const joystick = IconData(0xea5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![kanban-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/kanban-light.svg)
-  static const kanban = PhosphorFlatIconData(0xeb54, 'Light');
+  static const kanban = IconData(0xeb54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/key-light.svg)
-  static const key = PhosphorFlatIconData(0xe2d6, 'Light');
+  static const key = IconData(0xe2d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-return-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/key-return-light.svg)
-  static const keyReturn = PhosphorFlatIconData(0xe782, 'Light');
+  static const keyReturn = IconData(0xe782,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyboard-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/keyboard-light.svg)
-  static const keyboard = PhosphorFlatIconData(0xe2d8, 'Light');
+  static const keyboard = IconData(0xe2d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyhole-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/keyhole-light.svg)
-  static const keyhole = PhosphorFlatIconData(0xea78, 'Light');
+  static const keyhole = IconData(0xea78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![knife-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/knife-light.svg)
-  static const knife = PhosphorFlatIconData(0xe636, 'Light');
+  static const knife = IconData(0xe636,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ladder-light.svg)
-  static const ladder = PhosphorFlatIconData(0xe9e4, 'Light');
+  static const ladder = IconData(0xe9e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ladder-simple-light.svg)
-  static const ladderSimple = PhosphorFlatIconData(0xec26, 'Light');
+  static const ladderSimple = IconData(0xec26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lamp-light.svg)
-  static const lamp = PhosphorFlatIconData(0xe638, 'Light');
+  static const lamp = IconData(0xe638,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-pendant-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lamp-pendant-light.svg)
-  static const lampPendant = PhosphorFlatIconData(0xee2e, 'Light');
+  static const lampPendant = IconData(0xee2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![laptop-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/laptop-light.svg)
-  static const laptop = PhosphorFlatIconData(0xe586, 'Light');
+  static const laptop = IconData(0xe586,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lasso-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lasso-light.svg)
-  static const lasso = PhosphorFlatIconData(0xedc6, 'Light');
+  static const lasso = IconData(0xedc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lastfm-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lastfm-logo-light.svg)
-  static const lastfmLogo = PhosphorFlatIconData(0xe842, 'Light');
+  static const lastfmLogo = IconData(0xe842,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![layout-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/layout-light.svg)
-  static const layout = PhosphorFlatIconData(0xe6d6, 'Light');
+  static const layout = IconData(0xe6d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![leaf-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/leaf-light.svg)
-  static const leaf = PhosphorFlatIconData(0xe2da, 'Light');
+  static const leaf = IconData(0xe2da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lectern-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lectern-light.svg)
-  static const lectern = PhosphorFlatIconData(0xe95a, 'Light');
+  static const lectern = IconData(0xe95a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lego-light.svg)
-  static const lego = PhosphorFlatIconData(0xe8c6, 'Light');
+  static const lego = IconData(0xe8c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-smiley-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lego-smiley-light.svg)
-  static const legoSmiley = PhosphorFlatIconData(0xe8c7, 'Light');
+  static const legoSmiley = IconData(0xe8c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/less-than-light.svg)
-  static const lessThan = PhosphorFlatIconData(0xedac, 'Light');
+  static const lessThan = IconData(0xedac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-or-equal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/less-than-or-equal-light.svg)
-  static const lessThanOrEqual = PhosphorFlatIconData(0xeda4, 'Light');
+  static const lessThanOrEqual = IconData(0xeda4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-h-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/letter-circle-h-light.svg)
-  static const letterCircleH = PhosphorFlatIconData(0xebf8, 'Light');
+  static const letterCircleH = IconData(0xebf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-p-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/letter-circle-p-light.svg)
-  static const letterCircleP = PhosphorFlatIconData(0xec08, 'Light');
+  static const letterCircleP = IconData(0xec08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-v-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/letter-circle-v-light.svg)
-  static const letterCircleV = PhosphorFlatIconData(0xec14, 'Light');
+  static const letterCircleV = IconData(0xec14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lifebuoy-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lifebuoy-light.svg)
-  static const lifebuoy = PhosphorFlatIconData(0xe63a, 'Light');
+  static const lifebuoy = IconData(0xe63a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lightbulb-light.svg)
-  static const lightbulb = PhosphorFlatIconData(0xe2dc, 'Light');
+  static const lightbulb = IconData(0xe2dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-filament-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lightbulb-filament-light.svg)
-  static const lightbulbFilament = PhosphorFlatIconData(0xe63c, 'Light');
+  static const lightbulbFilament = IconData(0xe63c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lighthouse-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lighthouse-light.svg)
-  static const lighthouse = PhosphorFlatIconData(0xe9f6, 'Light');
+  static const lighthouse = IconData(0xe9f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lightning-light.svg)
-  static const lightning = PhosphorFlatIconData(0xe2de, 'Light');
+  static const lightning = IconData(0xe2de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-a-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lightning-a-light.svg)
-  static const lightningA = PhosphorFlatIconData(0xea84, 'Light');
+  static const lightningA = IconData(0xea84,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lightning-slash-light.svg)
-  static const lightningSlash = PhosphorFlatIconData(0xe2e0, 'Light');
+  static const lightningSlash = IconData(0xe2e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segment-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/line-segment-light.svg)
-  static const lineSegment = PhosphorFlatIconData(0xe6d2, 'Light');
+  static const lineSegment = IconData(0xe6d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segments-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/line-segments-light.svg)
-  static const lineSegments = PhosphorFlatIconData(0xe6d4, 'Light');
+  static const lineSegments = IconData(0xe6d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/line-vertical-light.svg)
-  static const lineVertical = PhosphorFlatIconData(0xed70, 'Light');
+  static const lineVertical = IconData(0xed70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/link-light.svg)
-  static const link = PhosphorFlatIconData(0xe2e2, 'Light');
+  static const link = IconData(0xe2e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-break-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/link-break-light.svg)
-  static const linkBreak = PhosphorFlatIconData(0xe2e4, 'Light');
+  static const linkBreak = IconData(0xe2e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/link-simple-light.svg)
-  static const linkSimple = PhosphorFlatIconData(0xe2e6, 'Light');
+  static const linkSimple = IconData(0xe2e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-break-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/link-simple-break-light.svg)
-  static const linkSimpleBreak = PhosphorFlatIconData(0xe2e8, 'Light');
+  static const linkSimpleBreak = IconData(0xe2e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/link-simple-horizontal-light.svg)
-  static const linkSimpleHorizontal = PhosphorFlatIconData(0xe2ea, 'Light');
+  static const linkSimpleHorizontal = IconData(0xe2ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-break-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/link-simple-horizontal-break-light.svg)
-  static const linkSimpleHorizontalBreak =
-      PhosphorFlatIconData(0xe2ec, 'Light');
+  static const linkSimpleHorizontalBreak = IconData(0xe2ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linkedin-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/linkedin-logo-light.svg)
-  static const linkedinLogo = PhosphorFlatIconData(0xe2ee, 'Light');
+  static const linkedinLogo = IconData(0xe2ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linktree-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/linktree-logo-light.svg)
-  static const linktreeLogo = PhosphorFlatIconData(0xedee, 'Light');
+  static const linktreeLogo = IconData(0xedee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linux-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/linux-logo-light.svg)
-  static const linuxLogo = PhosphorFlatIconData(0xeb02, 'Light');
+  static const linuxLogo = IconData(0xeb02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-light.svg)
-  static const list = PhosphorFlatIconData(0xe2f0, 'Light');
+  static const list = IconData(0xe2f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-bullets-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-bullets-light.svg)
-  static const listBullets = PhosphorFlatIconData(0xe2f2, 'Light');
+  static const listBullets = IconData(0xe2f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-checks-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-checks-light.svg)
-  static const listChecks = PhosphorFlatIconData(0xeadc, 'Light');
+  static const listChecks = IconData(0xeadc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-dashes-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-dashes-light.svg)
-  static const listDashes = PhosphorFlatIconData(0xe2f4, 'Light');
+  static const listDashes = IconData(0xe2f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-heart-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-heart-light.svg)
-  static const listHeart = PhosphorFlatIconData(0xebde, 'Light');
+  static const listHeart = IconData(0xebde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-magnifying-glass-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-magnifying-glass-light.svg)
-  static const listMagnifyingGlass = PhosphorFlatIconData(0xebe0, 'Light');
+  static const listMagnifyingGlass = IconData(0xebe0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-numbers-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-numbers-light.svg)
-  static const listNumbers = PhosphorFlatIconData(0xe2f6, 'Light');
+  static const listNumbers = IconData(0xe2f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-plus-light.svg)
-  static const listPlus = PhosphorFlatIconData(0xe2f8, 'Light');
+  static const listPlus = IconData(0xe2f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-star-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/list-star-light.svg)
-  static const listStar = PhosphorFlatIconData(0xebdc, 'Light');
+  static const listStar = IconData(0xebdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lock-light.svg)
-  static const lock = PhosphorFlatIconData(0xe2fa, 'Light');
+  static const lock = IconData(0xe2fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lock-key-light.svg)
-  static const lockKey = PhosphorFlatIconData(0xe2fe, 'Light');
+  static const lockKey = IconData(0xe2fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lock-key-open-light.svg)
-  static const lockKeyOpen = PhosphorFlatIconData(0xe300, 'Light');
+  static const lockKeyOpen = IconData(0xe300,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lock-laminated-light.svg)
-  static const lockLaminated = PhosphorFlatIconData(0xe302, 'Light');
+  static const lockLaminated = IconData(0xe302,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lock-laminated-open-light.svg)
-  static const lockLaminatedOpen = PhosphorFlatIconData(0xe304, 'Light');
+  static const lockLaminatedOpen = IconData(0xe304,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lock-open-light.svg)
-  static const lockOpen = PhosphorFlatIconData(0xe306, 'Light');
+  static const lockOpen = IconData(0xe306,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lock-simple-light.svg)
-  static const lockSimple = PhosphorFlatIconData(0xe308, 'Light');
+  static const lockSimple = IconData(0xe308,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lock-simple-open-light.svg)
-  static const lockSimpleOpen = PhosphorFlatIconData(0xe30a, 'Light');
+  static const lockSimpleOpen = IconData(0xe30a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lockers-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/lockers-light.svg)
-  static const lockers = PhosphorFlatIconData(0xecb8, 'Light');
+  static const lockers = IconData(0xecb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![log-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/log-light.svg)
-  static const log = PhosphorFlatIconData(0xed82, 'Light');
+  static const log = IconData(0xed82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magic-wand-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/magic-wand-light.svg)
-  static const magicWand = PhosphorFlatIconData(0xe6b6, 'Light');
+  static const magicWand = IconData(0xe6b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/magnet-light.svg)
-  static const magnet = PhosphorFlatIconData(0xe680, 'Light');
+  static const magnet = IconData(0xe680,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-straight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/magnet-straight-light.svg)
-  static const magnetStraight = PhosphorFlatIconData(0xe682, 'Light');
+  static const magnetStraight = IconData(0xe682,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/magnifying-glass-light.svg)
-  static const magnifyingGlass = PhosphorFlatIconData(0xe30c, 'Light');
+  static const magnifyingGlass = IconData(0xe30c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/magnifying-glass-minus-light.svg)
-  static const magnifyingGlassMinus = PhosphorFlatIconData(0xe30e, 'Light');
+  static const magnifyingGlassMinus = IconData(0xe30e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/magnifying-glass-plus-light.svg)
-  static const magnifyingGlassPlus = PhosphorFlatIconData(0xe310, 'Light');
+  static const magnifyingGlassPlus = IconData(0xe310,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mailbox-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mailbox-light.svg)
-  static const mailbox = PhosphorFlatIconData(0xec1e, 'Light');
+  static const mailbox = IconData(0xec1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/map-pin-light.svg)
-  static const mapPin = PhosphorFlatIconData(0xe316, 'Light');
+  static const mapPin = IconData(0xe316,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-area-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/map-pin-area-light.svg)
-  static const mapPinArea = PhosphorFlatIconData(0xee3a, 'Light');
+  static const mapPinArea = IconData(0xee3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-line-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/map-pin-line-light.svg)
-  static const mapPinLine = PhosphorFlatIconData(0xe318, 'Light');
+  static const mapPinLine = IconData(0xe318,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/map-pin-plus-light.svg)
-  static const mapPinPlus = PhosphorFlatIconData(0xe314, 'Light');
+  static const mapPinPlus = IconData(0xe314,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/map-pin-simple-light.svg)
-  static const mapPinSimple = PhosphorFlatIconData(0xee3e, 'Light');
+  static const mapPinSimple = IconData(0xee3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-area-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/map-pin-simple-area-light.svg)
-  static const mapPinSimpleArea = PhosphorFlatIconData(0xee3c, 'Light');
+  static const mapPinSimpleArea = IconData(0xee3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-line-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/map-pin-simple-line-light.svg)
-  static const mapPinSimpleLine = PhosphorFlatIconData(0xee38, 'Light');
+  static const mapPinSimpleLine = IconData(0xee38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-trifold-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/map-trifold-light.svg)
-  static const mapTrifold = PhosphorFlatIconData(0xe31a, 'Light');
+  static const mapTrifold = IconData(0xe31a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![markdown-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/markdown-logo-light.svg)
-  static const markdownLogo = PhosphorFlatIconData(0xe508, 'Light');
+  static const markdownLogo = IconData(0xe508,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![marker-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/marker-circle-light.svg)
-  static const markerCircle = PhosphorFlatIconData(0xe640, 'Light');
+  static const markerCircle = IconData(0xe640,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![martini-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/martini-light.svg)
-  static const martini = PhosphorFlatIconData(0xe31c, 'Light');
+  static const martini = IconData(0xe31c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-happy-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mask-happy-light.svg)
-  static const maskHappy = PhosphorFlatIconData(0xe9f4, 'Light');
+  static const maskHappy = IconData(0xe9f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-sad-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mask-sad-light.svg)
-  static const maskSad = PhosphorFlatIconData(0xeb9e, 'Light');
+  static const maskSad = IconData(0xeb9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mastodon-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mastodon-logo-light.svg)
-  static const mastodonLogo = PhosphorFlatIconData(0xed68, 'Light');
+  static const mastodonLogo = IconData(0xed68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![math-operations-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/math-operations-light.svg)
-  static const mathOperations = PhosphorFlatIconData(0xe31e, 'Light');
+  static const mathOperations = IconData(0xe31e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![matrix-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/matrix-logo-light.svg)
-  static const matrixLogo = PhosphorFlatIconData(0xed64, 'Light');
+  static const matrixLogo = IconData(0xed64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/medal-light.svg)
-  static const medal = PhosphorFlatIconData(0xe320, 'Light');
+  static const medal = IconData(0xe320,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-military-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/medal-military-light.svg)
-  static const medalMilitary = PhosphorFlatIconData(0xecfc, 'Light');
+  static const medalMilitary = IconData(0xecfc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medium-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/medium-logo-light.svg)
-  static const mediumLogo = PhosphorFlatIconData(0xe322, 'Light');
+  static const mediumLogo = IconData(0xe322,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/megaphone-light.svg)
-  static const megaphone = PhosphorFlatIconData(0xe324, 'Light');
+  static const megaphone = IconData(0xe324,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/megaphone-simple-light.svg)
-  static const megaphoneSimple = PhosphorFlatIconData(0xe642, 'Light');
+  static const megaphoneSimple = IconData(0xe642,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![member-of-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/member-of-light.svg)
-  static const memberOf = PhosphorFlatIconData(0xedc2, 'Light');
+  static const memberOf = IconData(0xedc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![memory-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/memory-light.svg)
-  static const memory = PhosphorFlatIconData(0xe9c4, 'Light');
+  static const memory = IconData(0xe9c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![messenger-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/messenger-logo-light.svg)
-  static const messengerLogo = PhosphorFlatIconData(0xe6d8, 'Light');
+  static const messengerLogo = IconData(0xe6d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meta-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/meta-logo-light.svg)
-  static const metaLogo = PhosphorFlatIconData(0xed02, 'Light');
+  static const metaLogo = IconData(0xed02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meteor-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/meteor-light.svg)
-  static const meteor = PhosphorFlatIconData(0xe9ba, 'Light');
+  static const meteor = IconData(0xe9ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![metronome-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/metronome-light.svg)
-  static const metronome = PhosphorFlatIconData(0xec8e, 'Light');
+  static const metronome = IconData(0xec8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microphone-light.svg)
-  static const microphone = PhosphorFlatIconData(0xe326, 'Light');
+  static const microphone = IconData(0xe326,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microphone-slash-light.svg)
-  static const microphoneSlash = PhosphorFlatIconData(0xe328, 'Light');
+  static const microphoneSlash = IconData(0xe328,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-stage-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microphone-stage-light.svg)
-  static const microphoneStage = PhosphorFlatIconData(0xe75c, 'Light');
+  static const microphoneStage = IconData(0xe75c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microscope-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microscope-light.svg)
-  static const microscope = PhosphorFlatIconData(0xec7a, 'Light');
+  static const microscope = IconData(0xec7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-excel-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microsoft-excel-logo-light.svg)
-  static const microsoftExcelLogo = PhosphorFlatIconData(0xeb6c, 'Light');
+  static const microsoftExcelLogo = IconData(0xeb6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-outlook-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microsoft-outlook-logo-light.svg)
-  static const microsoftOutlookLogo = PhosphorFlatIconData(0xeb70, 'Light');
+  static const microsoftOutlookLogo = IconData(0xeb70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-powerpoint-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microsoft-powerpoint-logo-light.svg)
-  static const microsoftPowerpointLogo = PhosphorFlatIconData(0xeace, 'Light');
+  static const microsoftPowerpointLogo = IconData(0xeace,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-teams-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microsoft-teams-logo-light.svg)
-  static const microsoftTeamsLogo = PhosphorFlatIconData(0xeb66, 'Light');
+  static const microsoftTeamsLogo = IconData(0xeb66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-word-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/microsoft-word-logo-light.svg)
-  static const microsoftWordLogo = PhosphorFlatIconData(0xeb6a, 'Light');
+  static const microsoftWordLogo = IconData(0xeb6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/minus-light.svg)
-  static const minus = PhosphorFlatIconData(0xe32a, 'Light');
+  static const minus = IconData(0xe32a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/minus-circle-light.svg)
-  static const minusCircle = PhosphorFlatIconData(0xe32c, 'Light');
+  static const minusCircle = IconData(0xe32c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/minus-square-light.svg)
-  static const minusSquare = PhosphorFlatIconData(0xed4c, 'Light');
+  static const minusSquare = IconData(0xed4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/money-light.svg)
-  static const money = PhosphorFlatIconData(0xe588, 'Light');
+  static const money = IconData(0xe588,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-wavy-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/money-wavy-light.svg)
-  static const moneyWavy = PhosphorFlatIconData(0xee68, 'Light');
+  static const moneyWavy = IconData(0xee68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/monitor-light.svg)
-  static const monitor = PhosphorFlatIconData(0xe32e, 'Light');
+  static const monitor = IconData(0xe32e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-arrow-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/monitor-arrow-up-light.svg)
-  static const monitorArrowUp = PhosphorFlatIconData(0xe58a, 'Light');
+  static const monitorArrowUp = IconData(0xe58a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-play-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/monitor-play-light.svg)
-  static const monitorPlay = PhosphorFlatIconData(0xe58c, 'Light');
+  static const monitorPlay = IconData(0xe58c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/moon-light.svg)
-  static const moon = PhosphorFlatIconData(0xe330, 'Light');
+  static const moon = IconData(0xe330,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-stars-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/moon-stars-light.svg)
-  static const moonStars = PhosphorFlatIconData(0xe58e, 'Light');
+  static const moonStars = IconData(0xe58e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/moped-light.svg)
-  static const moped = PhosphorFlatIconData(0xe824, 'Light');
+  static const moped = IconData(0xe824,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-front-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/moped-front-light.svg)
-  static const mopedFront = PhosphorFlatIconData(0xe822, 'Light');
+  static const mopedFront = IconData(0xe822,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mosque-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mosque-light.svg)
-  static const mosque = PhosphorFlatIconData(0xecee, 'Light');
+  static const mosque = IconData(0xecee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![motorcycle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/motorcycle-light.svg)
-  static const motorcycle = PhosphorFlatIconData(0xe80a, 'Light');
+  static const motorcycle = IconData(0xe80a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mountains-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mountains-light.svg)
-  static const mountains = PhosphorFlatIconData(0xe7ae, 'Light');
+  static const mountains = IconData(0xe7ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mouse-light.svg)
-  static const mouse = PhosphorFlatIconData(0xe33a, 'Light');
+  static const mouse = IconData(0xe33a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-left-click-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mouse-left-click-light.svg)
-  static const mouseLeftClick = PhosphorFlatIconData(0xe334, 'Light');
+  static const mouseLeftClick = IconData(0xe334,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-middle-click-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mouse-middle-click-light.svg)
-  static const mouseMiddleClick = PhosphorFlatIconData(0xe338, 'Light');
+  static const mouseMiddleClick = IconData(0xe338,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-right-click-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mouse-right-click-light.svg)
-  static const mouseRightClick = PhosphorFlatIconData(0xe336, 'Light');
+  static const mouseRightClick = IconData(0xe336,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-scroll-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mouse-scroll-light.svg)
-  static const mouseScroll = PhosphorFlatIconData(0xe332, 'Light');
+  static const mouseScroll = IconData(0xe332,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/mouse-simple-light.svg)
-  static const mouseSimple = PhosphorFlatIconData(0xe644, 'Light');
+  static const mouseSimple = IconData(0xe644,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/music-note-light.svg)
-  static const musicNote = PhosphorFlatIconData(0xe33c, 'Light');
+  static const musicNote = IconData(0xe33c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/music-note-simple-light.svg)
-  static const musicNoteSimple = PhosphorFlatIconData(0xe33e, 'Light');
+  static const musicNoteSimple = IconData(0xe33e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/music-notes-light.svg)
-  static const musicNotes = PhosphorFlatIconData(0xe340, 'Light');
+  static const musicNotes = IconData(0xe340,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/music-notes-minus-light.svg)
-  static const musicNotesMinus = PhosphorFlatIconData(0xee0c, 'Light');
+  static const musicNotesMinus = IconData(0xee0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/music-notes-plus-light.svg)
-  static const musicNotesPlus = PhosphorFlatIconData(0xeb7c, 'Light');
+  static const musicNotesPlus = IconData(0xeb7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/music-notes-simple-light.svg)
-  static const musicNotesSimple = PhosphorFlatIconData(0xe342, 'Light');
+  static const musicNotesSimple = IconData(0xe342,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![navigation-arrow-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/navigation-arrow-light.svg)
-  static const navigationArrow = PhosphorFlatIconData(0xeade, 'Light');
+  static const navigationArrow = IconData(0xeade,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![needle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/needle-light.svg)
-  static const needle = PhosphorFlatIconData(0xe82e, 'Light');
+  static const needle = IconData(0xe82e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/network-light.svg)
-  static const network = PhosphorFlatIconData(0xedde, 'Light');
+  static const network = IconData(0xedde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/network-slash-light.svg)
-  static const networkSlash = PhosphorFlatIconData(0xeddc, 'Light');
+  static const networkSlash = IconData(0xeddc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/network-x-light.svg)
-  static const networkX = PhosphorFlatIconData(0xedda, 'Light');
+  static const networkX = IconData(0xedda,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/newspaper-light.svg)
-  static const newspaper = PhosphorFlatIconData(0xe344, 'Light');
+  static const newspaper = IconData(0xe344,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-clipping-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/newspaper-clipping-light.svg)
-  static const newspaperClipping = PhosphorFlatIconData(0xe346, 'Light');
+  static const newspaperClipping = IconData(0xe346,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-equals-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/not-equals-light.svg)
-  static const notEquals = PhosphorFlatIconData(0xeda6, 'Light');
+  static const notEquals = IconData(0xeda6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-member-of-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/not-member-of-light.svg)
-  static const notMemberOf = PhosphorFlatIconData(0xedae, 'Light');
+  static const notMemberOf = IconData(0xedae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-subset-of-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/not-subset-of-light.svg)
-  static const notSubsetOf = PhosphorFlatIconData(0xedb0, 'Light');
+  static const notSubsetOf = IconData(0xedb0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-superset-of-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/not-superset-of-light.svg)
-  static const notSupersetOf = PhosphorFlatIconData(0xedb2, 'Light');
+  static const notSupersetOf = IconData(0xedb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notches-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/notches-light.svg)
-  static const notches = PhosphorFlatIconData(0xed3a, 'Light');
+  static const notches = IconData(0xed3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/note-light.svg)
-  static const note = PhosphorFlatIconData(0xe348, 'Light');
+  static const note = IconData(0xe348,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-blank-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/note-blank-light.svg)
-  static const noteBlank = PhosphorFlatIconData(0xe34a, 'Light');
+  static const noteBlank = IconData(0xe34a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-pencil-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/note-pencil-light.svg)
-  static const notePencil = PhosphorFlatIconData(0xe34c, 'Light');
+  static const notePencil = IconData(0xe34c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notebook-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/notebook-light.svg)
-  static const notebook = PhosphorFlatIconData(0xe34e, 'Light');
+  static const notebook = IconData(0xe34e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notepad-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/notepad-light.svg)
-  static const notepad = PhosphorFlatIconData(0xe63e, 'Light');
+  static const notepad = IconData(0xe63e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notification-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/notification-light.svg)
-  static const notification = PhosphorFlatIconData(0xe6fa, 'Light');
+  static const notification = IconData(0xe6fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notion-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/notion-logo-light.svg)
-  static const notionLogo = PhosphorFlatIconData(0xe9a0, 'Light');
+  static const notionLogo = IconData(0xe9a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nuclear-plant-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/nuclear-plant-light.svg)
-  static const nuclearPlant = PhosphorFlatIconData(0xed7c, 'Light');
+  static const nuclearPlant = IconData(0xed7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-eight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-eight-light.svg)
-  static const numberCircleEight = PhosphorFlatIconData(0xe352, 'Light');
+  static const numberCircleEight = IconData(0xe352,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-five-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-five-light.svg)
-  static const numberCircleFive = PhosphorFlatIconData(0xe358, 'Light');
+  static const numberCircleFive = IconData(0xe358,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-four-light.svg)
-  static const numberCircleFour = PhosphorFlatIconData(0xe35e, 'Light');
+  static const numberCircleFour = IconData(0xe35e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-nine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-nine-light.svg)
-  static const numberCircleNine = PhosphorFlatIconData(0xe364, 'Light');
+  static const numberCircleNine = IconData(0xe364,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-one-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-one-light.svg)
-  static const numberCircleOne = PhosphorFlatIconData(0xe36a, 'Light');
+  static const numberCircleOne = IconData(0xe36a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-seven-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-seven-light.svg)
-  static const numberCircleSeven = PhosphorFlatIconData(0xe370, 'Light');
+  static const numberCircleSeven = IconData(0xe370,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-six-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-six-light.svg)
-  static const numberCircleSix = PhosphorFlatIconData(0xe376, 'Light');
+  static const numberCircleSix = IconData(0xe376,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-three-light.svg)
-  static const numberCircleThree = PhosphorFlatIconData(0xe37c, 'Light');
+  static const numberCircleThree = IconData(0xe37c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-two-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-two-light.svg)
-  static const numberCircleTwo = PhosphorFlatIconData(0xe382, 'Light');
+  static const numberCircleTwo = IconData(0xe382,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-zero-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-circle-zero-light.svg)
-  static const numberCircleZero = PhosphorFlatIconData(0xe388, 'Light');
+  static const numberCircleZero = IconData(0xe388,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-eight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-eight-light.svg)
-  static const numberEight = PhosphorFlatIconData(0xe350, 'Light');
+  static const numberEight = IconData(0xe350,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-five-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-five-light.svg)
-  static const numberFive = PhosphorFlatIconData(0xe356, 'Light');
+  static const numberFive = IconData(0xe356,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-four-light.svg)
-  static const numberFour = PhosphorFlatIconData(0xe35c, 'Light');
+  static const numberFour = IconData(0xe35c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-nine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-nine-light.svg)
-  static const numberNine = PhosphorFlatIconData(0xe362, 'Light');
+  static const numberNine = IconData(0xe362,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-one-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-one-light.svg)
-  static const numberOne = PhosphorFlatIconData(0xe368, 'Light');
+  static const numberOne = IconData(0xe368,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-seven-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-seven-light.svg)
-  static const numberSeven = PhosphorFlatIconData(0xe36e, 'Light');
+  static const numberSeven = IconData(0xe36e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-six-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-six-light.svg)
-  static const numberSix = PhosphorFlatIconData(0xe374, 'Light');
+  static const numberSix = IconData(0xe374,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-eight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-eight-light.svg)
-  static const numberSquareEight = PhosphorFlatIconData(0xe354, 'Light');
+  static const numberSquareEight = IconData(0xe354,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-five-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-five-light.svg)
-  static const numberSquareFive = PhosphorFlatIconData(0xe35a, 'Light');
+  static const numberSquareFive = IconData(0xe35a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-four-light.svg)
-  static const numberSquareFour = PhosphorFlatIconData(0xe360, 'Light');
+  static const numberSquareFour = IconData(0xe360,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-nine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-nine-light.svg)
-  static const numberSquareNine = PhosphorFlatIconData(0xe366, 'Light');
+  static const numberSquareNine = IconData(0xe366,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-one-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-one-light.svg)
-  static const numberSquareOne = PhosphorFlatIconData(0xe36c, 'Light');
+  static const numberSquareOne = IconData(0xe36c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-seven-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-seven-light.svg)
-  static const numberSquareSeven = PhosphorFlatIconData(0xe372, 'Light');
+  static const numberSquareSeven = IconData(0xe372,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-six-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-six-light.svg)
-  static const numberSquareSix = PhosphorFlatIconData(0xe378, 'Light');
+  static const numberSquareSix = IconData(0xe378,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-three-light.svg)
-  static const numberSquareThree = PhosphorFlatIconData(0xe37e, 'Light');
+  static const numberSquareThree = IconData(0xe37e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-two-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-two-light.svg)
-  static const numberSquareTwo = PhosphorFlatIconData(0xe384, 'Light');
+  static const numberSquareTwo = IconData(0xe384,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-zero-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-square-zero-light.svg)
-  static const numberSquareZero = PhosphorFlatIconData(0xe38a, 'Light');
+  static const numberSquareZero = IconData(0xe38a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-three-light.svg)
-  static const numberThree = PhosphorFlatIconData(0xe37a, 'Light');
+  static const numberThree = IconData(0xe37a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-two-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-two-light.svg)
-  static const numberTwo = PhosphorFlatIconData(0xe380, 'Light');
+  static const numberTwo = IconData(0xe380,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-zero-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/number-zero-light.svg)
-  static const numberZero = PhosphorFlatIconData(0xe386, 'Light');
+  static const numberZero = IconData(0xe386,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![numpad-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/numpad-light.svg)
-  static const numpad = PhosphorFlatIconData(0xe3c8, 'Light');
+  static const numpad = IconData(0xe3c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nut-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/nut-light.svg)
-  static const nut = PhosphorFlatIconData(0xe38c, 'Light');
+  static const nut = IconData(0xe38c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ny-times-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ny-times-logo-light.svg)
-  static const nyTimesLogo = PhosphorFlatIconData(0xe646, 'Light');
+  static const nyTimesLogo = IconData(0xe646,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![octagon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/octagon-light.svg)
-  static const octagon = PhosphorFlatIconData(0xe38e, 'Light');
+  static const octagon = IconData(0xe38e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![office-chair-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/office-chair-light.svg)
-  static const officeChair = PhosphorFlatIconData(0xea46, 'Light');
+  static const officeChair = IconData(0xea46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![onigiri-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/onigiri-light.svg)
-  static const onigiri = PhosphorFlatIconData(0xee2c, 'Light');
+  static const onigiri = IconData(0xee2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![open-ai-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/open-ai-logo-light.svg)
-  static const openAiLogo = PhosphorFlatIconData(0xe7d2, 'Light');
+  static const openAiLogo = IconData(0xe7d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![option-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/option-light.svg)
-  static const option = PhosphorFlatIconData(0xe8a8, 'Light');
+  static const option = IconData(0xe8a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/orange-light.svg)
-  static const orange = PhosphorFlatIconData(0xee40, 'Light');
+  static const orange = IconData(0xee40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-slice-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/orange-slice-light.svg)
-  static const orangeSlice = PhosphorFlatIconData(0xed36, 'Light');
+  static const orangeSlice = IconData(0xed36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![oven-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/oven-light.svg)
-  static const oven = PhosphorFlatIconData(0xed8c, 'Light');
+  static const oven = IconData(0xed8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![package-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/package-light.svg)
-  static const package = PhosphorFlatIconData(0xe390, 'Light');
+  static const package = IconData(0xe390,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paint-brush-light.svg)
-  static const paintBrush = PhosphorFlatIconData(0xe6f0, 'Light');
+  static const paintBrush = IconData(0xe6f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-broad-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paint-brush-broad-light.svg)
-  static const paintBrushBroad = PhosphorFlatIconData(0xe590, 'Light');
+  static const paintBrushBroad = IconData(0xe590,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-household-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paint-brush-household-light.svg)
-  static const paintBrushHousehold = PhosphorFlatIconData(0xe6f2, 'Light');
+  static const paintBrushHousehold = IconData(0xe6f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-bucket-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paint-bucket-light.svg)
-  static const paintBucket = PhosphorFlatIconData(0xe392, 'Light');
+  static const paintBucket = IconData(0xe392,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-roller-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paint-roller-light.svg)
-  static const paintRoller = PhosphorFlatIconData(0xe6f4, 'Light');
+  static const paintRoller = IconData(0xe6f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![palette-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/palette-light.svg)
-  static const palette = PhosphorFlatIconData(0xe6c8, 'Light');
+  static const palette = IconData(0xe6c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![panorama-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/panorama-light.svg)
-  static const panorama = PhosphorFlatIconData(0xeaa2, 'Light');
+  static const panorama = IconData(0xeaa2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pants-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pants-light.svg)
-  static const pants = PhosphorFlatIconData(0xec88, 'Light');
+  static const pants = IconData(0xec88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paper-plane-light.svg)
-  static const paperPlane = PhosphorFlatIconData(0xe394, 'Light');
+  static const paperPlane = IconData(0xe394,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paper-plane-right-light.svg)
-  static const paperPlaneRight = PhosphorFlatIconData(0xe396, 'Light');
+  static const paperPlaneRight = IconData(0xe396,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-tilt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paper-plane-tilt-light.svg)
-  static const paperPlaneTilt = PhosphorFlatIconData(0xe398, 'Light');
+  static const paperPlaneTilt = IconData(0xe398,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paperclip-light.svg)
-  static const paperclip = PhosphorFlatIconData(0xe39a, 'Light');
+  static const paperclip = IconData(0xe39a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paperclip-horizontal-light.svg)
-  static const paperclipHorizontal = PhosphorFlatIconData(0xe592, 'Light');
+  static const paperclipHorizontal = IconData(0xe592,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parachute-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/parachute-light.svg)
-  static const parachute = PhosphorFlatIconData(0xea7c, 'Light');
+  static const parachute = IconData(0xea7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paragraph-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paragraph-light.svg)
-  static const paragraph = PhosphorFlatIconData(0xe960, 'Light');
+  static const paragraph = IconData(0xe960,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parallelogram-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/parallelogram-light.svg)
-  static const parallelogram = PhosphorFlatIconData(0xecc6, 'Light');
+  static const parallelogram = IconData(0xecc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![park-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/park-light.svg)
-  static const park = PhosphorFlatIconData(0xecb2, 'Light');
+  static const park = IconData(0xecb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![password-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/password-light.svg)
-  static const password = PhosphorFlatIconData(0xe752, 'Light');
+  static const password = IconData(0xe752,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![path-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/path-light.svg)
-  static const path = PhosphorFlatIconData(0xe39c, 'Light');
+  static const path = IconData(0xe39c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![patreon-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/patreon-logo-light.svg)
-  static const patreonLogo = PhosphorFlatIconData(0xe98a, 'Light');
+  static const patreonLogo = IconData(0xe98a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pause-light.svg)
-  static const pause = PhosphorFlatIconData(0xe39e, 'Light');
+  static const pause = IconData(0xe39e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pause-circle-light.svg)
-  static const pauseCircle = PhosphorFlatIconData(0xe3a0, 'Light');
+  static const pauseCircle = IconData(0xe3a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paw-print-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paw-print-light.svg)
-  static const pawPrint = PhosphorFlatIconData(0xe648, 'Light');
+  static const pawPrint = IconData(0xe648,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paypal-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/paypal-logo-light.svg)
-  static const paypalLogo = PhosphorFlatIconData(0xe98c, 'Light');
+  static const paypalLogo = IconData(0xe98c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![peace-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/peace-light.svg)
-  static const peace = PhosphorFlatIconData(0xe3a2, 'Light');
+  static const peace = IconData(0xe3a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pen-light.svg)
-  static const pen = PhosphorFlatIconData(0xe3aa, 'Light');
+  static const pen = IconData(0xe3aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pen-nib-light.svg)
-  static const penNib = PhosphorFlatIconData(0xe3ac, 'Light');
+  static const penNib = IconData(0xe3ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-straight-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pen-nib-straight-light.svg)
-  static const penNibStraight = PhosphorFlatIconData(0xe64a, 'Light');
+  static const penNibStraight = IconData(0xe64a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pencil-light.svg)
-  static const pencil = PhosphorFlatIconData(0xe3ae, 'Light');
+  static const pencil = IconData(0xe3ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pencil-circle-light.svg)
-  static const pencilCircle = PhosphorFlatIconData(0xe3b0, 'Light');
+  static const pencilCircle = IconData(0xe3b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-line-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pencil-line-light.svg)
-  static const pencilLine = PhosphorFlatIconData(0xe3b2, 'Light');
+  static const pencilLine = IconData(0xe3b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-ruler-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pencil-ruler-light.svg)
-  static const pencilRuler = PhosphorFlatIconData(0xe906, 'Light');
+  static const pencilRuler = IconData(0xe906,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pencil-simple-light.svg)
-  static const pencilSimple = PhosphorFlatIconData(0xe3b4, 'Light');
+  static const pencilSimple = IconData(0xe3b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-line-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pencil-simple-line-light.svg)
-  static const pencilSimpleLine = PhosphorFlatIconData(0xebc6, 'Light');
+  static const pencilSimpleLine = IconData(0xebc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pencil-simple-slash-light.svg)
-  static const pencilSimpleSlash = PhosphorFlatIconData(0xecf6, 'Light');
+  static const pencilSimpleSlash = IconData(0xecf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pencil-slash-light.svg)
-  static const pencilSlash = PhosphorFlatIconData(0xecf8, 'Light');
+  static const pencilSlash = IconData(0xecf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pentagon-light.svg)
-  static const pentagon = PhosphorFlatIconData(0xec7e, 'Light');
+  static const pentagon = IconData(0xec7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagram-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pentagram-light.svg)
-  static const pentagram = PhosphorFlatIconData(0xec5c, 'Light');
+  static const pentagram = IconData(0xec5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pepper-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pepper-light.svg)
-  static const pepper = PhosphorFlatIconData(0xe94a, 'Light');
+  static const pepper = IconData(0xe94a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![percent-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/percent-light.svg)
-  static const percent = PhosphorFlatIconData(0xe3b6, 'Light');
+  static const percent = IconData(0xe3b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-light.svg)
-  static const person = PhosphorFlatIconData(0xe3a8, 'Light');
+  static const person = IconData(0xe3a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-arms-spread-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-arms-spread-light.svg)
-  static const personArmsSpread = PhosphorFlatIconData(0xecfe, 'Light');
+  static const personArmsSpread = IconData(0xecfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-light.svg)
-  static const personSimple = PhosphorFlatIconData(0xe72e, 'Light');
+  static const personSimple = IconData(0xe72e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-bike-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-bike-light.svg)
-  static const personSimpleBike = PhosphorFlatIconData(0xe734, 'Light');
+  static const personSimpleBike = IconData(0xe734,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-circle-light.svg)
-  static const personSimpleCircle = PhosphorFlatIconData(0xee58, 'Light');
+  static const personSimpleCircle = IconData(0xee58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-hike-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-hike-light.svg)
-  static const personSimpleHike = PhosphorFlatIconData(0xed54, 'Light');
+  static const personSimpleHike = IconData(0xed54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-run-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-run-light.svg)
-  static const personSimpleRun = PhosphorFlatIconData(0xe730, 'Light');
+  static const personSimpleRun = IconData(0xe730,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-ski-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-ski-light.svg)
-  static const personSimpleSki = PhosphorFlatIconData(0xe71c, 'Light');
+  static const personSimpleSki = IconData(0xe71c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-snowboard-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-snowboard-light.svg)
-  static const personSimpleSnowboard = PhosphorFlatIconData(0xe71e, 'Light');
+  static const personSimpleSnowboard = IconData(0xe71e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-swim-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-swim-light.svg)
-  static const personSimpleSwim = PhosphorFlatIconData(0xe736, 'Light');
+  static const personSimpleSwim = IconData(0xe736,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-tai-chi-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-tai-chi-light.svg)
-  static const personSimpleTaiChi = PhosphorFlatIconData(0xed5c, 'Light');
+  static const personSimpleTaiChi = IconData(0xed5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-throw-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-throw-light.svg)
-  static const personSimpleThrow = PhosphorFlatIconData(0xe732, 'Light');
+  static const personSimpleThrow = IconData(0xe732,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-walk-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/person-simple-walk-light.svg)
-  static const personSimpleWalk = PhosphorFlatIconData(0xe73a, 'Light');
+  static const personSimpleWalk = IconData(0xe73a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![perspective-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/perspective-light.svg)
-  static const perspective = PhosphorFlatIconData(0xebe6, 'Light');
+  static const perspective = IconData(0xebe6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-light.svg)
-  static const phone = PhosphorFlatIconData(0xe3b8, 'Light');
+  static const phone = IconData(0xe3b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-call-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-call-light.svg)
-  static const phoneCall = PhosphorFlatIconData(0xe3ba, 'Light');
+  static const phoneCall = IconData(0xe3ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-disconnect-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-disconnect-light.svg)
-  static const phoneDisconnect = PhosphorFlatIconData(0xe3bc, 'Light');
+  static const phoneDisconnect = IconData(0xe3bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-incoming-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-incoming-light.svg)
-  static const phoneIncoming = PhosphorFlatIconData(0xe3be, 'Light');
+  static const phoneIncoming = IconData(0xe3be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-list-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-list-light.svg)
-  static const phoneList = PhosphorFlatIconData(0xe3cc, 'Light');
+  static const phoneList = IconData(0xe3cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-outgoing-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-outgoing-light.svg)
-  static const phoneOutgoing = PhosphorFlatIconData(0xe3c0, 'Light');
+  static const phoneOutgoing = IconData(0xe3c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-pause-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-pause-light.svg)
-  static const phonePause = PhosphorFlatIconData(0xe3ca, 'Light');
+  static const phonePause = IconData(0xe3ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-plus-light.svg)
-  static const phonePlus = PhosphorFlatIconData(0xec56, 'Light');
+  static const phonePlus = IconData(0xec56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-slash-light.svg)
-  static const phoneSlash = PhosphorFlatIconData(0xe3c2, 'Light');
+  static const phoneSlash = IconData(0xe3c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-transfer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-transfer-light.svg)
-  static const phoneTransfer = PhosphorFlatIconData(0xe3c6, 'Light');
+  static const phoneTransfer = IconData(0xe3c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phone-x-light.svg)
-  static const phoneX = PhosphorFlatIconData(0xe3c4, 'Light');
+  static const phoneX = IconData(0xe3c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phosphor-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/phosphor-logo-light.svg)
-  static const phosphorLogo = PhosphorFlatIconData(0xe3ce, 'Light');
+  static const phosphorLogo = IconData(0xe3ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pi-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pi-light.svg)
-  static const pi = PhosphorFlatIconData(0xec80, 'Light');
+  static const pi = IconData(0xec80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piano-keys-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/piano-keys-light.svg)
-  static const pianoKeys = PhosphorFlatIconData(0xe9c8, 'Light');
+  static const pianoKeys = IconData(0xe9c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picnic-table-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/picnic-table-light.svg)
-  static const picnicTable = PhosphorFlatIconData(0xee26, 'Light');
+  static const picnicTable = IconData(0xee26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picture-in-picture-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/picture-in-picture-light.svg)
-  static const pictureInpicture = PhosphorFlatIconData(0xe64c, 'Light');
+  static const pictureInpicture = IconData(0xe64c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piggy-bank-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/piggy-bank-light.svg)
-  static const piggyBank = PhosphorFlatIconData(0xea04, 'Light');
+  static const piggyBank = IconData(0xea04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pill-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pill-light.svg)
-  static const pill = PhosphorFlatIconData(0xe700, 'Light');
+  static const pill = IconData(0xe700,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ping-pong-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ping-pong-light.svg)
-  static const pingPong = PhosphorFlatIconData(0xea42, 'Light');
+  static const pingPong = IconData(0xea42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pint-glass-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pint-glass-light.svg)
-  static const pintGlass = PhosphorFlatIconData(0xedd0, 'Light');
+  static const pintGlass = IconData(0xedd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinterest-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pinterest-logo-light.svg)
-  static const pinterestLogo = PhosphorFlatIconData(0xe64e, 'Light');
+  static const pinterestLogo = IconData(0xe64e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinwheel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pinwheel-light.svg)
-  static const pinwheel = PhosphorFlatIconData(0xeb9c, 'Light');
+  static const pinwheel = IconData(0xeb9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pipe-light.svg)
-  static const pipe = PhosphorFlatIconData(0xed86, 'Light');
+  static const pipe = IconData(0xed86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-wrench-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pipe-wrench-light.svg)
-  static const pipeWrench = PhosphorFlatIconData(0xed88, 'Light');
+  static const pipeWrench = IconData(0xed88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pix-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pix-logo-light.svg)
-  static const pixLogo = PhosphorFlatIconData(0xecc2, 'Light');
+  static const pixLogo = IconData(0xecc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pizza-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pizza-light.svg)
-  static const pizza = PhosphorFlatIconData(0xe796, 'Light');
+  static const pizza = IconData(0xe796,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![placeholder-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/placeholder-light.svg)
-  static const placeholder = PhosphorFlatIconData(0xe650, 'Light');
+  static const placeholder = IconData(0xe650,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![planet-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/planet-light.svg)
-  static const planet = PhosphorFlatIconData(0xe652, 'Light');
+  static const planet = IconData(0xe652,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plant-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plant-light.svg)
-  static const plant = PhosphorFlatIconData(0xebae, 'Light');
+  static const plant = IconData(0xebae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/play-light.svg)
-  static const play = PhosphorFlatIconData(0xe3d0, 'Light');
+  static const play = IconData(0xe3d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/play-circle-light.svg)
-  static const playCircle = PhosphorFlatIconData(0xe3d2, 'Light');
+  static const playCircle = IconData(0xe3d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-pause-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/play-pause-light.svg)
-  static const playPause = PhosphorFlatIconData(0xe8be, 'Light');
+  static const playPause = IconData(0xe8be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![playlist-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/playlist-light.svg)
-  static const playlist = PhosphorFlatIconData(0xe6aa, 'Light');
+  static const playlist = IconData(0xe6aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plug-light.svg)
-  static const plug = PhosphorFlatIconData(0xe946, 'Light');
+  static const plug = IconData(0xe946,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-charging-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plug-charging-light.svg)
-  static const plugCharging = PhosphorFlatIconData(0xeb5c, 'Light');
+  static const plugCharging = IconData(0xeb5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plugs-light.svg)
-  static const plugs = PhosphorFlatIconData(0xeb56, 'Light');
+  static const plugs = IconData(0xeb56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-connected-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plugs-connected-light.svg)
-  static const plugsConnected = PhosphorFlatIconData(0xeb5a, 'Light');
+  static const plugsConnected = IconData(0xeb5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plus-light.svg)
-  static const plus = PhosphorFlatIconData(0xe3d4, 'Light');
+  static const plus = IconData(0xe3d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plus-circle-light.svg)
-  static const plusCircle = PhosphorFlatIconData(0xe3d6, 'Light');
+  static const plusCircle = IconData(0xe3d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plus-minus-light.svg)
-  static const plusMinus = PhosphorFlatIconData(0xe3d8, 'Light');
+  static const plusMinus = IconData(0xe3d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/plus-square-light.svg)
-  static const plusSquare = PhosphorFlatIconData(0xed4a, 'Light');
+  static const plusSquare = IconData(0xed4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![poker-chip-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/poker-chip-light.svg)
-  static const pokerChip = PhosphorFlatIconData(0xe594, 'Light');
+  static const pokerChip = IconData(0xe594,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![police-car-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/police-car-light.svg)
-  static const policeCar = PhosphorFlatIconData(0xec4a, 'Light');
+  static const policeCar = IconData(0xec4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![polygon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/polygon-light.svg)
-  static const polygon = PhosphorFlatIconData(0xe6d0, 'Light');
+  static const polygon = IconData(0xe6d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popcorn-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/popcorn-light.svg)
-  static const popcorn = PhosphorFlatIconData(0xeb4e, 'Light');
+  static const popcorn = IconData(0xeb4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popsicle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/popsicle-light.svg)
-  static const popsicle = PhosphorFlatIconData(0xebbe, 'Light');
+  static const popsicle = IconData(0xebbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![potted-plant-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/potted-plant-light.svg)
-  static const pottedPlant = PhosphorFlatIconData(0xec22, 'Light');
+  static const pottedPlant = IconData(0xec22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![power-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/power-light.svg)
-  static const power = PhosphorFlatIconData(0xe3da, 'Light');
+  static const power = IconData(0xe3da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prescription-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/prescription-light.svg)
-  static const prescription = PhosphorFlatIconData(0xe7a2, 'Light');
+  static const prescription = IconData(0xe7a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/presentation-light.svg)
-  static const presentation = PhosphorFlatIconData(0xe654, 'Light');
+  static const presentation = IconData(0xe654,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-chart-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/presentation-chart-light.svg)
-  static const presentationChart = PhosphorFlatIconData(0xe656, 'Light');
+  static const presentationChart = IconData(0xe656,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![printer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/printer-light.svg)
-  static const printer = PhosphorFlatIconData(0xe3dc, 'Light');
+  static const printer = IconData(0xe3dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/prohibit-light.svg)
-  static const prohibit = PhosphorFlatIconData(0xe3de, 'Light');
+  static const prohibit = IconData(0xe3de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-inset-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/prohibit-inset-light.svg)
-  static const prohibitInset = PhosphorFlatIconData(0xe3e0, 'Light');
+  static const prohibitInset = IconData(0xe3e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/projector-screen-light.svg)
-  static const projectorScreen = PhosphorFlatIconData(0xe658, 'Light');
+  static const projectorScreen = IconData(0xe658,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-chart-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/projector-screen-chart-light.svg)
-  static const projectorScreenChart = PhosphorFlatIconData(0xe65a, 'Light');
+  static const projectorScreenChart = IconData(0xe65a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pulse-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/pulse-light.svg)
-  static const pulse = PhosphorFlatIconData(0xe000, 'Light');
+  static const pulse = IconData(0xe000,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/push-pin-light.svg)
-  static const pushPin = PhosphorFlatIconData(0xe3e2, 'Light');
+  static const pushPin = IconData(0xe3e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/push-pin-simple-light.svg)
-  static const pushPinSimple = PhosphorFlatIconData(0xe65c, 'Light');
+  static const pushPinSimple = IconData(0xe65c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/push-pin-simple-slash-light.svg)
-  static const pushPinSimpleSlash = PhosphorFlatIconData(0xe65e, 'Light');
+  static const pushPinSimpleSlash = IconData(0xe65e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/push-pin-slash-light.svg)
-  static const pushPinSlash = PhosphorFlatIconData(0xe3e4, 'Light');
+  static const pushPinSlash = IconData(0xe3e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![puzzle-piece-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/puzzle-piece-light.svg)
-  static const puzzlePiece = PhosphorFlatIconData(0xe596, 'Light');
+  static const puzzlePiece = IconData(0xe596,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![qr-code-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/qr-code-light.svg)
-  static const qrCode = PhosphorFlatIconData(0xe3e6, 'Light');
+  static const qrCode = IconData(0xe3e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/question-light.svg)
-  static const question = PhosphorFlatIconData(0xe3e8, 'Light');
+  static const question = IconData(0xe3e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-mark-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/question-mark-light.svg)
-  static const questionMark = PhosphorFlatIconData(0xe3e9, 'Light');
+  static const questionMark = IconData(0xe3e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![queue-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/queue-light.svg)
-  static const queue = PhosphorFlatIconData(0xe6ac, 'Light');
+  static const queue = IconData(0xe6ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![quotes-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/quotes-light.svg)
-  static const quotes = PhosphorFlatIconData(0xe660, 'Light');
+  static const quotes = IconData(0xe660,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rabbit-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rabbit-light.svg)
-  static const rabbit = PhosphorFlatIconData(0xeac2, 'Light');
+  static const rabbit = IconData(0xeac2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![racquet-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/racquet-light.svg)
-  static const racquet = PhosphorFlatIconData(0xee02, 'Light');
+  static const racquet = IconData(0xee02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/radical-light.svg)
-  static const radical = PhosphorFlatIconData(0xe3ea, 'Light');
+  static const radical = IconData(0xe3ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/radio-light.svg)
-  static const radio = PhosphorFlatIconData(0xe77e, 'Light');
+  static const radio = IconData(0xe77e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-button-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/radio-button-light.svg)
-  static const radioButton = PhosphorFlatIconData(0xeb08, 'Light');
+  static const radioButton = IconData(0xeb08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radioactive-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/radioactive-light.svg)
-  static const radioactive = PhosphorFlatIconData(0xe9dc, 'Light');
+  static const radioactive = IconData(0xe9dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rainbow-light.svg)
-  static const rainbow = PhosphorFlatIconData(0xe598, 'Light');
+  static const rainbow = IconData(0xe598,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-cloud-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rainbow-cloud-light.svg)
-  static const rainbowCloud = PhosphorFlatIconData(0xe59a, 'Light');
+  static const rainbowCloud = IconData(0xe59a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ranking-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ranking-light.svg)
-  static const ranking = PhosphorFlatIconData(0xed62, 'Light');
+  static const ranking = IconData(0xed62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![read-cv-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/read-cv-logo-light.svg)
-  static const readCvLogo = PhosphorFlatIconData(0xed0c, 'Light');
+  static const readCvLogo = IconData(0xed0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/receipt-light.svg)
-  static const receipt = PhosphorFlatIconData(0xe3ec, 'Light');
+  static const receipt = IconData(0xe3ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/receipt-x-light.svg)
-  static const receiptX = PhosphorFlatIconData(0xed40, 'Light');
+  static const receiptX = IconData(0xed40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![record-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/record-light.svg)
-  static const record = PhosphorFlatIconData(0xe3ee, 'Light');
+  static const record = IconData(0xe3ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rectangle-light.svg)
-  static const rectangle = PhosphorFlatIconData(0xe3f0, 'Light');
+  static const rectangle = IconData(0xe3f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-dashed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rectangle-dashed-light.svg)
-  static const rectangleDashed = PhosphorFlatIconData(0xe3f2, 'Light');
+  static const rectangleDashed = IconData(0xe3f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![recycle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/recycle-light.svg)
-  static const recycle = PhosphorFlatIconData(0xe75a, 'Light');
+  static const recycle = IconData(0xe75a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![reddit-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/reddit-logo-light.svg)
-  static const redditLogo = PhosphorFlatIconData(0xe59c, 'Light');
+  static const redditLogo = IconData(0xe59c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/repeat-light.svg)
-  static const repeat = PhosphorFlatIconData(0xe3f6, 'Light');
+  static const repeat = IconData(0xe3f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-once-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/repeat-once-light.svg)
-  static const repeatOnce = PhosphorFlatIconData(0xe3f8, 'Light');
+  static const repeatOnce = IconData(0xe3f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![replit-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/replit-logo-light.svg)
-  static const replitLogo = PhosphorFlatIconData(0xeb8a, 'Light');
+  static const replitLogo = IconData(0xeb8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![resize-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/resize-light.svg)
-  static const resize = PhosphorFlatIconData(0xed6e, 'Light');
+  static const resize = IconData(0xed6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rewind-light.svg)
-  static const rewind = PhosphorFlatIconData(0xe6a8, 'Light');
+  static const rewind = IconData(0xe6a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rewind-circle-light.svg)
-  static const rewindCircle = PhosphorFlatIconData(0xe3fa, 'Light');
+  static const rewindCircle = IconData(0xe3fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![road-horizon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/road-horizon-light.svg)
-  static const roadHorizon = PhosphorFlatIconData(0xe838, 'Light');
+  static const roadHorizon = IconData(0xe838,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![robot-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/robot-light.svg)
-  static const robot = PhosphorFlatIconData(0xe762, 'Light');
+  static const robot = IconData(0xe762,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rocket-light.svg)
-  static const rocket = PhosphorFlatIconData(0xe3fc, 'Light');
+  static const rocket = IconData(0xe3fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-launch-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rocket-launch-light.svg)
-  static const rocketLaunch = PhosphorFlatIconData(0xe3fe, 'Light');
+  static const rocketLaunch = IconData(0xe3fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rows-light.svg)
-  static const rows = PhosphorFlatIconData(0xe5a2, 'Light');
+  static const rows = IconData(0xe5a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-bottom-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rows-plus-bottom-light.svg)
-  static const rowsPlusBottom = PhosphorFlatIconData(0xe59e, 'Light');
+  static const rowsPlusBottom = IconData(0xe59e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-top-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rows-plus-top-light.svg)
-  static const rowsPlusTop = PhosphorFlatIconData(0xe5a0, 'Light');
+  static const rowsPlusTop = IconData(0xe5a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rss-light.svg)
-  static const rss = PhosphorFlatIconData(0xe400, 'Light');
+  static const rss = IconData(0xe400,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rss-simple-light.svg)
-  static const rssSimple = PhosphorFlatIconData(0xe402, 'Light');
+  static const rssSimple = IconData(0xe402,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rug-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/rug-light.svg)
-  static const rug = PhosphorFlatIconData(0xea1a, 'Light');
+  static const rug = IconData(0xea1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ruler-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ruler-light.svg)
-  static const ruler = PhosphorFlatIconData(0xe6b8, 'Light');
+  static const ruler = IconData(0xe6b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sailboat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sailboat-light.svg)
-  static const sailboat = PhosphorFlatIconData(0xe78a, 'Light');
+  static const sailboat = IconData(0xe78a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scales-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/scales-light.svg)
-  static const scales = PhosphorFlatIconData(0xe750, 'Light');
+  static const scales = IconData(0xe750,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/scan-light.svg)
-  static const scan = PhosphorFlatIconData(0xebb6, 'Light');
+  static const scan = IconData(0xebb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-smiley-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/scan-smiley-light.svg)
-  static const scanSmiley = PhosphorFlatIconData(0xebb4, 'Light');
+  static const scanSmiley = IconData(0xebb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scissors-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/scissors-light.svg)
-  static const scissors = PhosphorFlatIconData(0xeae0, 'Light');
+  static const scissors = IconData(0xeae0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scooter-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/scooter-light.svg)
-  static const scooter = PhosphorFlatIconData(0xe820, 'Light');
+  static const scooter = IconData(0xe820,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screencast-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/screencast-light.svg)
-  static const screencast = PhosphorFlatIconData(0xe404, 'Light');
+  static const screencast = IconData(0xe404,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screwdriver-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/screwdriver-light.svg)
-  static const screwdriver = PhosphorFlatIconData(0xe86e, 'Light');
+  static const screwdriver = IconData(0xe86e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/scribble-light.svg)
-  static const scribble = PhosphorFlatIconData(0xe806, 'Light');
+  static const scribble = IconData(0xe806,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-loop-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/scribble-loop-light.svg)
-  static const scribbleLoop = PhosphorFlatIconData(0xe662, 'Light');
+  static const scribbleLoop = IconData(0xe662,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scroll-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/scroll-light.svg)
-  static const scroll = PhosphorFlatIconData(0xeb7a, 'Light');
+  static const scroll = IconData(0xeb7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/seal-light.svg)
-  static const seal = PhosphorFlatIconData(0xe604, 'Light');
+  static const seal = IconData(0xe604,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-check-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/seal-check-light.svg)
-  static const sealCheck = PhosphorFlatIconData(0xe606, 'Light');
+  static const sealCheck = IconData(0xe606,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-percent-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/seal-percent-light.svg)
-  static const sealPercent = PhosphorFlatIconData(0xe60a, 'Light');
+  static const sealPercent = IconData(0xe60a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-question-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/seal-question-light.svg)
-  static const sealQuestion = PhosphorFlatIconData(0xe608, 'Light');
+  static const sealQuestion = IconData(0xe608,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-warning-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/seal-warning-light.svg)
-  static const sealWarning = PhosphorFlatIconData(0xe60c, 'Light');
+  static const sealWarning = IconData(0xe60c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/seat-light.svg)
-  static const seat = PhosphorFlatIconData(0xeb8e, 'Light');
+  static const seat = IconData(0xeb8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seatbelt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/seatbelt-light.svg)
-  static const seatbelt = PhosphorFlatIconData(0xedfe, 'Light');
+  static const seatbelt = IconData(0xedfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![security-camera-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/security-camera-light.svg)
-  static const securityCamera = PhosphorFlatIconData(0xeca4, 'Light');
+  static const securityCamera = IconData(0xeca4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/selection-light.svg)
-  static const selection = PhosphorFlatIconData(0xe69a, 'Light');
+  static const selection = IconData(0xe69a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-all-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/selection-all-light.svg)
-  static const selectionAll = PhosphorFlatIconData(0xe746, 'Light');
+  static const selectionAll = IconData(0xe746,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-background-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/selection-background-light.svg)
-  static const selectionBackground = PhosphorFlatIconData(0xeaf8, 'Light');
+  static const selectionBackground = IconData(0xeaf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-foreground-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/selection-foreground-light.svg)
-  static const selectionForeground = PhosphorFlatIconData(0xeaf6, 'Light');
+  static const selectionForeground = IconData(0xeaf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-inverse-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/selection-inverse-light.svg)
-  static const selectionInverse = PhosphorFlatIconData(0xe744, 'Light');
+  static const selectionInverse = IconData(0xe744,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/selection-plus-light.svg)
-  static const selectionPlus = PhosphorFlatIconData(0xe69c, 'Light');
+  static const selectionPlus = IconData(0xe69c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/selection-slash-light.svg)
-  static const selectionSlash = PhosphorFlatIconData(0xe69e, 'Light');
+  static const selectionSlash = IconData(0xe69e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shapes-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shapes-light.svg)
-  static const shapes = PhosphorFlatIconData(0xec5e, 'Light');
+  static const shapes = IconData(0xec5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/share-light.svg)
-  static const share = PhosphorFlatIconData(0xe406, 'Light');
+  static const share = IconData(0xe406,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-fat-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/share-fat-light.svg)
-  static const shareFat = PhosphorFlatIconData(0xed52, 'Light');
+  static const shareFat = IconData(0xed52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-network-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/share-network-light.svg)
-  static const shareNetwork = PhosphorFlatIconData(0xe408, 'Light');
+  static const shareNetwork = IconData(0xe408,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shield-light.svg)
-  static const shield = PhosphorFlatIconData(0xe40a, 'Light');
+  static const shield = IconData(0xe40a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-check-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shield-check-light.svg)
-  static const shieldCheck = PhosphorFlatIconData(0xe40c, 'Light');
+  static const shieldCheck = IconData(0xe40c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-checkered-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shield-checkered-light.svg)
-  static const shieldCheckered = PhosphorFlatIconData(0xe708, 'Light');
+  static const shieldCheckered = IconData(0xe708,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-chevron-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shield-chevron-light.svg)
-  static const shieldChevron = PhosphorFlatIconData(0xe40e, 'Light');
+  static const shieldChevron = IconData(0xe40e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shield-plus-light.svg)
-  static const shieldPlus = PhosphorFlatIconData(0xe706, 'Light');
+  static const shieldPlus = IconData(0xe706,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shield-slash-light.svg)
-  static const shieldSlash = PhosphorFlatIconData(0xe410, 'Light');
+  static const shieldSlash = IconData(0xe410,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-star-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shield-star-light.svg)
-  static const shieldStar = PhosphorFlatIconData(0xec34, 'Light');
+  static const shieldStar = IconData(0xec34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-warning-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shield-warning-light.svg)
-  static const shieldWarning = PhosphorFlatIconData(0xe412, 'Light');
+  static const shieldWarning = IconData(0xe412,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shipping-container-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shipping-container-light.svg)
-  static const shippingContainer = PhosphorFlatIconData(0xe78c, 'Light');
+  static const shippingContainer = IconData(0xe78c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shirt-folded-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shirt-folded-light.svg)
-  static const shirtFolded = PhosphorFlatIconData(0xea92, 'Light');
+  static const shirtFolded = IconData(0xea92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shooting-star-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shooting-star-light.svg)
-  static const shootingStar = PhosphorFlatIconData(0xecfa, 'Light');
+  static const shootingStar = IconData(0xecfa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shopping-bag-light.svg)
-  static const shoppingBag = PhosphorFlatIconData(0xe416, 'Light');
+  static const shoppingBag = IconData(0xe416,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-open-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shopping-bag-open-light.svg)
-  static const shoppingBagOpen = PhosphorFlatIconData(0xe418, 'Light');
+  static const shoppingBagOpen = IconData(0xe418,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shopping-cart-light.svg)
-  static const shoppingCart = PhosphorFlatIconData(0xe41e, 'Light');
+  static const shoppingCart = IconData(0xe41e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shopping-cart-simple-light.svg)
-  static const shoppingCartSimple = PhosphorFlatIconData(0xe420, 'Light');
+  static const shoppingCartSimple = IconData(0xe420,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shovel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shovel-light.svg)
-  static const shovel = PhosphorFlatIconData(0xe9e6, 'Light');
+  static const shovel = IconData(0xe9e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shower-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shower-light.svg)
-  static const shower = PhosphorFlatIconData(0xe776, 'Light');
+  static const shower = IconData(0xe776,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shrimp-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shrimp-light.svg)
-  static const shrimp = PhosphorFlatIconData(0xeab4, 'Light');
+  static const shrimp = IconData(0xeab4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shuffle-light.svg)
-  static const shuffle = PhosphorFlatIconData(0xe422, 'Light');
+  static const shuffle = IconData(0xe422,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-angular-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shuffle-angular-light.svg)
-  static const shuffleAngular = PhosphorFlatIconData(0xe424, 'Light');
+  static const shuffleAngular = IconData(0xe424,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/shuffle-simple-light.svg)
-  static const shuffleSimple = PhosphorFlatIconData(0xe426, 'Light');
+  static const shuffleSimple = IconData(0xe426,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sidebar-light.svg)
-  static const sidebar = PhosphorFlatIconData(0xeab6, 'Light');
+  static const sidebar = IconData(0xeab6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sidebar-simple-light.svg)
-  static const sidebarSimple = PhosphorFlatIconData(0xec24, 'Light');
+  static const sidebarSimple = IconData(0xec24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sigma-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sigma-light.svg)
-  static const sigma = PhosphorFlatIconData(0xeab8, 'Light');
+  static const sigma = IconData(0xeab8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-in-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sign-in-light.svg)
-  static const signIn = PhosphorFlatIconData(0xe428, 'Light');
+  static const signIn = IconData(0xe428,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-out-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sign-out-light.svg)
-  static const signOut = PhosphorFlatIconData(0xe42a, 'Light');
+  static const signOut = IconData(0xe42a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signature-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/signature-light.svg)
-  static const signature = PhosphorFlatIconData(0xebac, 'Light');
+  static const signature = IconData(0xebac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signpost-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/signpost-light.svg)
-  static const signpost = PhosphorFlatIconData(0xe89c, 'Light');
+  static const signpost = IconData(0xe89c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sim-card-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sim-card-light.svg)
-  static const simCard = PhosphorFlatIconData(0xe664, 'Light');
+  static const simCard = IconData(0xe664,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![siren-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/siren-light.svg)
-  static const siren = PhosphorFlatIconData(0xe9b8, 'Light');
+  static const siren = IconData(0xe9b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sketch-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sketch-logo-light.svg)
-  static const sketchLogo = PhosphorFlatIconData(0xe42c, 'Light');
+  static const sketchLogo = IconData(0xe42c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/skip-back-light.svg)
-  static const skipBack = PhosphorFlatIconData(0xe5a4, 'Light');
+  static const skipBack = IconData(0xe5a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/skip-back-circle-light.svg)
-  static const skipBackCircle = PhosphorFlatIconData(0xe42e, 'Light');
+  static const skipBackCircle = IconData(0xe42e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/skip-forward-light.svg)
-  static const skipForward = PhosphorFlatIconData(0xe5a6, 'Light');
+  static const skipForward = IconData(0xe5a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/skip-forward-circle-light.svg)
-  static const skipForwardCircle = PhosphorFlatIconData(0xe430, 'Light');
+  static const skipForwardCircle = IconData(0xe430,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skull-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/skull-light.svg)
-  static const skull = PhosphorFlatIconData(0xe916, 'Light');
+  static const skull = IconData(0xe916,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skype-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/skype-logo-light.svg)
-  static const skypeLogo = PhosphorFlatIconData(0xe8dc, 'Light');
+  static const skypeLogo = IconData(0xe8dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slack-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/slack-logo-light.svg)
-  static const slackLogo = PhosphorFlatIconData(0xe5a8, 'Light');
+  static const slackLogo = IconData(0xe5a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sliders-light.svg)
-  static const sliders = PhosphorFlatIconData(0xe432, 'Light');
+  static const sliders = IconData(0xe432,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sliders-horizontal-light.svg)
-  static const slidersHorizontal = PhosphorFlatIconData(0xe434, 'Light');
+  static const slidersHorizontal = IconData(0xe434,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slideshow-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/slideshow-light.svg)
-  static const slideshow = PhosphorFlatIconData(0xed32, 'Light');
+  static const slideshow = IconData(0xed32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-light.svg)
-  static const smiley = PhosphorFlatIconData(0xe436, 'Light');
+  static const smiley = IconData(0xe436,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-angry-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-angry-light.svg)
-  static const smileyAngry = PhosphorFlatIconData(0xec62, 'Light');
+  static const smileyAngry = IconData(0xec62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-blank-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-blank-light.svg)
-  static const smileyBlank = PhosphorFlatIconData(0xe438, 'Light');
+  static const smileyBlank = IconData(0xe438,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-meh-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-meh-light.svg)
-  static const smileyMeh = PhosphorFlatIconData(0xe43a, 'Light');
+  static const smileyMeh = IconData(0xe43a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-melting-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-melting-light.svg)
-  static const smileyMelting = PhosphorFlatIconData(0xee56, 'Light');
+  static const smileyMelting = IconData(0xee56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-nervous-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-nervous-light.svg)
-  static const smileyNervous = PhosphorFlatIconData(0xe43c, 'Light');
+  static const smileyNervous = IconData(0xe43c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sad-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-sad-light.svg)
-  static const smileySad = PhosphorFlatIconData(0xe43e, 'Light');
+  static const smileySad = IconData(0xe43e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sticker-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-sticker-light.svg)
-  static const smileySticker = PhosphorFlatIconData(0xe440, 'Light');
+  static const smileySticker = IconData(0xe440,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-wink-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-wink-light.svg)
-  static const smileyWink = PhosphorFlatIconData(0xe666, 'Light');
+  static const smileyWink = IconData(0xe666,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-x-eyes-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/smiley-x-eyes-light.svg)
-  static const smileyXEyes = PhosphorFlatIconData(0xe442, 'Light');
+  static const smileyXEyes = IconData(0xe442,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snapchat-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/snapchat-logo-light.svg)
-  static const snapchatLogo = PhosphorFlatIconData(0xe668, 'Light');
+  static const snapchatLogo = IconData(0xe668,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sneaker-light.svg)
-  static const sneaker = PhosphorFlatIconData(0xe80c, 'Light');
+  static const sneaker = IconData(0xe80c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-move-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sneaker-move-light.svg)
-  static const sneakerMove = PhosphorFlatIconData(0xed60, 'Light');
+  static const sneakerMove = IconData(0xed60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snowflake-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/snowflake-light.svg)
-  static const snowflake = PhosphorFlatIconData(0xe5aa, 'Light');
+  static const snowflake = IconData(0xe5aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soccer-ball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/soccer-ball-light.svg)
-  static const soccerBall = PhosphorFlatIconData(0xe716, 'Light');
+  static const soccerBall = IconData(0xe716,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sock-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sock-light.svg)
-  static const sock = PhosphorFlatIconData(0xecce, 'Light');
+  static const sock = IconData(0xecce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-panel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/solar-panel-light.svg)
-  static const solarPanel = PhosphorFlatIconData(0xed7a, 'Light');
+  static const solarPanel = IconData(0xed7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-roof-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/solar-roof-light.svg)
-  static const solarRoof = PhosphorFlatIconData(0xed7b, 'Light');
+  static const solarRoof = IconData(0xed7b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-ascending-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sort-ascending-light.svg)
-  static const sortAscending = PhosphorFlatIconData(0xe444, 'Light');
+  static const sortAscending = IconData(0xe444,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-descending-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sort-descending-light.svg)
-  static const sortDescending = PhosphorFlatIconData(0xe446, 'Light');
+  static const sortDescending = IconData(0xe446,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soundcloud-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/soundcloud-logo-light.svg)
-  static const soundcloudLogo = PhosphorFlatIconData(0xe8de, 'Light');
+  static const soundcloudLogo = IconData(0xe8de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spade-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/spade-light.svg)
-  static const spade = PhosphorFlatIconData(0xe448, 'Light');
+  static const spade = IconData(0xe448,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sparkle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sparkle-light.svg)
-  static const sparkle = PhosphorFlatIconData(0xe6a2, 'Light');
+  static const sparkle = IconData(0xe6a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-hifi-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-hifi-light.svg)
-  static const speakerHifi = PhosphorFlatIconData(0xea08, 'Light');
+  static const speakerHifi = IconData(0xea08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-high-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-high-light.svg)
-  static const speakerHigh = PhosphorFlatIconData(0xe44a, 'Light');
+  static const speakerHigh = IconData(0xe44a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-low-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-low-light.svg)
-  static const speakerLow = PhosphorFlatIconData(0xe44c, 'Light');
+  static const speakerLow = IconData(0xe44c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-none-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-none-light.svg)
-  static const speakerNone = PhosphorFlatIconData(0xe44e, 'Light');
+  static const speakerNone = IconData(0xe44e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-high-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-simple-high-light.svg)
-  static const speakerSimpleHigh = PhosphorFlatIconData(0xe450, 'Light');
+  static const speakerSimpleHigh = IconData(0xe450,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-low-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-simple-low-light.svg)
-  static const speakerSimpleLow = PhosphorFlatIconData(0xe452, 'Light');
+  static const speakerSimpleLow = IconData(0xe452,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-none-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-simple-none-light.svg)
-  static const speakerSimpleNone = PhosphorFlatIconData(0xe454, 'Light');
+  static const speakerSimpleNone = IconData(0xe454,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-simple-slash-light.svg)
-  static const speakerSimpleSlash = PhosphorFlatIconData(0xe456, 'Light');
+  static const speakerSimpleSlash = IconData(0xe456,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-simple-x-light.svg)
-  static const speakerSimpleX = PhosphorFlatIconData(0xe458, 'Light');
+  static const speakerSimpleX = IconData(0xe458,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-slash-light.svg)
-  static const speakerSlash = PhosphorFlatIconData(0xe45a, 'Light');
+  static const speakerSlash = IconData(0xe45a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speaker-x-light.svg)
-  static const speakerX = PhosphorFlatIconData(0xe45c, 'Light');
+  static const speakerX = IconData(0xe45c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speedometer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/speedometer-light.svg)
-  static const speedometer = PhosphorFlatIconData(0xee74, 'Light');
+  static const speedometer = IconData(0xee74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sphere-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sphere-light.svg)
-  static const sphere = PhosphorFlatIconData(0xee66, 'Light');
+  static const sphere = IconData(0xee66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/spinner-light.svg)
-  static const spinner = PhosphorFlatIconData(0xe66a, 'Light');
+  static const spinner = IconData(0xe66a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-ball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/spinner-ball-light.svg)
-  static const spinnerBall = PhosphorFlatIconData(0xee28, 'Light');
+  static const spinnerBall = IconData(0xee28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-gap-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/spinner-gap-light.svg)
-  static const spinnerGap = PhosphorFlatIconData(0xe66c, 'Light');
+  static const spinnerGap = IconData(0xe66c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spiral-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/spiral-light.svg)
-  static const spiral = PhosphorFlatIconData(0xe9fa, 'Light');
+  static const spiral = IconData(0xe9fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/split-horizontal-light.svg)
-  static const splitHorizontal = PhosphorFlatIconData(0xe872, 'Light');
+  static const splitHorizontal = IconData(0xe872,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/split-vertical-light.svg)
-  static const splitVertical = PhosphorFlatIconData(0xe876, 'Light');
+  static const splitVertical = IconData(0xe876,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spotify-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/spotify-logo-light.svg)
-  static const spotifyLogo = PhosphorFlatIconData(0xe66e, 'Light');
+  static const spotifyLogo = IconData(0xe66e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spray-bottle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/spray-bottle-light.svg)
-  static const sprayBottle = PhosphorFlatIconData(0xe7e4, 'Light');
+  static const sprayBottle = IconData(0xe7e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/square-light.svg)
-  static const square = PhosphorFlatIconData(0xe45e, 'Light');
+  static const square = IconData(0xe45e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/square-half-light.svg)
-  static const squareHalf = PhosphorFlatIconData(0xe462, 'Light');
+  static const squareHalf = IconData(0xe462,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-bottom-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/square-half-bottom-light.svg)
-  static const squareHalfBottom = PhosphorFlatIconData(0xeb16, 'Light');
+  static const squareHalfBottom = IconData(0xeb16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/square-logo-light.svg)
-  static const squareLogo = PhosphorFlatIconData(0xe690, 'Light');
+  static const squareLogo = IconData(0xe690,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-horizontal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/square-split-horizontal-light.svg)
-  static const squareSplitHorizontal = PhosphorFlatIconData(0xe870, 'Light');
+  static const squareSplitHorizontal = IconData(0xe870,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-vertical-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/square-split-vertical-light.svg)
-  static const squareSplitVertical = PhosphorFlatIconData(0xe874, 'Light');
+  static const squareSplitVertical = IconData(0xe874,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![squares-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/squares-four-light.svg)
-  static const squaresFour = PhosphorFlatIconData(0xe464, 'Light');
+  static const squaresFour = IconData(0xe464,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stack-light.svg)
-  static const stack = PhosphorFlatIconData(0xe466, 'Light');
+  static const stack = IconData(0xe466,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stack-minus-light.svg)
-  static const stackMinus = PhosphorFlatIconData(0xedf4, 'Light');
+  static const stackMinus = IconData(0xedf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-overflow-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stack-overflow-logo-light.svg)
-  static const stackOverflowLogo = PhosphorFlatIconData(0xeb78, 'Light');
+  static const stackOverflowLogo = IconData(0xeb78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stack-plus-light.svg)
-  static const stackPlus = PhosphorFlatIconData(0xedf6, 'Light');
+  static const stackPlus = IconData(0xedf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stack-simple-light.svg)
-  static const stackSimple = PhosphorFlatIconData(0xe468, 'Light');
+  static const stackSimple = IconData(0xe468,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stairs-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stairs-light.svg)
-  static const stairs = PhosphorFlatIconData(0xe8ec, 'Light');
+  static const stairs = IconData(0xe8ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stamp-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stamp-light.svg)
-  static const stamp = PhosphorFlatIconData(0xea48, 'Light');
+  static const stamp = IconData(0xea48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![standard-definition-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/standard-definition-light.svg)
-  static const standardDefinition = PhosphorFlatIconData(0xea90, 'Light');
+  static const standardDefinition = IconData(0xea90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/star-light.svg)
-  static const star = PhosphorFlatIconData(0xe46a, 'Light');
+  static const star = IconData(0xe46a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-and-crescent-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/star-and-crescent-light.svg)
-  static const starAndCrescent = PhosphorFlatIconData(0xecf4, 'Light');
+  static const starAndCrescent = IconData(0xecf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/star-four-light.svg)
-  static const starFour = PhosphorFlatIconData(0xe6a4, 'Light');
+  static const starFour = IconData(0xe6a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-half-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/star-half-light.svg)
-  static const starHalf = PhosphorFlatIconData(0xe70a, 'Light');
+  static const starHalf = IconData(0xe70a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-of-david-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/star-of-david-light.svg)
-  static const starOfDavid = PhosphorFlatIconData(0xe89e, 'Light');
+  static const starOfDavid = IconData(0xe89e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steam-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/steam-logo-light.svg)
-  static const steamLogo = PhosphorFlatIconData(0xead4, 'Light');
+  static const steamLogo = IconData(0xead4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steering-wheel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/steering-wheel-light.svg)
-  static const steeringWheel = PhosphorFlatIconData(0xe9ac, 'Light');
+  static const steeringWheel = IconData(0xe9ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steps-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/steps-light.svg)
-  static const steps = PhosphorFlatIconData(0xecbe, 'Light');
+  static const steps = IconData(0xecbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stethoscope-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stethoscope-light.svg)
-  static const stethoscope = PhosphorFlatIconData(0xe7ea, 'Light');
+  static const stethoscope = IconData(0xe7ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sticker-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sticker-light.svg)
-  static const sticker = PhosphorFlatIconData(0xe5ac, 'Light');
+  static const sticker = IconData(0xe5ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stool-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stool-light.svg)
-  static const stool = PhosphorFlatIconData(0xea44, 'Light');
+  static const stool = IconData(0xea44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stop-light.svg)
-  static const stop = PhosphorFlatIconData(0xe46c, 'Light');
+  static const stop = IconData(0xe46c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stop-circle-light.svg)
-  static const stopCircle = PhosphorFlatIconData(0xe46e, 'Light');
+  static const stopCircle = IconData(0xe46e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![storefront-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/storefront-light.svg)
-  static const storefront = PhosphorFlatIconData(0xe470, 'Light');
+  static const storefront = IconData(0xe470,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![strategy-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/strategy-light.svg)
-  static const strategy = PhosphorFlatIconData(0xea3a, 'Light');
+  static const strategy = IconData(0xea3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stripe-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/stripe-logo-light.svg)
-  static const stripeLogo = PhosphorFlatIconData(0xe698, 'Light');
+  static const stripeLogo = IconData(0xe698,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![student-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/student-light.svg)
-  static const student = PhosphorFlatIconData(0xe73e, 'Light');
+  static const student = IconData(0xe73e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-of-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/subset-of-light.svg)
-  static const subsetOf = PhosphorFlatIconData(0xedc0, 'Light');
+  static const subsetOf = IconData(0xedc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-proper-of-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/subset-proper-of-light.svg)
-  static const subsetProperOf = PhosphorFlatIconData(0xedb6, 'Light');
+  static const subsetProperOf = IconData(0xedb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/subtitles-light.svg)
-  static const subtitles = PhosphorFlatIconData(0xe1a8, 'Light');
+  static const subtitles = IconData(0xe1a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/subtitles-slash-light.svg)
-  static const subtitlesSlash = PhosphorFlatIconData(0xe1a6, 'Light');
+  static const subtitlesSlash = IconData(0xe1a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/subtract-light.svg)
-  static const subtract = PhosphorFlatIconData(0xebd6, 'Light');
+  static const subtract = IconData(0xebd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/subtract-square-light.svg)
-  static const subtractSquare = PhosphorFlatIconData(0xebd4, 'Light');
+  static const subtractSquare = IconData(0xebd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subway-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/subway-light.svg)
-  static const subway = PhosphorFlatIconData(0xe498, 'Light');
+  static const subway = IconData(0xe498,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/suitcase-light.svg)
-  static const suitcase = PhosphorFlatIconData(0xe5ae, 'Light');
+  static const suitcase = IconData(0xe5ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-rolling-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/suitcase-rolling-light.svg)
-  static const suitcaseRolling = PhosphorFlatIconData(0xe9b0, 'Light');
+  static const suitcaseRolling = IconData(0xe9b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/suitcase-simple-light.svg)
-  static const suitcaseSimple = PhosphorFlatIconData(0xe5b0, 'Light');
+  static const suitcaseSimple = IconData(0xe5b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sun-light.svg)
-  static const sun = PhosphorFlatIconData(0xe472, 'Light');
+  static const sun = IconData(0xe472,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-dim-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sun-dim-light.svg)
-  static const sunDim = PhosphorFlatIconData(0xe474, 'Light');
+  static const sunDim = IconData(0xe474,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-horizon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sun-horizon-light.svg)
-  static const sunHorizon = PhosphorFlatIconData(0xe5b6, 'Light');
+  static const sunHorizon = IconData(0xe5b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sunglasses-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sunglasses-light.svg)
-  static const sunglasses = PhosphorFlatIconData(0xe816, 'Light');
+  static const sunglasses = IconData(0xe816,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-of-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/superset-of-light.svg)
-  static const supersetOf = PhosphorFlatIconData(0xedb8, 'Light');
+  static const supersetOf = IconData(0xedb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-proper-of-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/superset-proper-of-light.svg)
-  static const supersetProperOf = PhosphorFlatIconData(0xedb4, 'Light');
+  static const supersetProperOf = IconData(0xedb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swap-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/swap-light.svg)
-  static const swap = PhosphorFlatIconData(0xe83c, 'Light');
+  static const swap = IconData(0xe83c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swatches-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/swatches-light.svg)
-  static const swatches = PhosphorFlatIconData(0xe5b8, 'Light');
+  static const swatches = IconData(0xe5b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swimming-pool-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/swimming-pool-light.svg)
-  static const swimmingPool = PhosphorFlatIconData(0xecb6, 'Light');
+  static const swimmingPool = IconData(0xecb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sword-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/sword-light.svg)
-  static const sword = PhosphorFlatIconData(0xe5ba, 'Light');
+  static const sword = IconData(0xe5ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![synagogue-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/synagogue-light.svg)
-  static const synagogue = PhosphorFlatIconData(0xecec, 'Light');
+  static const synagogue = IconData(0xecec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![syringe-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/syringe-light.svg)
-  static const syringe = PhosphorFlatIconData(0xe968, 'Light');
+  static const syringe = IconData(0xe968,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![t-shirt-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/t-shirt-light.svg)
-  static const tShirt = PhosphorFlatIconData(0xe670, 'Light');
+  static const tShirt = IconData(0xe670,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![table-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/table-light.svg)
-  static const table = PhosphorFlatIconData(0xe476, 'Light');
+  static const table = IconData(0xe476,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tabs-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tabs-light.svg)
-  static const tabs = PhosphorFlatIconData(0xe778, 'Light');
+  static const tabs = IconData(0xe778,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tag-light.svg)
-  static const tag = PhosphorFlatIconData(0xe478, 'Light');
+  static const tag = IconData(0xe478,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-chevron-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tag-chevron-light.svg)
-  static const tagChevron = PhosphorFlatIconData(0xe672, 'Light');
+  static const tagChevron = IconData(0xe672,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tag-simple-light.svg)
-  static const tagSimple = PhosphorFlatIconData(0xe47a, 'Light');
+  static const tagSimple = IconData(0xe47a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![target-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/target-light.svg)
-  static const target = PhosphorFlatIconData(0xe47c, 'Light');
+  static const target = IconData(0xe47c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![taxi-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/taxi-light.svg)
-  static const taxi = PhosphorFlatIconData(0xe902, 'Light');
+  static const taxi = IconData(0xe902,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tea-bag-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tea-bag-light.svg)
-  static const teaBag = PhosphorFlatIconData(0xe8e6, 'Light');
+  static const teaBag = IconData(0xe8e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![telegram-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/telegram-logo-light.svg)
-  static const telegramLogo = PhosphorFlatIconData(0xe5bc, 'Light');
+  static const telegramLogo = IconData(0xe5bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/television-light.svg)
-  static const television = PhosphorFlatIconData(0xe754, 'Light');
+  static const television = IconData(0xe754,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/television-simple-light.svg)
-  static const televisionSimple = PhosphorFlatIconData(0xeae6, 'Light');
+  static const televisionSimple = IconData(0xeae6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tennis-ball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tennis-ball-light.svg)
-  static const tennisBall = PhosphorFlatIconData(0xe720, 'Light');
+  static const tennisBall = IconData(0xe720,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tent-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tent-light.svg)
-  static const tent = PhosphorFlatIconData(0xe8ba, 'Light');
+  static const tent = IconData(0xe8ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/terminal-light.svg)
-  static const terminal = PhosphorFlatIconData(0xe47e, 'Light');
+  static const terminal = IconData(0xe47e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-window-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/terminal-window-light.svg)
-  static const terminalWindow = PhosphorFlatIconData(0xeae8, 'Light');
+  static const terminalWindow = IconData(0xeae8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![test-tube-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/test-tube-light.svg)
-  static const testTube = PhosphorFlatIconData(0xe7a0, 'Light');
+  static const testTube = IconData(0xe7a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-a-underline-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-a-underline-light.svg)
-  static const textAUnderline = PhosphorFlatIconData(0xed34, 'Light');
+  static const textAUnderline = IconData(0xed34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-aa-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-aa-light.svg)
-  static const textAa = PhosphorFlatIconData(0xe6ee, 'Light');
+  static const textAa = IconData(0xe6ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-center-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-align-center-light.svg)
-  static const textAlignCenter = PhosphorFlatIconData(0xe480, 'Light');
+  static const textAlignCenter = IconData(0xe480,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-justify-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-align-justify-light.svg)
-  static const textAlignJustify = PhosphorFlatIconData(0xe482, 'Light');
+  static const textAlignJustify = IconData(0xe482,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-align-left-light.svg)
-  static const textAlignLeft = PhosphorFlatIconData(0xe484, 'Light');
+  static const textAlignLeft = IconData(0xe484,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-align-right-light.svg)
-  static const textAlignRight = PhosphorFlatIconData(0xe486, 'Light');
+  static const textAlignRight = IconData(0xe486,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-b-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-b-light.svg)
-  static const textB = PhosphorFlatIconData(0xe5be, 'Light');
+  static const textB = IconData(0xe5be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-columns-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-columns-light.svg)
-  static const textColumns = PhosphorFlatIconData(0xec96, 'Light');
+  static const textColumns = IconData(0xec96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-h-light.svg)
-  static const textH = PhosphorFlatIconData(0xe6ba, 'Light');
+  static const textH = IconData(0xe6ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-five-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-h-five-light.svg)
-  static const textHFive = PhosphorFlatIconData(0xe6c4, 'Light');
+  static const textHFive = IconData(0xe6c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-h-four-light.svg)
-  static const textHFour = PhosphorFlatIconData(0xe6c2, 'Light');
+  static const textHFour = IconData(0xe6c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-one-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-h-one-light.svg)
-  static const textHOne = PhosphorFlatIconData(0xe6bc, 'Light');
+  static const textHOne = IconData(0xe6bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-six-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-h-six-light.svg)
-  static const textHSix = PhosphorFlatIconData(0xe6c6, 'Light');
+  static const textHSix = IconData(0xe6c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-h-three-light.svg)
-  static const textHThree = PhosphorFlatIconData(0xe6c0, 'Light');
+  static const textHThree = IconData(0xe6c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-two-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-h-two-light.svg)
-  static const textHTwo = PhosphorFlatIconData(0xe6be, 'Light');
+  static const textHTwo = IconData(0xe6be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-indent-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-indent-light.svg)
-  static const textIndent = PhosphorFlatIconData(0xea1e, 'Light');
+  static const textIndent = IconData(0xea1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-italic-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-italic-light.svg)
-  static const textItalic = PhosphorFlatIconData(0xe5c0, 'Light');
+  static const textItalic = IconData(0xe5c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-outdent-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-outdent-light.svg)
-  static const textOutdent = PhosphorFlatIconData(0xea1c, 'Light');
+  static const textOutdent = IconData(0xea1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-strikethrough-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-strikethrough-light.svg)
-  static const textStrikethrough = PhosphorFlatIconData(0xe5c2, 'Light');
+  static const textStrikethrough = IconData(0xe5c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-subscript-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-subscript-light.svg)
-  static const textSubscript = PhosphorFlatIconData(0xec98, 'Light');
+  static const textSubscript = IconData(0xec98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-superscript-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-superscript-light.svg)
-  static const textSuperscript = PhosphorFlatIconData(0xec9a, 'Light');
+  static const textSuperscript = IconData(0xec9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-t-light.svg)
-  static const textT = PhosphorFlatIconData(0xe48a, 'Light');
+  static const textT = IconData(0xe48a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-t-slash-light.svg)
-  static const textTSlash = PhosphorFlatIconData(0xe488, 'Light');
+  static const textTSlash = IconData(0xe488,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-underline-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/text-underline-light.svg)
-  static const textUnderline = PhosphorFlatIconData(0xe5c4, 'Light');
+  static const textUnderline = IconData(0xe5c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![textbox-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/textbox-light.svg)
-  static const textbox = PhosphorFlatIconData(0xeb0a, 'Light');
+  static const textbox = IconData(0xeb0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/thermometer-light.svg)
-  static const thermometer = PhosphorFlatIconData(0xe5c6, 'Light');
+  static const thermometer = IconData(0xe5c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-cold-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/thermometer-cold-light.svg)
-  static const thermometerCold = PhosphorFlatIconData(0xe5c8, 'Light');
+  static const thermometerCold = IconData(0xe5c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-hot-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/thermometer-hot-light.svg)
-  static const thermometerHot = PhosphorFlatIconData(0xe5ca, 'Light');
+  static const thermometerHot = IconData(0xe5ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/thermometer-simple-light.svg)
-  static const thermometerSimple = PhosphorFlatIconData(0xe5cc, 'Light');
+  static const thermometerSimple = IconData(0xe5cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![threads-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/threads-logo-light.svg)
-  static const threadsLogo = PhosphorFlatIconData(0xed9e, 'Light');
+  static const threadsLogo = IconData(0xed9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![three-d-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/three-d-light.svg)
-  static const threeD = PhosphorFlatIconData(0xea5a, 'Light');
+  static const threeD = IconData(0xea5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/thumbs-down-light.svg)
-  static const thumbsDown = PhosphorFlatIconData(0xe48c, 'Light');
+  static const thumbsDown = IconData(0xe48c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/thumbs-up-light.svg)
-  static const thumbsUp = PhosphorFlatIconData(0xe48e, 'Light');
+  static const thumbsUp = IconData(0xe48e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ticket-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/ticket-light.svg)
-  static const ticket = PhosphorFlatIconData(0xe490, 'Light');
+  static const ticket = IconData(0xe490,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tidal-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tidal-logo-light.svg)
-  static const tidalLogo = PhosphorFlatIconData(0xed1c, 'Light');
+  static const tidalLogo = IconData(0xed1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tiktok-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tiktok-logo-light.svg)
-  static const tiktokLogo = PhosphorFlatIconData(0xeaf2, 'Light');
+  static const tiktokLogo = IconData(0xeaf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tilde-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tilde-light.svg)
-  static const tilde = PhosphorFlatIconData(0xeda8, 'Light');
+  static const tilde = IconData(0xeda8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![timer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/timer-light.svg)
-  static const timer = PhosphorFlatIconData(0xe492, 'Light');
+  static const timer = IconData(0xe492,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tip-jar-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tip-jar-light.svg)
-  static const tipJar = PhosphorFlatIconData(0xe7e2, 'Light');
+  static const tipJar = IconData(0xe7e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tipi-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tipi-light.svg)
-  static const tipi = PhosphorFlatIconData(0xed30, 'Light');
+  static const tipi = IconData(0xed30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tire-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tire-light.svg)
-  static const tire = PhosphorFlatIconData(0xedd2, 'Light');
+  static const tire = IconData(0xedd2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-left-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/toggle-left-light.svg)
-  static const toggleLeft = PhosphorFlatIconData(0xe674, 'Light');
+  static const toggleLeft = IconData(0xe674,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-right-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/toggle-right-light.svg)
-  static const toggleRight = PhosphorFlatIconData(0xe676, 'Light');
+  static const toggleRight = IconData(0xe676,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/toilet-light.svg)
-  static const toilet = PhosphorFlatIconData(0xe79a, 'Light');
+  static const toilet = IconData(0xe79a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-paper-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/toilet-paper-light.svg)
-  static const toiletPaper = PhosphorFlatIconData(0xe79c, 'Light');
+  static const toiletPaper = IconData(0xe79c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toolbox-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/toolbox-light.svg)
-  static const toolbox = PhosphorFlatIconData(0xeca0, 'Light');
+  static const toolbox = IconData(0xeca0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tooth-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tooth-light.svg)
-  static const tooth = PhosphorFlatIconData(0xe9cc, 'Light');
+  static const tooth = IconData(0xe9cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tornado-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tornado-light.svg)
-  static const tornado = PhosphorFlatIconData(0xe88c, 'Light');
+  static const tornado = IconData(0xe88c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tote-light.svg)
-  static const tote = PhosphorFlatIconData(0xe494, 'Light');
+  static const tote = IconData(0xe494,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tote-simple-light.svg)
-  static const toteSimple = PhosphorFlatIconData(0xe678, 'Light');
+  static const toteSimple = IconData(0xe678,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![towel-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/towel-light.svg)
-  static const towel = PhosphorFlatIconData(0xede6, 'Light');
+  static const towel = IconData(0xede6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tractor-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tractor-light.svg)
-  static const tractor = PhosphorFlatIconData(0xec6e, 'Light');
+  static const tractor = IconData(0xec6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trademark-light.svg)
-  static const trademark = PhosphorFlatIconData(0xe9f0, 'Light');
+  static const trademark = IconData(0xe9f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-registered-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trademark-registered-light.svg)
-  static const trademarkRegistered = PhosphorFlatIconData(0xe3f4, 'Light');
+  static const trademarkRegistered = IconData(0xe3f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-cone-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/traffic-cone-light.svg)
-  static const trafficCone = PhosphorFlatIconData(0xe9a8, 'Light');
+  static const trafficCone = IconData(0xe9a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-sign-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/traffic-sign-light.svg)
-  static const trafficSign = PhosphorFlatIconData(0xe67a, 'Light');
+  static const trafficSign = IconData(0xe67a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-signal-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/traffic-signal-light.svg)
-  static const trafficSignal = PhosphorFlatIconData(0xe9aa, 'Light');
+  static const trafficSignal = IconData(0xe9aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/train-light.svg)
-  static const train = PhosphorFlatIconData(0xe496, 'Light');
+  static const train = IconData(0xe496,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-regional-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/train-regional-light.svg)
-  static const trainRegional = PhosphorFlatIconData(0xe49e, 'Light');
+  static const trainRegional = IconData(0xe49e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/train-simple-light.svg)
-  static const trainSimple = PhosphorFlatIconData(0xe4a0, 'Light');
+  static const trainSimple = IconData(0xe4a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tram-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tram-light.svg)
-  static const tram = PhosphorFlatIconData(0xe9ec, 'Light');
+  static const tram = IconData(0xe9ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![translate-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/translate-light.svg)
-  static const translate = PhosphorFlatIconData(0xe4a2, 'Light');
+  static const translate = IconData(0xe4a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trash-light.svg)
-  static const trash = PhosphorFlatIconData(0xe4a6, 'Light');
+  static const trash = IconData(0xe4a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trash-simple-light.svg)
-  static const trashSimple = PhosphorFlatIconData(0xe4a8, 'Light');
+  static const trashSimple = IconData(0xe4a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tray-light.svg)
-  static const tray = PhosphorFlatIconData(0xe4aa, 'Light');
+  static const tray = IconData(0xe4aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tray-arrow-down-light.svg)
-  static const trayArrowDown = PhosphorFlatIconData(0xe010, 'Light');
+  static const trayArrowDown = IconData(0xe010,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tray-arrow-up-light.svg)
-  static const trayArrowUp = PhosphorFlatIconData(0xee52, 'Light');
+  static const trayArrowUp = IconData(0xee52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![treasure-chest-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/treasure-chest-light.svg)
-  static const treasureChest = PhosphorFlatIconData(0xede2, 'Light');
+  static const treasureChest = IconData(0xede2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tree-light.svg)
-  static const tree = PhosphorFlatIconData(0xe6da, 'Light');
+  static const tree = IconData(0xe6da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-evergreen-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tree-evergreen-light.svg)
-  static const treeEvergreen = PhosphorFlatIconData(0xe6dc, 'Light');
+  static const treeEvergreen = IconData(0xe6dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-palm-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tree-palm-light.svg)
-  static const treePalm = PhosphorFlatIconData(0xe91a, 'Light');
+  static const treePalm = IconData(0xe91a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-structure-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tree-structure-light.svg)
-  static const treeStructure = PhosphorFlatIconData(0xe67c, 'Light');
+  static const treeStructure = IconData(0xe67c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-view-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tree-view-light.svg)
-  static const treeView = PhosphorFlatIconData(0xee48, 'Light');
+  static const treeView = IconData(0xee48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-down-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trend-down-light.svg)
-  static const trendDown = PhosphorFlatIconData(0xe4ac, 'Light');
+  static const trendDown = IconData(0xe4ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-up-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trend-up-light.svg)
-  static const trendUp = PhosphorFlatIconData(0xe4ae, 'Light');
+  static const trendUp = IconData(0xe4ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/triangle-light.svg)
-  static const triangle = PhosphorFlatIconData(0xe4b0, 'Light');
+  static const triangle = IconData(0xe4b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-dashed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/triangle-dashed-light.svg)
-  static const triangleDashed = PhosphorFlatIconData(0xe4b2, 'Light');
+  static const triangleDashed = IconData(0xe4b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trolley-light.svg)
-  static const trolley = PhosphorFlatIconData(0xe5b2, 'Light');
+  static const trolley = IconData(0xe5b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-suitcase-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trolley-suitcase-light.svg)
-  static const trolleySuitcase = PhosphorFlatIconData(0xe5b4, 'Light');
+  static const trolleySuitcase = IconData(0xe5b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trophy-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/trophy-light.svg)
-  static const trophy = PhosphorFlatIconData(0xe67e, 'Light');
+  static const trophy = IconData(0xe67e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/truck-light.svg)
-  static const truck = PhosphorFlatIconData(0xe4b4, 'Light');
+  static const truck = IconData(0xe4b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-trailer-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/truck-trailer-light.svg)
-  static const truckTrailer = PhosphorFlatIconData(0xe4b6, 'Light');
+  static const truckTrailer = IconData(0xe4b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tumblr-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/tumblr-logo-light.svg)
-  static const tumblrLogo = PhosphorFlatIconData(0xe8d4, 'Light');
+  static const tumblrLogo = IconData(0xe8d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitch-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/twitch-logo-light.svg)
-  static const twitchLogo = PhosphorFlatIconData(0xe5ce, 'Light');
+  static const twitchLogo = IconData(0xe5ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitter-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/twitter-logo-light.svg)
-  static const twitterLogo = PhosphorFlatIconData(0xe4ba, 'Light');
+  static const twitterLogo = IconData(0xe4ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/umbrella-light.svg)
-  static const umbrella = PhosphorFlatIconData(0xe684, 'Light');
+  static const umbrella = IconData(0xe684,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/umbrella-simple-light.svg)
-  static const umbrellaSimple = PhosphorFlatIconData(0xe686, 'Light');
+  static const umbrellaSimple = IconData(0xe686,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![union-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/union-light.svg)
-  static const union = PhosphorFlatIconData(0xedbe, 'Light');
+  static const union = IconData(0xedbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/unite-light.svg)
-  static const unite = PhosphorFlatIconData(0xe87e, 'Light');
+  static const unite = IconData(0xe87e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/unite-square-light.svg)
-  static const uniteSquare = PhosphorFlatIconData(0xe878, 'Light');
+  static const uniteSquare = IconData(0xe878,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/upload-light.svg)
-  static const upload = PhosphorFlatIconData(0xe4be, 'Light');
+  static const upload = IconData(0xe4be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-simple-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/upload-simple-light.svg)
-  static const uploadSimple = PhosphorFlatIconData(0xe4c0, 'Light');
+  static const uploadSimple = IconData(0xe4c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![usb-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/usb-light.svg)
-  static const usb = PhosphorFlatIconData(0xe956, 'Light');
+  static const usb = IconData(0xe956,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-light.svg)
-  static const user = PhosphorFlatIconData(0xe4c2, 'Light');
+  static const user = IconData(0xe4c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-check-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-check-light.svg)
-  static const userCheck = PhosphorFlatIconData(0xeafa, 'Light');
+  static const userCheck = IconData(0xeafa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-circle-light.svg)
-  static const userCircle = PhosphorFlatIconData(0xe4c4, 'Light');
+  static const userCircle = IconData(0xe4c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-check-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-circle-check-light.svg)
-  static const userCircleCheck = PhosphorFlatIconData(0xec38, 'Light');
+  static const userCircleCheck = IconData(0xec38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-dashed-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-circle-dashed-light.svg)
-  static const userCircleDashed = PhosphorFlatIconData(0xec36, 'Light');
+  static const userCircleDashed = IconData(0xec36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-gear-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-circle-gear-light.svg)
-  static const userCircleGear = PhosphorFlatIconData(0xe4c6, 'Light');
+  static const userCircleGear = IconData(0xe4c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-circle-minus-light.svg)
-  static const userCircleMinus = PhosphorFlatIconData(0xe4c8, 'Light');
+  static const userCircleMinus = IconData(0xe4c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-circle-plus-light.svg)
-  static const userCirclePlus = PhosphorFlatIconData(0xe4ca, 'Light');
+  static const userCirclePlus = IconData(0xe4ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-focus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-focus-light.svg)
-  static const userFocus = PhosphorFlatIconData(0xe6fc, 'Light');
+  static const userFocus = IconData(0xe6fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-gear-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-gear-light.svg)
-  static const userGear = PhosphorFlatIconData(0xe4cc, 'Light');
+  static const userGear = IconData(0xe4cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-list-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-list-light.svg)
-  static const userList = PhosphorFlatIconData(0xe73c, 'Light');
+  static const userList = IconData(0xe73c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-minus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-minus-light.svg)
-  static const userMinus = PhosphorFlatIconData(0xe4ce, 'Light');
+  static const userMinus = IconData(0xe4ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-plus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-plus-light.svg)
-  static const userPlus = PhosphorFlatIconData(0xe4d0, 'Light');
+  static const userPlus = IconData(0xe4d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-rectangle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-rectangle-light.svg)
-  static const userRectangle = PhosphorFlatIconData(0xe4d2, 'Light');
+  static const userRectangle = IconData(0xe4d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-sound-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-sound-light.svg)
-  static const userSound = PhosphorFlatIconData(0xeca8, 'Light');
+  static const userSound = IconData(0xeca8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-square-light.svg)
-  static const userSquare = PhosphorFlatIconData(0xe4d4, 'Light');
+  static const userSquare = IconData(0xe4d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-switch-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/user-switch-light.svg)
-  static const userSwitch = PhosphorFlatIconData(0xe756, 'Light');
+  static const userSwitch = IconData(0xe756,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/users-light.svg)
-  static const users = PhosphorFlatIconData(0xe4d6, 'Light');
+  static const users = IconData(0xe4d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-four-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/users-four-light.svg)
-  static const usersFour = PhosphorFlatIconData(0xe68c, 'Light');
+  static const usersFour = IconData(0xe68c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/users-three-light.svg)
-  static const usersThree = PhosphorFlatIconData(0xe68e, 'Light');
+  static const usersThree = IconData(0xe68e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![van-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/van-light.svg)
-  static const van = PhosphorFlatIconData(0xe826, 'Light');
+  static const van = IconData(0xe826,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vault-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/vault-light.svg)
-  static const vault = PhosphorFlatIconData(0xe76e, 'Light');
+  static const vault = IconData(0xe76e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-three-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/vector-three-light.svg)
-  static const vectorThree = PhosphorFlatIconData(0xee62, 'Light');
+  static const vectorThree = IconData(0xee62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-two-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/vector-two-light.svg)
-  static const vectorTwo = PhosphorFlatIconData(0xee64, 'Light');
+  static const vectorTwo = IconData(0xee64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vibrate-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/vibrate-light.svg)
-  static const vibrate = PhosphorFlatIconData(0xe4d8, 'Light');
+  static const vibrate = IconData(0xe4d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/video-light.svg)
-  static const video = PhosphorFlatIconData(0xe740, 'Light');
+  static const video = IconData(0xe740,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/video-camera-light.svg)
-  static const videoCamera = PhosphorFlatIconData(0xe4da, 'Light');
+  static const videoCamera = IconData(0xe4da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/video-camera-slash-light.svg)
-  static const videoCameraSlash = PhosphorFlatIconData(0xe4dc, 'Light');
+  static const videoCameraSlash = IconData(0xe4dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-conference-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/video-conference-light.svg)
-  static const videoConference = PhosphorFlatIconData(0xedce, 'Light');
+  static const videoConference = IconData(0xedce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vignette-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/vignette-light.svg)
-  static const vignette = PhosphorFlatIconData(0xeba2, 'Light');
+  static const vignette = IconData(0xeba2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vinyl-record-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/vinyl-record-light.svg)
-  static const vinylRecord = PhosphorFlatIconData(0xecac, 'Light');
+  static const vinylRecord = IconData(0xecac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virtual-reality-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/virtual-reality-light.svg)
-  static const virtualReality = PhosphorFlatIconData(0xe7b8, 'Light');
+  static const virtualReality = IconData(0xe7b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virus-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/virus-light.svg)
-  static const virus = PhosphorFlatIconData(0xe7d6, 'Light');
+  static const virus = IconData(0xe7d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![visor-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/visor-light.svg)
-  static const visor = PhosphorFlatIconData(0xee2a, 'Light');
+  static const visor = IconData(0xee2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![voicemail-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/voicemail-light.svg)
-  static const voicemail = PhosphorFlatIconData(0xe4de, 'Light');
+  static const voicemail = IconData(0xe4de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![volleyball-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/volleyball-light.svg)
-  static const volleyball = PhosphorFlatIconData(0xe726, 'Light');
+  static const volleyball = IconData(0xe726,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wall-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wall-light.svg)
-  static const wall = PhosphorFlatIconData(0xe688, 'Light');
+  static const wall = IconData(0xe688,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wallet-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wallet-light.svg)
-  static const wallet = PhosphorFlatIconData(0xe68a, 'Light');
+  static const wallet = IconData(0xe68a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warehouse-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/warehouse-light.svg)
-  static const warehouse = PhosphorFlatIconData(0xecd4, 'Light');
+  static const warehouse = IconData(0xecd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/warning-light.svg)
-  static const warning = PhosphorFlatIconData(0xe4e0, 'Light');
+  static const warning = IconData(0xe4e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/warning-circle-light.svg)
-  static const warningCircle = PhosphorFlatIconData(0xe4e2, 'Light');
+  static const warningCircle = IconData(0xe4e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-diamond-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/warning-diamond-light.svg)
-  static const warningDiamond = PhosphorFlatIconData(0xe7fc, 'Light');
+  static const warningDiamond = IconData(0xe7fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-octagon-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/warning-octagon-light.svg)
-  static const warningOctagon = PhosphorFlatIconData(0xe4e4, 'Light');
+  static const warningOctagon = IconData(0xe4e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![washing-machine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/washing-machine-light.svg)
-  static const washingMachine = PhosphorFlatIconData(0xede8, 'Light');
+  static const washingMachine = IconData(0xede8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![watch-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/watch-light.svg)
-  static const watch = PhosphorFlatIconData(0xe4e6, 'Light');
+  static const watch = IconData(0xe4e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sawtooth-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wave-sawtooth-light.svg)
-  static const waveSawtooth = PhosphorFlatIconData(0xea9c, 'Light');
+  static const waveSawtooth = IconData(0xea9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wave-sine-light.svg)
-  static const waveSine = PhosphorFlatIconData(0xea9a, 'Light');
+  static const waveSine = IconData(0xea9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wave-square-light.svg)
-  static const waveSquare = PhosphorFlatIconData(0xea9e, 'Light');
+  static const waveSquare = IconData(0xea9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-triangle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wave-triangle-light.svg)
-  static const waveTriangle = PhosphorFlatIconData(0xeaa0, 'Light');
+  static const waveTriangle = IconData(0xeaa0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/waveform-light.svg)
-  static const waveform = PhosphorFlatIconData(0xe802, 'Light');
+  static const waveform = IconData(0xe802,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/waveform-slash-light.svg)
-  static const waveformSlash = PhosphorFlatIconData(0xe800, 'Light');
+  static const waveformSlash = IconData(0xe800,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waves-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/waves-light.svg)
-  static const waves = PhosphorFlatIconData(0xe6de, 'Light');
+  static const waves = IconData(0xe6de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/webcam-light.svg)
-  static const webcam = PhosphorFlatIconData(0xe9b2, 'Light');
+  static const webcam = IconData(0xe9b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/webcam-slash-light.svg)
-  static const webcamSlash = PhosphorFlatIconData(0xecdc, 'Light');
+  static const webcamSlash = IconData(0xecdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webhooks-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/webhooks-logo-light.svg)
-  static const webhooksLogo = PhosphorFlatIconData(0xecae, 'Light');
+  static const webhooksLogo = IconData(0xecae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wechat-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wechat-logo-light.svg)
-  static const wechatLogo = PhosphorFlatIconData(0xe8d2, 'Light');
+  static const wechatLogo = IconData(0xe8d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![whatsapp-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/whatsapp-logo-light.svg)
-  static const whatsappLogo = PhosphorFlatIconData(0xe5d0, 'Light');
+  static const whatsappLogo = IconData(0xe5d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wheelchair-light.svg)
-  static const wheelchair = PhosphorFlatIconData(0xe4e8, 'Light');
+  static const wheelchair = IconData(0xe4e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-motion-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wheelchair-motion-light.svg)
-  static const wheelchairMotion = PhosphorFlatIconData(0xe89a, 'Light');
+  static const wheelchairMotion = IconData(0xe89a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-high-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wifi-high-light.svg)
-  static const wifiHigh = PhosphorFlatIconData(0xe4ea, 'Light');
+  static const wifiHigh = IconData(0xe4ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-low-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wifi-low-light.svg)
-  static const wifiLow = PhosphorFlatIconData(0xe4ec, 'Light');
+  static const wifiLow = IconData(0xe4ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-medium-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wifi-medium-light.svg)
-  static const wifiMedium = PhosphorFlatIconData(0xe4ee, 'Light');
+  static const wifiMedium = IconData(0xe4ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-none-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wifi-none-light.svg)
-  static const wifiNone = PhosphorFlatIconData(0xe4f0, 'Light');
+  static const wifiNone = IconData(0xe4f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-slash-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wifi-slash-light.svg)
-  static const wifiSlash = PhosphorFlatIconData(0xe4f2, 'Light');
+  static const wifiSlash = IconData(0xe4f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wifi-x-light.svg)
-  static const wifiX = PhosphorFlatIconData(0xe4f4, 'Light');
+  static const wifiX = IconData(0xe4f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wind-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wind-light.svg)
-  static const wind = PhosphorFlatIconData(0xe5d2, 'Light');
+  static const wind = IconData(0xe5d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windmill-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/windmill-light.svg)
-  static const windmill = PhosphorFlatIconData(0xe9f8, 'Light');
+  static const windmill = IconData(0xe9f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windows-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/windows-logo-light.svg)
-  static const windowsLogo = PhosphorFlatIconData(0xe692, 'Light');
+  static const windowsLogo = IconData(0xe692,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wine-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wine-light.svg)
-  static const wine = PhosphorFlatIconData(0xe6b2, 'Light');
+  static const wine = IconData(0xe6b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wrench-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/wrench-light.svg)
-  static const wrench = PhosphorFlatIconData(0xe5d4, 'Light');
+  static const wrench = IconData(0xe5d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/x-light.svg)
-  static const x = PhosphorFlatIconData(0xe4f6, 'Light');
+  static const x = IconData(0xe4f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-circle-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/x-circle-light.svg)
-  static const xCircle = PhosphorFlatIconData(0xe4f8, 'Light');
+  static const xCircle = IconData(0xe4f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/x-logo-light.svg)
-  static const xLogo = PhosphorFlatIconData(0xe4bc, 'Light');
+  static const xLogo = IconData(0xe4bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-square-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/x-square-light.svg)
-  static const xSquare = PhosphorFlatIconData(0xe4fa, 'Light');
+  static const xSquare = IconData(0xe4fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yarn-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/yarn-light.svg)
-  static const yarn = PhosphorFlatIconData(0xed9a, 'Light');
+  static const yarn = IconData(0xed9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yin-yang-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/yin-yang-light.svg)
-  static const yinYang = PhosphorFlatIconData(0xe92a, 'Light');
+  static const yinYang = IconData(0xe92a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![youtube-logo-light](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/light/youtube-logo-light.svg)
-  static const youtubeLogo = PhosphorFlatIconData(0xe4fc, 'Light');
+  static const youtubeLogo = IconData(0xe4fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 }

--- a/lib/src/phosphor_icons_regular.dart
+++ b/lib/src/phosphor_icons_regular.dart
@@ -1,4554 +1,6060 @@
 // Auto generated File
 // DON'T EDIT BY HAND
 
-import 'package:phosphor_flutter/src/phosphor_icon_data.dart';
 import 'package:flutter/widgets.dart';
+
+const String _f = 'PhosphorRegular';
+const String _p = 'phosphor_flutter';
 
 @staticIconProvider
 class PhosphorIconsRegular {
   const PhosphorIconsRegular();
 
   /// ![acorn](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/acorn.svg)
-  static const acorn = PhosphorFlatIconData(0xeb9a, 'Regular');
+  static const acorn = IconData(0xeb9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/address-book.svg)
-  static const addressBook = PhosphorFlatIconData(0xe6f8, 'Regular');
+  static const addressBook = IconData(0xe6f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-tabs](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/address-book-tabs.svg)
-  static const addressBookTabs = PhosphorFlatIconData(0xee4e, 'Regular');
+  static const addressBookTabs = IconData(0xee4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![air-traffic-control](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/air-traffic-control.svg)
-  static const airTrafficControl = PhosphorFlatIconData(0xecd8, 'Regular');
+  static const airTrafficControl = IconData(0xecd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/airplane.svg)
-  static const airplane = PhosphorFlatIconData(0xe002, 'Regular');
+  static const airplane = IconData(0xe002,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-in-flight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/airplane-in-flight.svg)
-  static const airplaneInFlight = PhosphorFlatIconData(0xe4fe, 'Regular');
+  static const airplaneInFlight = IconData(0xe4fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-landing](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/airplane-landing.svg)
-  static const airplaneLanding = PhosphorFlatIconData(0xe502, 'Regular');
+  static const airplaneLanding = IconData(0xe502,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-takeoff](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/airplane-takeoff.svg)
-  static const airplaneTakeoff = PhosphorFlatIconData(0xe504, 'Regular');
+  static const airplaneTakeoff = IconData(0xe504,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-taxiing](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/airplane-taxiing.svg)
-  static const airplaneTaxiing = PhosphorFlatIconData(0xe500, 'Regular');
+  static const airplaneTaxiing = IconData(0xe500,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-tilt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/airplane-tilt.svg)
-  static const airplaneTilt = PhosphorFlatIconData(0xe5d6, 'Regular');
+  static const airplaneTilt = IconData(0xe5d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplay](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/airplay.svg)
-  static const airplay = PhosphorFlatIconData(0xe004, 'Regular');
+  static const airplay = IconData(0xe004,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alarm](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/alarm.svg)
-  static const alarm = PhosphorFlatIconData(0xe006, 'Regular');
+  static const alarm = IconData(0xe006,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alien](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/alien.svg)
-  static const alien = PhosphorFlatIconData(0xe8a6, 'Regular');
+  static const alien = IconData(0xe8a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-bottom.svg)
-  static const alignBottom = PhosphorFlatIconData(0xe506, 'Regular');
+  static const alignBottom = IconData(0xe506,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-bottom-simple.svg)
-  static const alignBottomSimple = PhosphorFlatIconData(0xeb0c, 'Regular');
+  static const alignBottomSimple = IconData(0xeb0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-center-horizontal.svg)
-  static const alignCenterHorizontal = PhosphorFlatIconData(0xe50a, 'Regular');
+  static const alignCenterHorizontal = IconData(0xe50a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-center-horizontal-simple.svg)
-  static const alignCenterHorizontalSimple =
-      PhosphorFlatIconData(0xeb0e, 'Regular');
+  static const alignCenterHorizontalSimple = IconData(0xeb0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-center-vertical.svg)
-  static const alignCenterVertical = PhosphorFlatIconData(0xe50c, 'Regular');
+  static const alignCenterVertical = IconData(0xe50c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-center-vertical-simple.svg)
-  static const alignCenterVerticalSimple =
-      PhosphorFlatIconData(0xeb10, 'Regular');
+  static const alignCenterVerticalSimple = IconData(0xeb10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-left.svg)
-  static const alignLeft = PhosphorFlatIconData(0xe50e, 'Regular');
+  static const alignLeft = IconData(0xe50e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-left-simple.svg)
-  static const alignLeftSimple = PhosphorFlatIconData(0xeaee, 'Regular');
+  static const alignLeftSimple = IconData(0xeaee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-right.svg)
-  static const alignRight = PhosphorFlatIconData(0xe510, 'Regular');
+  static const alignRight = IconData(0xe510,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-right-simple.svg)
-  static const alignRightSimple = PhosphorFlatIconData(0xeb12, 'Regular');
+  static const alignRightSimple = IconData(0xeb12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-top.svg)
-  static const alignTop = PhosphorFlatIconData(0xe512, 'Regular');
+  static const alignTop = IconData(0xe512,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/align-top-simple.svg)
-  static const alignTopSimple = PhosphorFlatIconData(0xeb14, 'Regular');
+  static const alignTopSimple = IconData(0xeb14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![amazon-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/amazon-logo.svg)
-  static const amazonLogo = PhosphorFlatIconData(0xe96c, 'Regular');
+  static const amazonLogo = IconData(0xe96c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ambulance](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ambulance.svg)
-  static const ambulance = PhosphorFlatIconData(0xe572, 'Regular');
+  static const ambulance = IconData(0xe572,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/anchor.svg)
-  static const anchor = PhosphorFlatIconData(0xe514, 'Regular');
+  static const anchor = IconData(0xe514,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/anchor-simple.svg)
-  static const anchorSimple = PhosphorFlatIconData(0xe5d8, 'Regular');
+  static const anchorSimple = IconData(0xe5d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![android-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/android-logo.svg)
-  static const androidLogo = PhosphorFlatIconData(0xe008, 'Regular');
+  static const androidLogo = IconData(0xe008,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/angle.svg)
-  static const angle = PhosphorFlatIconData(0xe7bc, 'Regular');
+  static const angle = IconData(0xe7bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angular-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/angular-logo.svg)
-  static const angularLogo = PhosphorFlatIconData(0xeb80, 'Regular');
+  static const angularLogo = IconData(0xeb80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![aperture](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/aperture.svg)
-  static const aperture = PhosphorFlatIconData(0xe00a, 'Regular');
+  static const aperture = IconData(0xe00a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-store-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/app-store-logo.svg)
-  static const appStoreLogo = PhosphorFlatIconData(0xe974, 'Regular');
+  static const appStoreLogo = IconData(0xe974,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-window](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/app-window.svg)
-  static const appWindow = PhosphorFlatIconData(0xe5da, 'Regular');
+  static const appWindow = IconData(0xe5da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/apple-logo.svg)
-  static const appleLogo = PhosphorFlatIconData(0xe516, 'Regular');
+  static const appleLogo = IconData(0xe516,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-podcasts-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/apple-podcasts-logo.svg)
-  static const applePodcastsLogo = PhosphorFlatIconData(0xeb96, 'Regular');
+  static const applePodcastsLogo = IconData(0xeb96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![approximate-equals](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/approximate-equals.svg)
-  static const approximateEquals = PhosphorFlatIconData(0xedaa, 'Regular');
+  static const approximateEquals = IconData(0xedaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![archive](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/archive.svg)
-  static const archive = PhosphorFlatIconData(0xe00c, 'Regular');
+  static const archive = IconData(0xe00c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![armchair](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/armchair.svg)
-  static const armchair = PhosphorFlatIconData(0xe012, 'Regular');
+  static const armchair = IconData(0xe012,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-arc-left.svg)
-  static const arrowArcLeft = PhosphorFlatIconData(0xe014, 'Regular');
+  static const arrowArcLeft = IconData(0xe014,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-arc-right.svg)
-  static const arrowArcRight = PhosphorFlatIconData(0xe016, 'Regular');
+  static const arrowArcRight = IconData(0xe016,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-double-up-left.svg)
-  static const arrowBendDoubleUpLeft = PhosphorFlatIconData(0xe03a, 'Regular');
+  static const arrowBendDoubleUpLeft = IconData(0xe03a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-double-up-right.svg)
-  static const arrowBendDoubleUpRight = PhosphorFlatIconData(0xe03c, 'Regular');
+  static const arrowBendDoubleUpRight = IconData(0xe03c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-down-left.svg)
-  static const arrowBendDownLeft = PhosphorFlatIconData(0xe018, 'Regular');
+  static const arrowBendDownLeft = IconData(0xe018,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-down-right.svg)
-  static const arrowBendDownRight = PhosphorFlatIconData(0xe01a, 'Regular');
+  static const arrowBendDownRight = IconData(0xe01a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-left-down.svg)
-  static const arrowBendLeftDown = PhosphorFlatIconData(0xe01c, 'Regular');
+  static const arrowBendLeftDown = IconData(0xe01c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-left-up.svg)
-  static const arrowBendLeftUp = PhosphorFlatIconData(0xe01e, 'Regular');
+  static const arrowBendLeftUp = IconData(0xe01e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-right-down.svg)
-  static const arrowBendRightDown = PhosphorFlatIconData(0xe020, 'Regular');
+  static const arrowBendRightDown = IconData(0xe020,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-right-up.svg)
-  static const arrowBendRightUp = PhosphorFlatIconData(0xe022, 'Regular');
+  static const arrowBendRightUp = IconData(0xe022,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-up-left.svg)
-  static const arrowBendUpLeft = PhosphorFlatIconData(0xe024, 'Regular');
+  static const arrowBendUpLeft = IconData(0xe024,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-bend-up-right.svg)
-  static const arrowBendUpRight = PhosphorFlatIconData(0xe026, 'Regular');
+  static const arrowBendUpRight = IconData(0xe026,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-circle-down.svg)
-  static const arrowCircleDown = PhosphorFlatIconData(0xe028, 'Regular');
+  static const arrowCircleDown = IconData(0xe028,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-circle-down-left.svg)
-  static const arrowCircleDownLeft = PhosphorFlatIconData(0xe02a, 'Regular');
+  static const arrowCircleDownLeft = IconData(0xe02a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-circle-down-right.svg)
-  static const arrowCircleDownRight = PhosphorFlatIconData(0xe02c, 'Regular');
+  static const arrowCircleDownRight = IconData(0xe02c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-circle-left.svg)
-  static const arrowCircleLeft = PhosphorFlatIconData(0xe05a, 'Regular');
+  static const arrowCircleLeft = IconData(0xe05a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-circle-right.svg)
-  static const arrowCircleRight = PhosphorFlatIconData(0xe02e, 'Regular');
+  static const arrowCircleRight = IconData(0xe02e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-circle-up.svg)
-  static const arrowCircleUp = PhosphorFlatIconData(0xe030, 'Regular');
+  static const arrowCircleUp = IconData(0xe030,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-circle-up-left.svg)
-  static const arrowCircleUpLeft = PhosphorFlatIconData(0xe032, 'Regular');
+  static const arrowCircleUpLeft = IconData(0xe032,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-circle-up-right.svg)
-  static const arrowCircleUpRight = PhosphorFlatIconData(0xe034, 'Regular');
+  static const arrowCircleUpRight = IconData(0xe034,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-clockwise](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-clockwise.svg)
-  static const arrowClockwise = PhosphorFlatIconData(0xe036, 'Regular');
+  static const arrowClockwise = IconData(0xe036,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-counter-clockwise](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-counter-clockwise.svg)
-  static const arrowCounterClockwise = PhosphorFlatIconData(0xe038, 'Regular');
+  static const arrowCounterClockwise = IconData(0xe038,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-down.svg)
-  static const arrowDown = PhosphorFlatIconData(0xe03e, 'Regular');
+  static const arrowDown = IconData(0xe03e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-down-left.svg)
-  static const arrowDownLeft = PhosphorFlatIconData(0xe040, 'Regular');
+  static const arrowDownLeft = IconData(0xe040,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-down-right.svg)
-  static const arrowDownRight = PhosphorFlatIconData(0xe042, 'Regular');
+  static const arrowDownRight = IconData(0xe042,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-down-left.svg)
-  static const arrowElbowDownLeft = PhosphorFlatIconData(0xe044, 'Regular');
+  static const arrowElbowDownLeft = IconData(0xe044,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-down-right.svg)
-  static const arrowElbowDownRight = PhosphorFlatIconData(0xe046, 'Regular');
+  static const arrowElbowDownRight = IconData(0xe046,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-left.svg)
-  static const arrowElbowLeft = PhosphorFlatIconData(0xe048, 'Regular');
+  static const arrowElbowLeft = IconData(0xe048,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-left-down.svg)
-  static const arrowElbowLeftDown = PhosphorFlatIconData(0xe04a, 'Regular');
+  static const arrowElbowLeftDown = IconData(0xe04a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-left-up.svg)
-  static const arrowElbowLeftUp = PhosphorFlatIconData(0xe04c, 'Regular');
+  static const arrowElbowLeftUp = IconData(0xe04c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-right.svg)
-  static const arrowElbowRight = PhosphorFlatIconData(0xe04e, 'Regular');
+  static const arrowElbowRight = IconData(0xe04e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-right-down.svg)
-  static const arrowElbowRightDown = PhosphorFlatIconData(0xe050, 'Regular');
+  static const arrowElbowRightDown = IconData(0xe050,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-right-up.svg)
-  static const arrowElbowRightUp = PhosphorFlatIconData(0xe052, 'Regular');
+  static const arrowElbowRightUp = IconData(0xe052,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-up-left.svg)
-  static const arrowElbowUpLeft = PhosphorFlatIconData(0xe054, 'Regular');
+  static const arrowElbowUpLeft = IconData(0xe054,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-elbow-up-right.svg)
-  static const arrowElbowUpRight = PhosphorFlatIconData(0xe056, 'Regular');
+  static const arrowElbowUpRight = IconData(0xe056,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-down.svg)
-  static const arrowFatDown = PhosphorFlatIconData(0xe518, 'Regular');
+  static const arrowFatDown = IconData(0xe518,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-left.svg)
-  static const arrowFatLeft = PhosphorFlatIconData(0xe51a, 'Regular');
+  static const arrowFatLeft = IconData(0xe51a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-line-down.svg)
-  static const arrowFatLineDown = PhosphorFlatIconData(0xe51c, 'Regular');
+  static const arrowFatLineDown = IconData(0xe51c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-line-left.svg)
-  static const arrowFatLineLeft = PhosphorFlatIconData(0xe51e, 'Regular');
+  static const arrowFatLineLeft = IconData(0xe51e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-line-right.svg)
-  static const arrowFatLineRight = PhosphorFlatIconData(0xe520, 'Regular');
+  static const arrowFatLineRight = IconData(0xe520,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-line-up.svg)
-  static const arrowFatLineUp = PhosphorFlatIconData(0xe522, 'Regular');
+  static const arrowFatLineUp = IconData(0xe522,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-lines-down.svg)
-  static const arrowFatLinesDown = PhosphorFlatIconData(0xe524, 'Regular');
+  static const arrowFatLinesDown = IconData(0xe524,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-lines-left.svg)
-  static const arrowFatLinesLeft = PhosphorFlatIconData(0xe526, 'Regular');
+  static const arrowFatLinesLeft = IconData(0xe526,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-lines-right.svg)
-  static const arrowFatLinesRight = PhosphorFlatIconData(0xe528, 'Regular');
+  static const arrowFatLinesRight = IconData(0xe528,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-lines-up.svg)
-  static const arrowFatLinesUp = PhosphorFlatIconData(0xe52a, 'Regular');
+  static const arrowFatLinesUp = IconData(0xe52a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-right.svg)
-  static const arrowFatRight = PhosphorFlatIconData(0xe52c, 'Regular');
+  static const arrowFatRight = IconData(0xe52c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-fat-up.svg)
-  static const arrowFatUp = PhosphorFlatIconData(0xe52e, 'Regular');
+  static const arrowFatUp = IconData(0xe52e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-left.svg)
-  static const arrowLeft = PhosphorFlatIconData(0xe058, 'Regular');
+  static const arrowLeft = IconData(0xe058,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-line-down.svg)
-  static const arrowLineDown = PhosphorFlatIconData(0xe05c, 'Regular');
+  static const arrowLineDown = IconData(0xe05c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-line-down-left.svg)
-  static const arrowLineDownLeft = PhosphorFlatIconData(0xe05e, 'Regular');
+  static const arrowLineDownLeft = IconData(0xe05e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-line-down-right.svg)
-  static const arrowLineDownRight = PhosphorFlatIconData(0xe060, 'Regular');
+  static const arrowLineDownRight = IconData(0xe060,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-line-left.svg)
-  static const arrowLineLeft = PhosphorFlatIconData(0xe062, 'Regular');
+  static const arrowLineLeft = IconData(0xe062,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-line-right.svg)
-  static const arrowLineRight = PhosphorFlatIconData(0xe064, 'Regular');
+  static const arrowLineRight = IconData(0xe064,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-line-up.svg)
-  static const arrowLineUp = PhosphorFlatIconData(0xe066, 'Regular');
+  static const arrowLineUp = IconData(0xe066,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-line-up-left.svg)
-  static const arrowLineUpLeft = PhosphorFlatIconData(0xe068, 'Regular');
+  static const arrowLineUpLeft = IconData(0xe068,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-line-up-right.svg)
-  static const arrowLineUpRight = PhosphorFlatIconData(0xe06a, 'Regular');
+  static const arrowLineUpRight = IconData(0xe06a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-right.svg)
-  static const arrowRight = PhosphorFlatIconData(0xe06c, 'Regular');
+  static const arrowRight = IconData(0xe06c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-down.svg)
-  static const arrowSquareDown = PhosphorFlatIconData(0xe06e, 'Regular');
+  static const arrowSquareDown = IconData(0xe06e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-down-left.svg)
-  static const arrowSquareDownLeft = PhosphorFlatIconData(0xe070, 'Regular');
+  static const arrowSquareDownLeft = IconData(0xe070,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-down-right.svg)
-  static const arrowSquareDownRight = PhosphorFlatIconData(0xe072, 'Regular');
+  static const arrowSquareDownRight = IconData(0xe072,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-in](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-in.svg)
-  static const arrowSquareIn = PhosphorFlatIconData(0xe5dc, 'Regular');
+  static const arrowSquareIn = IconData(0xe5dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-left.svg)
-  static const arrowSquareLeft = PhosphorFlatIconData(0xe074, 'Regular');
+  static const arrowSquareLeft = IconData(0xe074,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-out](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-out.svg)
-  static const arrowSquareOut = PhosphorFlatIconData(0xe5de, 'Regular');
+  static const arrowSquareOut = IconData(0xe5de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-right.svg)
-  static const arrowSquareRight = PhosphorFlatIconData(0xe076, 'Regular');
+  static const arrowSquareRight = IconData(0xe076,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-up.svg)
-  static const arrowSquareUp = PhosphorFlatIconData(0xe078, 'Regular');
+  static const arrowSquareUp = IconData(0xe078,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-up-left.svg)
-  static const arrowSquareUpLeft = PhosphorFlatIconData(0xe07a, 'Regular');
+  static const arrowSquareUpLeft = IconData(0xe07a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-square-up-right.svg)
-  static const arrowSquareUpRight = PhosphorFlatIconData(0xe07c, 'Regular');
+  static const arrowSquareUpRight = IconData(0xe07c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-u-down-left.svg)
-  static const arrowUDownLeft = PhosphorFlatIconData(0xe07e, 'Regular');
+  static const arrowUDownLeft = IconData(0xe07e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-u-down-right.svg)
-  static const arrowUDownRight = PhosphorFlatIconData(0xe080, 'Regular');
+  static const arrowUDownRight = IconData(0xe080,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-u-left-down.svg)
-  static const arrowULeftDown = PhosphorFlatIconData(0xe082, 'Regular');
+  static const arrowULeftDown = IconData(0xe082,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-u-left-up.svg)
-  static const arrowULeftUp = PhosphorFlatIconData(0xe084, 'Regular');
+  static const arrowULeftUp = IconData(0xe084,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-u-right-down.svg)
-  static const arrowURightDown = PhosphorFlatIconData(0xe086, 'Regular');
+  static const arrowURightDown = IconData(0xe086,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-u-right-up.svg)
-  static const arrowURightUp = PhosphorFlatIconData(0xe088, 'Regular');
+  static const arrowURightUp = IconData(0xe088,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-u-up-left.svg)
-  static const arrowUUpLeft = PhosphorFlatIconData(0xe08a, 'Regular');
+  static const arrowUUpLeft = IconData(0xe08a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-u-up-right.svg)
-  static const arrowUUpRight = PhosphorFlatIconData(0xe08c, 'Regular');
+  static const arrowUUpRight = IconData(0xe08c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-up.svg)
-  static const arrowUp = PhosphorFlatIconData(0xe08e, 'Regular');
+  static const arrowUp = IconData(0xe08e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-up-left.svg)
-  static const arrowUpLeft = PhosphorFlatIconData(0xe090, 'Regular');
+  static const arrowUpLeft = IconData(0xe090,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrow-up-right.svg)
-  static const arrowUpRight = PhosphorFlatIconData(0xe092, 'Regular');
+  static const arrowUpRight = IconData(0xe092,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-clockwise](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-clockwise.svg)
-  static const arrowsClockwise = PhosphorFlatIconData(0xe094, 'Regular');
+  static const arrowsClockwise = IconData(0xe094,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-counter-clockwise](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-counter-clockwise.svg)
-  static const arrowsCounterClockwise = PhosphorFlatIconData(0xe096, 'Regular');
+  static const arrowsCounterClockwise = IconData(0xe096,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-down-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-down-up.svg)
-  static const arrowsDownUp = PhosphorFlatIconData(0xe098, 'Regular');
+  static const arrowsDownUp = IconData(0xe098,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-horizontal.svg)
-  static const arrowsHorizontal = PhosphorFlatIconData(0xeb06, 'Regular');
+  static const arrowsHorizontal = IconData(0xeb06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-in.svg)
-  static const arrowsIn = PhosphorFlatIconData(0xe09a, 'Regular');
+  static const arrowsIn = IconData(0xe09a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-cardinal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-in-cardinal.svg)
-  static const arrowsInCardinal = PhosphorFlatIconData(0xe09c, 'Regular');
+  static const arrowsInCardinal = IconData(0xe09c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-in-line-horizontal.svg)
-  static const arrowsInLineHorizontal = PhosphorFlatIconData(0xe530, 'Regular');
+  static const arrowsInLineHorizontal = IconData(0xe530,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-in-line-vertical.svg)
-  static const arrowsInLineVertical = PhosphorFlatIconData(0xe532, 'Regular');
+  static const arrowsInLineVertical = IconData(0xe532,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-in-simple.svg)
-  static const arrowsInSimple = PhosphorFlatIconData(0xe09e, 'Regular');
+  static const arrowsInSimple = IconData(0xe09e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-left-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-left-right.svg)
-  static const arrowsLeftRight = PhosphorFlatIconData(0xe0a0, 'Regular');
+  static const arrowsLeftRight = IconData(0xe0a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-merge](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-merge.svg)
-  static const arrowsMerge = PhosphorFlatIconData(0xed3e, 'Regular');
+  static const arrowsMerge = IconData(0xed3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-out.svg)
-  static const arrowsOut = PhosphorFlatIconData(0xe0a2, 'Regular');
+  static const arrowsOut = IconData(0xe0a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-cardinal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-out-cardinal.svg)
-  static const arrowsOutCardinal = PhosphorFlatIconData(0xe0a4, 'Regular');
+  static const arrowsOutCardinal = IconData(0xe0a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-out-line-horizontal.svg)
-  static const arrowsOutLineHorizontal =
-      PhosphorFlatIconData(0xe534, 'Regular');
+  static const arrowsOutLineHorizontal = IconData(0xe534,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-out-line-vertical.svg)
-  static const arrowsOutLineVertical = PhosphorFlatIconData(0xe536, 'Regular');
+  static const arrowsOutLineVertical = IconData(0xe536,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-out-simple.svg)
-  static const arrowsOutSimple = PhosphorFlatIconData(0xe0a6, 'Regular');
+  static const arrowsOutSimple = IconData(0xe0a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-split](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-split.svg)
-  static const arrowsSplit = PhosphorFlatIconData(0xed3c, 'Regular');
+  static const arrowsSplit = IconData(0xed3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/arrows-vertical.svg)
-  static const arrowsVertical = PhosphorFlatIconData(0xeb04, 'Regular');
+  static const arrowsVertical = IconData(0xeb04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/article.svg)
-  static const article = PhosphorFlatIconData(0xe0a8, 'Regular');
+  static const article = IconData(0xe0a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-medium](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/article-medium.svg)
-  static const articleMedium = PhosphorFlatIconData(0xe5e0, 'Regular');
+  static const articleMedium = IconData(0xe5e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-ny-times](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/article-ny-times.svg)
-  static const articleNyTimes = PhosphorFlatIconData(0xe5e2, 'Regular');
+  static const articleNyTimes = IconData(0xe5e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asclepius](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/asclepius.svg)
-  static const asclepius = PhosphorFlatIconData(0xee34, 'Regular');
+  static const asclepius = IconData(0xee34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/asterisk.svg)
-  static const asterisk = PhosphorFlatIconData(0xe0aa, 'Regular');
+  static const asterisk = IconData(0xe0aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/asterisk-simple.svg)
-  static const asteriskSimple = PhosphorFlatIconData(0xe832, 'Regular');
+  static const asteriskSimple = IconData(0xe832,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![at](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/at.svg)
-  static const at = PhosphorFlatIconData(0xe0ac, 'Regular');
+  static const at = IconData(0xe0ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![atom](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/atom.svg)
-  static const atom = PhosphorFlatIconData(0xe5e4, 'Regular');
+  static const atom = IconData(0xe5e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![avocado](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/avocado.svg)
-  static const avocado = PhosphorFlatIconData(0xee04, 'Regular');
+  static const avocado = IconData(0xee04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![axe](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/axe.svg)
-  static const axe = PhosphorFlatIconData(0xe9fc, 'Regular');
+  static const axe = IconData(0xe9fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/baby.svg)
-  static const baby = PhosphorFlatIconData(0xe774, 'Regular');
+  static const baby = IconData(0xe774,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-carriage](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/baby-carriage.svg)
-  static const babyCarriage = PhosphorFlatIconData(0xe818, 'Regular');
+  static const babyCarriage = IconData(0xe818,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backpack](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/backpack.svg)
-  static const backpack = PhosphorFlatIconData(0xe922, 'Regular');
+  static const backpack = IconData(0xe922,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backspace](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/backspace.svg)
-  static const backspace = PhosphorFlatIconData(0xe0ae, 'Regular');
+  static const backspace = IconData(0xe0ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bag.svg)
-  static const bag = PhosphorFlatIconData(0xe0b0, 'Regular');
+  static const bag = IconData(0xe0b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bag-simple.svg)
-  static const bagSimple = PhosphorFlatIconData(0xe5e6, 'Regular');
+  static const bagSimple = IconData(0xe5e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![balloon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/balloon.svg)
-  static const balloon = PhosphorFlatIconData(0xe76c, 'Regular');
+  static const balloon = IconData(0xe76c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bandaids](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bandaids.svg)
-  static const bandaids = PhosphorFlatIconData(0xe0b2, 'Regular');
+  static const bandaids = IconData(0xe0b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bank](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bank.svg)
-  static const bank = PhosphorFlatIconData(0xe0b4, 'Regular');
+  static const bank = IconData(0xe0b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barbell](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/barbell.svg)
-  static const barbell = PhosphorFlatIconData(0xe0b6, 'Regular');
+  static const barbell = IconData(0xe0b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barcode](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/barcode.svg)
-  static const barcode = PhosphorFlatIconData(0xe0b8, 'Regular');
+  static const barcode = IconData(0xe0b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barn](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/barn.svg)
-  static const barn = PhosphorFlatIconData(0xec72, 'Regular');
+  static const barn = IconData(0xec72,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barricade](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/barricade.svg)
-  static const barricade = PhosphorFlatIconData(0xe948, 'Regular');
+  static const barricade = IconData(0xe948,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/baseball.svg)
-  static const baseball = PhosphorFlatIconData(0xe71a, 'Regular');
+  static const baseball = IconData(0xe71a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-cap](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/baseball-cap.svg)
-  static const baseballCap = PhosphorFlatIconData(0xea28, 'Regular');
+  static const baseballCap = IconData(0xea28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-helmet](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/baseball-helmet.svg)
-  static const baseballHelmet = PhosphorFlatIconData(0xee4a, 'Regular');
+  static const baseballHelmet = IconData(0xee4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basket](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/basket.svg)
-  static const basket = PhosphorFlatIconData(0xe964, 'Regular');
+  static const basket = IconData(0xe964,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basketball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/basketball.svg)
-  static const basketball = PhosphorFlatIconData(0xe724, 'Regular');
+  static const basketball = IconData(0xe724,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bathtub](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bathtub.svg)
-  static const bathtub = PhosphorFlatIconData(0xe81e, 'Regular');
+  static const bathtub = IconData(0xe81e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-charging.svg)
-  static const batteryCharging = PhosphorFlatIconData(0xe0ba, 'Regular');
+  static const batteryCharging = IconData(0xe0ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-charging-vertical.svg)
-  static const batteryChargingVertical =
-      PhosphorFlatIconData(0xe0bc, 'Regular');
+  static const batteryChargingVertical = IconData(0xe0bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-empty](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-empty.svg)
-  static const batteryEmpty = PhosphorFlatIconData(0xe0be, 'Regular');
+  static const batteryEmpty = IconData(0xe0be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-full](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-full.svg)
-  static const batteryFull = PhosphorFlatIconData(0xe0c0, 'Regular');
+  static const batteryFull = IconData(0xe0c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-high](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-high.svg)
-  static const batteryHigh = PhosphorFlatIconData(0xe0c2, 'Regular');
+  static const batteryHigh = IconData(0xe0c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-low](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-low.svg)
-  static const batteryLow = PhosphorFlatIconData(0xe0c4, 'Regular');
+  static const batteryLow = IconData(0xe0c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-medium](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-medium.svg)
-  static const batteryMedium = PhosphorFlatIconData(0xe0c6, 'Regular');
+  static const batteryMedium = IconData(0xe0c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-plus.svg)
-  static const batteryPlus = PhosphorFlatIconData(0xe808, 'Regular');
+  static const batteryPlus = IconData(0xe808,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-plus-vertical.svg)
-  static const batteryPlusVertical = PhosphorFlatIconData(0xec50, 'Regular');
+  static const batteryPlusVertical = IconData(0xec50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-empty](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-vertical-empty.svg)
-  static const batteryVerticalEmpty = PhosphorFlatIconData(0xe7c6, 'Regular');
+  static const batteryVerticalEmpty = IconData(0xe7c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-full](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-vertical-full.svg)
-  static const batteryVerticalFull = PhosphorFlatIconData(0xe7c4, 'Regular');
+  static const batteryVerticalFull = IconData(0xe7c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-high](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-vertical-high.svg)
-  static const batteryVerticalHigh = PhosphorFlatIconData(0xe7c2, 'Regular');
+  static const batteryVerticalHigh = IconData(0xe7c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-low](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-vertical-low.svg)
-  static const batteryVerticalLow = PhosphorFlatIconData(0xe7be, 'Regular');
+  static const batteryVerticalLow = IconData(0xe7be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-medium](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-vertical-medium.svg)
-  static const batteryVerticalMedium = PhosphorFlatIconData(0xe7c0, 'Regular');
+  static const batteryVerticalMedium = IconData(0xe7c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-warning.svg)
-  static const batteryWarning = PhosphorFlatIconData(0xe0c8, 'Regular');
+  static const batteryWarning = IconData(0xe0c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/battery-warning-vertical.svg)
-  static const batteryWarningVertical = PhosphorFlatIconData(0xe0ca, 'Regular');
+  static const batteryWarningVertical = IconData(0xe0ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beach-ball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/beach-ball.svg)
-  static const beachBall = PhosphorFlatIconData(0xed24, 'Regular');
+  static const beachBall = IconData(0xed24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beanie](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/beanie.svg)
-  static const beanie = PhosphorFlatIconData(0xea2a, 'Regular');
+  static const beanie = IconData(0xea2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bed.svg)
-  static const bed = PhosphorFlatIconData(0xe0cc, 'Regular');
+  static const bed = IconData(0xe0cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-bottle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/beer-bottle.svg)
-  static const beerBottle = PhosphorFlatIconData(0xe7b0, 'Regular');
+  static const beerBottle = IconData(0xe7b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-stein](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/beer-stein.svg)
-  static const beerStein = PhosphorFlatIconData(0xeb62, 'Regular');
+  static const beerStein = IconData(0xeb62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![behance-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/behance-logo.svg)
-  static const behanceLogo = PhosphorFlatIconData(0xe7f4, 'Regular');
+  static const behanceLogo = IconData(0xe7f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bell.svg)
-  static const bell = PhosphorFlatIconData(0xe0ce, 'Regular');
+  static const bell = IconData(0xe0ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-ringing](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bell-ringing.svg)
-  static const bellRinging = PhosphorFlatIconData(0xe5e8, 'Regular');
+  static const bellRinging = IconData(0xe5e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bell-simple.svg)
-  static const bellSimple = PhosphorFlatIconData(0xe0d0, 'Regular');
+  static const bellSimple = IconData(0xe0d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-ringing](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bell-simple-ringing.svg)
-  static const bellSimpleRinging = PhosphorFlatIconData(0xe5ea, 'Regular');
+  static const bellSimpleRinging = IconData(0xe5ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bell-simple-slash.svg)
-  static const bellSimpleSlash = PhosphorFlatIconData(0xe0d2, 'Regular');
+  static const bellSimpleSlash = IconData(0xe0d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-z](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bell-simple-z.svg)
-  static const bellSimpleZ = PhosphorFlatIconData(0xe5ec, 'Regular');
+  static const bellSimpleZ = IconData(0xe5ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bell-slash.svg)
-  static const bellSlash = PhosphorFlatIconData(0xe0d4, 'Regular');
+  static const bellSlash = IconData(0xe0d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-z](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bell-z.svg)
-  static const bellZ = PhosphorFlatIconData(0xe5ee, 'Regular');
+  static const bellZ = IconData(0xe5ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![belt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/belt.svg)
-  static const belt = PhosphorFlatIconData(0xea2c, 'Regular');
+  static const belt = IconData(0xea2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bezier-curve](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bezier-curve.svg)
-  static const bezierCurve = PhosphorFlatIconData(0xeb00, 'Regular');
+  static const bezierCurve = IconData(0xeb00,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bicycle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bicycle.svg)
-  static const bicycle = PhosphorFlatIconData(0xe0d6, 'Regular');
+  static const bicycle = IconData(0xe0d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binary](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/binary.svg)
-  static const binary = PhosphorFlatIconData(0xee60, 'Regular');
+  static const binary = IconData(0xee60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binoculars](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/binoculars.svg)
-  static const binoculars = PhosphorFlatIconData(0xea64, 'Regular');
+  static const binoculars = IconData(0xea64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![biohazard](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/biohazard.svg)
-  static const biohazard = PhosphorFlatIconData(0xe9e0, 'Regular');
+  static const biohazard = IconData(0xe9e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bird](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bird.svg)
-  static const bird = PhosphorFlatIconData(0xe72c, 'Regular');
+  static const bird = IconData(0xe72c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![blueprint](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/blueprint.svg)
-  static const blueprint = PhosphorFlatIconData(0xeda0, 'Regular');
+  static const blueprint = IconData(0xeda0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bluetooth.svg)
-  static const bluetooth = PhosphorFlatIconData(0xe0da, 'Regular');
+  static const bluetooth = IconData(0xe0da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-connected](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bluetooth-connected.svg)
-  static const bluetoothConnected = PhosphorFlatIconData(0xe0dc, 'Regular');
+  static const bluetoothConnected = IconData(0xe0dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bluetooth-slash.svg)
-  static const bluetoothSlash = PhosphorFlatIconData(0xe0de, 'Regular');
+  static const bluetoothSlash = IconData(0xe0de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bluetooth-x.svg)
-  static const bluetoothX = PhosphorFlatIconData(0xe0e0, 'Regular');
+  static const bluetoothX = IconData(0xe0e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/boat.svg)
-  static const boat = PhosphorFlatIconData(0xe786, 'Regular');
+  static const boat = IconData(0xe786,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bomb](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bomb.svg)
-  static const bomb = PhosphorFlatIconData(0xee0a, 'Regular');
+  static const bomb = IconData(0xee0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bone.svg)
-  static const bone = PhosphorFlatIconData(0xe7f2, 'Regular');
+  static const bone = IconData(0xe7f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/book.svg)
-  static const book = PhosphorFlatIconData(0xe0e2, 'Regular');
+  static const book = IconData(0xe0e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-bookmark](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/book-bookmark.svg)
-  static const bookBookmark = PhosphorFlatIconData(0xe0e4, 'Regular');
+  static const bookBookmark = IconData(0xe0e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/book-open.svg)
-  static const bookOpen = PhosphorFlatIconData(0xe0e6, 'Regular');
+  static const bookOpen = IconData(0xe0e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-text](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/book-open-text.svg)
-  static const bookOpenText = PhosphorFlatIconData(0xe8f2, 'Regular');
+  static const bookOpenText = IconData(0xe8f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-user](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/book-open-user.svg)
-  static const bookOpenUser = PhosphorFlatIconData(0xede0, 'Regular');
+  static const bookOpenUser = IconData(0xede0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bookmark.svg)
-  static const bookmark = PhosphorFlatIconData(0xe0e8, 'Regular');
+  static const bookmark = IconData(0xe0e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bookmark-simple.svg)
-  static const bookmarkSimple = PhosphorFlatIconData(0xe0ea, 'Regular');
+  static const bookmarkSimple = IconData(0xe0ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bookmarks.svg)
-  static const bookmarks = PhosphorFlatIconData(0xe0ec, 'Regular');
+  static const bookmarks = IconData(0xe0ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bookmarks-simple.svg)
-  static const bookmarksSimple = PhosphorFlatIconData(0xe5f0, 'Regular');
+  static const bookmarksSimple = IconData(0xe5f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![books](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/books.svg)
-  static const books = PhosphorFlatIconData(0xe758, 'Regular');
+  static const books = IconData(0xe758,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boot](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/boot.svg)
-  static const boot = PhosphorFlatIconData(0xecca, 'Regular');
+  static const boot = IconData(0xecca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boules](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/boules.svg)
-  static const boules = PhosphorFlatIconData(0xe722, 'Regular');
+  static const boules = IconData(0xe722,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bounding-box](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bounding-box.svg)
-  static const boundingBox = PhosphorFlatIconData(0xe6ce, 'Regular');
+  static const boundingBox = IconData(0xe6ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-food](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bowl-food.svg)
-  static const bowlFood = PhosphorFlatIconData(0xeaa4, 'Regular');
+  static const bowlFood = IconData(0xeaa4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-steam](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bowl-steam.svg)
-  static const bowlSteam = PhosphorFlatIconData(0xe8e4, 'Regular');
+  static const bowlSteam = IconData(0xe8e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowling-ball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bowling-ball.svg)
-  static const bowlingBall = PhosphorFlatIconData(0xea34, 'Regular');
+  static const bowlingBall = IconData(0xea34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/box-arrow-down.svg)
-  static const boxArrowDown = PhosphorFlatIconData(0xe00e, 'Regular');
+  static const boxArrowDown = IconData(0xe00e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/box-arrow-up.svg)
-  static const boxArrowUp = PhosphorFlatIconData(0xee54, 'Regular');
+  static const boxArrowUp = IconData(0xee54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boxing-glove](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/boxing-glove.svg)
-  static const boxingGlove = PhosphorFlatIconData(0xea36, 'Regular');
+  static const boxingGlove = IconData(0xea36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-angle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/brackets-angle.svg)
-  static const bracketsAngle = PhosphorFlatIconData(0xe862, 'Regular');
+  static const bracketsAngle = IconData(0xe862,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-curly](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/brackets-curly.svg)
-  static const bracketsCurly = PhosphorFlatIconData(0xe860, 'Regular');
+  static const bracketsCurly = IconData(0xe860,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-round](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/brackets-round.svg)
-  static const bracketsRound = PhosphorFlatIconData(0xe864, 'Regular');
+  static const bracketsRound = IconData(0xe864,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/brackets-square.svg)
-  static const bracketsSquare = PhosphorFlatIconData(0xe85e, 'Regular');
+  static const bracketsSquare = IconData(0xe85e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brain](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/brain.svg)
-  static const brain = PhosphorFlatIconData(0xe74e, 'Regular');
+  static const brain = IconData(0xe74e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brandy](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/brandy.svg)
-  static const brandy = PhosphorFlatIconData(0xe6b4, 'Regular');
+  static const brandy = IconData(0xe6b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bread](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bread.svg)
-  static const bread = PhosphorFlatIconData(0xe81c, 'Regular');
+  static const bread = IconData(0xe81c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bridge](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bridge.svg)
-  static const bridge = PhosphorFlatIconData(0xea68, 'Regular');
+  static const bridge = IconData(0xea68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/briefcase.svg)
-  static const briefcase = PhosphorFlatIconData(0xe0ee, 'Regular');
+  static const briefcase = IconData(0xe0ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-metal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/briefcase-metal.svg)
-  static const briefcaseMetal = PhosphorFlatIconData(0xe5f2, 'Regular');
+  static const briefcaseMetal = IconData(0xe5f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broadcast](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/broadcast.svg)
-  static const broadcast = PhosphorFlatIconData(0xe0f2, 'Regular');
+  static const broadcast = IconData(0xe0f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broom](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/broom.svg)
-  static const broom = PhosphorFlatIconData(0xec54, 'Regular');
+  static const broom = IconData(0xec54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browser](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/browser.svg)
-  static const browser = PhosphorFlatIconData(0xe0f4, 'Regular');
+  static const browser = IconData(0xe0f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browsers](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/browsers.svg)
-  static const browsers = PhosphorFlatIconData(0xe0f6, 'Regular');
+  static const browsers = IconData(0xe0f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bug.svg)
-  static const bug = PhosphorFlatIconData(0xe5f4, 'Regular');
+  static const bug = IconData(0xe5f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-beetle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bug-beetle.svg)
-  static const bugBeetle = PhosphorFlatIconData(0xe5f6, 'Regular');
+  static const bugBeetle = IconData(0xe5f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-droid](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bug-droid.svg)
-  static const bugDroid = PhosphorFlatIconData(0xe5f8, 'Regular');
+  static const bugDroid = IconData(0xe5f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/building.svg)
-  static const building = PhosphorFlatIconData(0xe100, 'Regular');
+  static const building = IconData(0xe100,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-apartment](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/building-apartment.svg)
-  static const buildingApartment = PhosphorFlatIconData(0xe0fe, 'Regular');
+  static const buildingApartment = IconData(0xe0fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-office](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/building-office.svg)
-  static const buildingOffice = PhosphorFlatIconData(0xe0ff, 'Regular');
+  static const buildingOffice = IconData(0xe0ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![buildings](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/buildings.svg)
-  static const buildings = PhosphorFlatIconData(0xe102, 'Regular');
+  static const buildings = IconData(0xe102,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bulldozer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bulldozer.svg)
-  static const bulldozer = PhosphorFlatIconData(0xec6c, 'Regular');
+  static const bulldozer = IconData(0xec6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/bus.svg)
-  static const bus = PhosphorFlatIconData(0xe106, 'Regular');
+  static const bus = IconData(0xe106,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![butterfly](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/butterfly.svg)
-  static const butterfly = PhosphorFlatIconData(0xea6e, 'Regular');
+  static const butterfly = IconData(0xea6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cable-car](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cable-car.svg)
-  static const cableCar = PhosphorFlatIconData(0xe49c, 'Regular');
+  static const cableCar = IconData(0xe49c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cactus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cactus.svg)
-  static const cactus = PhosphorFlatIconData(0xe918, 'Regular');
+  static const cactus = IconData(0xe918,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cake](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cake.svg)
-  static const cake = PhosphorFlatIconData(0xe780, 'Regular');
+  static const cake = IconData(0xe780,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calculator](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calculator.svg)
-  static const calculator = PhosphorFlatIconData(0xe538, 'Regular');
+  static const calculator = IconData(0xe538,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar.svg)
-  static const calendar = PhosphorFlatIconData(0xe108, 'Regular');
+  static const calendar = IconData(0xe108,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-blank](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-blank.svg)
-  static const calendarBlank = PhosphorFlatIconData(0xe10a, 'Regular');
+  static const calendarBlank = IconData(0xe10a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-check](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-check.svg)
-  static const calendarCheck = PhosphorFlatIconData(0xe712, 'Regular');
+  static const calendarCheck = IconData(0xe712,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dot](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-dot.svg)
-  static const calendarDot = PhosphorFlatIconData(0xe7b2, 'Regular');
+  static const calendarDot = IconData(0xe7b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dots](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-dots.svg)
-  static const calendarDots = PhosphorFlatIconData(0xe7b4, 'Regular');
+  static const calendarDots = IconData(0xe7b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-heart](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-heart.svg)
-  static const calendarHeart = PhosphorFlatIconData(0xe8b0, 'Regular');
+  static const calendarHeart = IconData(0xe8b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-minus.svg)
-  static const calendarMinus = PhosphorFlatIconData(0xea14, 'Regular');
+  static const calendarMinus = IconData(0xea14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-plus.svg)
-  static const calendarPlus = PhosphorFlatIconData(0xe714, 'Regular');
+  static const calendarPlus = IconData(0xe714,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-slash.svg)
-  static const calendarSlash = PhosphorFlatIconData(0xea12, 'Regular');
+  static const calendarSlash = IconData(0xea12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-star](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-star.svg)
-  static const calendarStar = PhosphorFlatIconData(0xe8b2, 'Regular');
+  static const calendarStar = IconData(0xe8b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/calendar-x.svg)
-  static const calendarX = PhosphorFlatIconData(0xe10c, 'Regular');
+  static const calendarX = IconData(0xe10c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![call-bell](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/call-bell.svg)
-  static const callBell = PhosphorFlatIconData(0xe7de, 'Regular');
+  static const callBell = IconData(0xe7de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/camera.svg)
-  static const camera = PhosphorFlatIconData(0xe10e, 'Regular');
+  static const camera = IconData(0xe10e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/camera-plus.svg)
-  static const cameraPlus = PhosphorFlatIconData(0xec58, 'Regular');
+  static const cameraPlus = IconData(0xec58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-rotate](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/camera-rotate.svg)
-  static const cameraRotate = PhosphorFlatIconData(0xe7a4, 'Regular');
+  static const cameraRotate = IconData(0xe7a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/camera-slash.svg)
-  static const cameraSlash = PhosphorFlatIconData(0xe110, 'Regular');
+  static const cameraSlash = IconData(0xe110,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![campfire](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/campfire.svg)
-  static const campfire = PhosphorFlatIconData(0xe9d8, 'Regular');
+  static const campfire = IconData(0xe9d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/car.svg)
-  static const car = PhosphorFlatIconData(0xe112, 'Regular');
+  static const car = IconData(0xe112,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-battery](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/car-battery.svg)
-  static const carBattery = PhosphorFlatIconData(0xee30, 'Regular');
+  static const carBattery = IconData(0xee30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-profile](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/car-profile.svg)
-  static const carProfile = PhosphorFlatIconData(0xe8cc, 'Regular');
+  static const carProfile = IconData(0xe8cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/car-simple.svg)
-  static const carSimple = PhosphorFlatIconData(0xe114, 'Regular');
+  static const carSimple = IconData(0xe114,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cardholder](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cardholder.svg)
-  static const cardholder = PhosphorFlatIconData(0xe5fa, 'Regular');
+  static const cardholder = IconData(0xe5fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cards.svg)
-  static const cards = PhosphorFlatIconData(0xe0f8, 'Regular');
+  static const cards = IconData(0xe0f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cards-three.svg)
-  static const cardsThree = PhosphorFlatIconData(0xee50, 'Regular');
+  static const cardsThree = IconData(0xee50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-double-down.svg)
-  static const caretCircleDoubleDown = PhosphorFlatIconData(0xe116, 'Regular');
+  static const caretCircleDoubleDown = IconData(0xe116,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-double-left.svg)
-  static const caretCircleDoubleLeft = PhosphorFlatIconData(0xe118, 'Regular');
+  static const caretCircleDoubleLeft = IconData(0xe118,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-double-right.svg)
-  static const caretCircleDoubleRight = PhosphorFlatIconData(0xe11a, 'Regular');
+  static const caretCircleDoubleRight = IconData(0xe11a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-double-up.svg)
-  static const caretCircleDoubleUp = PhosphorFlatIconData(0xe11c, 'Regular');
+  static const caretCircleDoubleUp = IconData(0xe11c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-down.svg)
-  static const caretCircleDown = PhosphorFlatIconData(0xe11e, 'Regular');
+  static const caretCircleDown = IconData(0xe11e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-left.svg)
-  static const caretCircleLeft = PhosphorFlatIconData(0xe120, 'Regular');
+  static const caretCircleLeft = IconData(0xe120,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-right.svg)
-  static const caretCircleRight = PhosphorFlatIconData(0xe122, 'Regular');
+  static const caretCircleRight = IconData(0xe122,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-up.svg)
-  static const caretCircleUp = PhosphorFlatIconData(0xe124, 'Regular');
+  static const caretCircleUp = IconData(0xe124,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-circle-up-down.svg)
-  static const caretCircleUpDown = PhosphorFlatIconData(0xe13e, 'Regular');
+  static const caretCircleUpDown = IconData(0xe13e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-double-down.svg)
-  static const caretDoubleDown = PhosphorFlatIconData(0xe126, 'Regular');
+  static const caretDoubleDown = IconData(0xe126,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-double-left.svg)
-  static const caretDoubleLeft = PhosphorFlatIconData(0xe128, 'Regular');
+  static const caretDoubleLeft = IconData(0xe128,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-double-right.svg)
-  static const caretDoubleRight = PhosphorFlatIconData(0xe12a, 'Regular');
+  static const caretDoubleRight = IconData(0xe12a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-double-up.svg)
-  static const caretDoubleUp = PhosphorFlatIconData(0xe12c, 'Regular');
+  static const caretDoubleUp = IconData(0xe12c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-down.svg)
-  static const caretDown = PhosphorFlatIconData(0xe136, 'Regular');
+  static const caretDown = IconData(0xe136,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-left.svg)
-  static const caretLeft = PhosphorFlatIconData(0xe138, 'Regular');
+  static const caretLeft = IconData(0xe138,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-line-down.svg)
-  static const caretLineDown = PhosphorFlatIconData(0xe134, 'Regular');
+  static const caretLineDown = IconData(0xe134,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-line-left.svg)
-  static const caretLineLeft = PhosphorFlatIconData(0xe132, 'Regular');
+  static const caretLineLeft = IconData(0xe132,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-line-right.svg)
-  static const caretLineRight = PhosphorFlatIconData(0xe130, 'Regular');
+  static const caretLineRight = IconData(0xe130,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-line-up.svg)
-  static const caretLineUp = PhosphorFlatIconData(0xe12e, 'Regular');
+  static const caretLineUp = IconData(0xe12e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-right.svg)
-  static const caretRight = PhosphorFlatIconData(0xe13a, 'Regular');
+  static const caretRight = IconData(0xe13a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-up.svg)
-  static const caretUp = PhosphorFlatIconData(0xe13c, 'Regular');
+  static const caretUp = IconData(0xe13c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/caret-up-down.svg)
-  static const caretUpDown = PhosphorFlatIconData(0xe140, 'Regular');
+  static const caretUpDown = IconData(0xe140,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![carrot](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/carrot.svg)
-  static const carrot = PhosphorFlatIconData(0xed38, 'Regular');
+  static const carrot = IconData(0xed38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cash-register](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cash-register.svg)
-  static const cashRegister = PhosphorFlatIconData(0xed80, 'Regular');
+  static const cashRegister = IconData(0xed80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cassette-tape](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cassette-tape.svg)
-  static const cassetteTape = PhosphorFlatIconData(0xed2e, 'Regular');
+  static const cassetteTape = IconData(0xed2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![castle-turret](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/castle-turret.svg)
-  static const castleTurret = PhosphorFlatIconData(0xe9d0, 'Regular');
+  static const castleTurret = IconData(0xe9d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cat.svg)
-  static const cat = PhosphorFlatIconData(0xe748, 'Regular');
+  static const cat = IconData(0xe748,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-full](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cell-signal-full.svg)
-  static const cellSignalFull = PhosphorFlatIconData(0xe142, 'Regular');
+  static const cellSignalFull = IconData(0xe142,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-high](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cell-signal-high.svg)
-  static const cellSignalHigh = PhosphorFlatIconData(0xe144, 'Regular');
+  static const cellSignalHigh = IconData(0xe144,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-low](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cell-signal-low.svg)
-  static const cellSignalLow = PhosphorFlatIconData(0xe146, 'Regular');
+  static const cellSignalLow = IconData(0xe146,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-medium](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cell-signal-medium.svg)
-  static const cellSignalMedium = PhosphorFlatIconData(0xe148, 'Regular');
+  static const cellSignalMedium = IconData(0xe148,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-none](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cell-signal-none.svg)
-  static const cellSignalNone = PhosphorFlatIconData(0xe14a, 'Regular');
+  static const cellSignalNone = IconData(0xe14a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cell-signal-slash.svg)
-  static const cellSignalSlash = PhosphorFlatIconData(0xe14c, 'Regular');
+  static const cellSignalSlash = IconData(0xe14c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cell-signal-x.svg)
-  static const cellSignalX = PhosphorFlatIconData(0xe14e, 'Regular');
+  static const cellSignalX = IconData(0xe14e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-tower](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cell-tower.svg)
-  static const cellTower = PhosphorFlatIconData(0xebaa, 'Regular');
+  static const cellTower = IconData(0xebaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![certificate](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/certificate.svg)
-  static const certificate = PhosphorFlatIconData(0xe766, 'Regular');
+  static const certificate = IconData(0xe766,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chair](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chair.svg)
-  static const chair = PhosphorFlatIconData(0xe950, 'Regular');
+  static const chair = IconData(0xe950,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chalkboard.svg)
-  static const chalkboard = PhosphorFlatIconData(0xe5fc, 'Regular');
+  static const chalkboard = IconData(0xe5fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chalkboard-simple.svg)
-  static const chalkboardSimple = PhosphorFlatIconData(0xe5fe, 'Regular');
+  static const chalkboardSimple = IconData(0xe5fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-teacher](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chalkboard-teacher.svg)
-  static const chalkboardTeacher = PhosphorFlatIconData(0xe600, 'Regular');
+  static const chalkboardTeacher = IconData(0xe600,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![champagne](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/champagne.svg)
-  static const champagne = PhosphorFlatIconData(0xeaca, 'Regular');
+  static const champagne = IconData(0xeaca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![charging-station](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/charging-station.svg)
-  static const chargingStation = PhosphorFlatIconData(0xe8d0, 'Regular');
+  static const chargingStation = IconData(0xe8d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-bar.svg)
-  static const chartBar = PhosphorFlatIconData(0xe150, 'Regular');
+  static const chartBar = IconData(0xe150,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-bar-horizontal.svg)
-  static const chartBarHorizontal = PhosphorFlatIconData(0xe152, 'Regular');
+  static const chartBarHorizontal = IconData(0xe152,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-donut](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-donut.svg)
-  static const chartDonut = PhosphorFlatIconData(0xeaa6, 'Regular');
+  static const chartDonut = IconData(0xeaa6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-line.svg)
-  static const chartLine = PhosphorFlatIconData(0xe154, 'Regular');
+  static const chartLine = IconData(0xe154,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-line-down.svg)
-  static const chartLineDown = PhosphorFlatIconData(0xe8b6, 'Regular');
+  static const chartLineDown = IconData(0xe8b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-line-up.svg)
-  static const chartLineUp = PhosphorFlatIconData(0xe156, 'Regular');
+  static const chartLineUp = IconData(0xe156,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-pie.svg)
-  static const chartPie = PhosphorFlatIconData(0xe158, 'Regular');
+  static const chartPie = IconData(0xe158,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-slice](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-pie-slice.svg)
-  static const chartPieSlice = PhosphorFlatIconData(0xe15a, 'Regular');
+  static const chartPieSlice = IconData(0xe15a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-polar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-polar.svg)
-  static const chartPolar = PhosphorFlatIconData(0xeaa8, 'Regular');
+  static const chartPolar = IconData(0xeaa8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-scatter](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chart-scatter.svg)
-  static const chartScatter = PhosphorFlatIconData(0xeaac, 'Regular');
+  static const chartScatter = IconData(0xeaac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat.svg)
-  static const chat = PhosphorFlatIconData(0xe15c, 'Regular');
+  static const chat = IconData(0xe15c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-centered.svg)
-  static const chatCentered = PhosphorFlatIconData(0xe160, 'Regular');
+  static const chatCentered = IconData(0xe160,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-dots](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-centered-dots.svg)
-  static const chatCenteredDots = PhosphorFlatIconData(0xe164, 'Regular');
+  static const chatCenteredDots = IconData(0xe164,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-centered-slash.svg)
-  static const chatCenteredSlash = PhosphorFlatIconData(0xe162, 'Regular');
+  static const chatCenteredSlash = IconData(0xe162,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-text](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-centered-text.svg)
-  static const chatCenteredText = PhosphorFlatIconData(0xe166, 'Regular');
+  static const chatCenteredText = IconData(0xe166,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-circle.svg)
-  static const chatCircle = PhosphorFlatIconData(0xe168, 'Regular');
+  static const chatCircle = IconData(0xe168,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-dots](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-circle-dots.svg)
-  static const chatCircleDots = PhosphorFlatIconData(0xe16c, 'Regular');
+  static const chatCircleDots = IconData(0xe16c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-circle-slash.svg)
-  static const chatCircleSlash = PhosphorFlatIconData(0xe16a, 'Regular');
+  static const chatCircleSlash = IconData(0xe16a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-text](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-circle-text.svg)
-  static const chatCircleText = PhosphorFlatIconData(0xe16e, 'Regular');
+  static const chatCircleText = IconData(0xe16e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-dots](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-dots.svg)
-  static const chatDots = PhosphorFlatIconData(0xe170, 'Regular');
+  static const chatDots = IconData(0xe170,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-slash.svg)
-  static const chatSlash = PhosphorFlatIconData(0xe15e, 'Regular');
+  static const chatSlash = IconData(0xe15e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-teardrop.svg)
-  static const chatTeardrop = PhosphorFlatIconData(0xe172, 'Regular');
+  static const chatTeardrop = IconData(0xe172,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-dots](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-teardrop-dots.svg)
-  static const chatTeardropDots = PhosphorFlatIconData(0xe176, 'Regular');
+  static const chatTeardropDots = IconData(0xe176,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-teardrop-slash.svg)
-  static const chatTeardropSlash = PhosphorFlatIconData(0xe174, 'Regular');
+  static const chatTeardropSlash = IconData(0xe174,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-text](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-teardrop-text.svg)
-  static const chatTeardropText = PhosphorFlatIconData(0xe178, 'Regular');
+  static const chatTeardropText = IconData(0xe178,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-text](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chat-text.svg)
-  static const chatText = PhosphorFlatIconData(0xe17a, 'Regular');
+  static const chatText = IconData(0xe17a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chats.svg)
-  static const chats = PhosphorFlatIconData(0xe17c, 'Regular');
+  static const chats = IconData(0xe17c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chats-circle.svg)
-  static const chatsCircle = PhosphorFlatIconData(0xe17e, 'Regular');
+  static const chatsCircle = IconData(0xe17e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-teardrop](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chats-teardrop.svg)
-  static const chatsTeardrop = PhosphorFlatIconData(0xe180, 'Regular');
+  static const chatsTeardrop = IconData(0xe180,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/check.svg)
-  static const check = PhosphorFlatIconData(0xe182, 'Regular');
+  static const check = IconData(0xe182,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/check-circle.svg)
-  static const checkCircle = PhosphorFlatIconData(0xe184, 'Regular');
+  static const checkCircle = IconData(0xe184,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-fat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/check-fat.svg)
-  static const checkFat = PhosphorFlatIconData(0xeba6, 'Regular');
+  static const checkFat = IconData(0xeba6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/check-square.svg)
-  static const checkSquare = PhosphorFlatIconData(0xe186, 'Regular');
+  static const checkSquare = IconData(0xe186,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-offset](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/check-square-offset.svg)
-  static const checkSquareOffset = PhosphorFlatIconData(0xe188, 'Regular');
+  static const checkSquareOffset = IconData(0xe188,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checkerboard](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/checkerboard.svg)
-  static const checkerboard = PhosphorFlatIconData(0xe8c4, 'Regular');
+  static const checkerboard = IconData(0xe8c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checks](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/checks.svg)
-  static const checks = PhosphorFlatIconData(0xe53a, 'Regular');
+  static const checks = IconData(0xe53a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheers](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cheers.svg)
-  static const cheers = PhosphorFlatIconData(0xea4a, 'Regular');
+  static const cheers = IconData(0xea4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheese](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cheese.svg)
-  static const cheese = PhosphorFlatIconData(0xe9fe, 'Regular');
+  static const cheese = IconData(0xe9fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chef-hat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/chef-hat.svg)
-  static const chefHat = PhosphorFlatIconData(0xed8e, 'Regular');
+  static const chefHat = IconData(0xed8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cherries](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cherries.svg)
-  static const cherries = PhosphorFlatIconData(0xe830, 'Regular');
+  static const cherries = IconData(0xe830,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![church](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/church.svg)
-  static const church = PhosphorFlatIconData(0xecea, 'Regular');
+  static const church = IconData(0xecea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cigarette.svg)
-  static const cigarette = PhosphorFlatIconData(0xed90, 'Regular');
+  static const cigarette = IconData(0xed90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cigarette-slash.svg)
-  static const cigaretteSlash = PhosphorFlatIconData(0xed92, 'Regular');
+  static const cigaretteSlash = IconData(0xed92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circle.svg)
-  static const circle = PhosphorFlatIconData(0xe18a, 'Regular');
+  static const circle = IconData(0xe18a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-dashed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circle-dashed.svg)
-  static const circleDashed = PhosphorFlatIconData(0xe602, 'Regular');
+  static const circleDashed = IconData(0xe602,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circle-half.svg)
-  static const circleHalf = PhosphorFlatIconData(0xe18c, 'Regular');
+  static const circleHalf = IconData(0xe18c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-tilt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circle-half-tilt.svg)
-  static const circleHalfTilt = PhosphorFlatIconData(0xe18e, 'Regular');
+  static const circleHalfTilt = IconData(0xe18e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-notch](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circle-notch.svg)
-  static const circleNotch = PhosphorFlatIconData(0xeb44, 'Regular');
+  static const circleNotch = IconData(0xeb44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circles-four.svg)
-  static const circlesFour = PhosphorFlatIconData(0xe190, 'Regular');
+  static const circlesFour = IconData(0xe190,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circles-three.svg)
-  static const circlesThree = PhosphorFlatIconData(0xe192, 'Regular');
+  static const circlesThree = IconData(0xe192,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circles-three-plus.svg)
-  static const circlesThreePlus = PhosphorFlatIconData(0xe194, 'Regular');
+  static const circlesThreePlus = IconData(0xe194,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circuitry](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/circuitry.svg)
-  static const circuitry = PhosphorFlatIconData(0xe9c2, 'Regular');
+  static const circuitry = IconData(0xe9c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![city](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/city.svg)
-  static const city = PhosphorFlatIconData(0xea6a, 'Regular');
+  static const city = IconData(0xea6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clipboard.svg)
-  static const clipboard = PhosphorFlatIconData(0xe196, 'Regular');
+  static const clipboard = IconData(0xe196,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-text](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clipboard-text.svg)
-  static const clipboardText = PhosphorFlatIconData(0xe198, 'Regular');
+  static const clipboardText = IconData(0xe198,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clock.svg)
-  static const clock = PhosphorFlatIconData(0xe19a, 'Regular');
+  static const clock = IconData(0xe19a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-afternoon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clock-afternoon.svg)
-  static const clockAfternoon = PhosphorFlatIconData(0xe19c, 'Regular');
+  static const clockAfternoon = IconData(0xe19c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-clockwise](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clock-clockwise.svg)
-  static const clockClockwise = PhosphorFlatIconData(0xe19e, 'Regular');
+  static const clockClockwise = IconData(0xe19e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-countdown](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clock-countdown.svg)
-  static const clockCountdown = PhosphorFlatIconData(0xed2c, 'Regular');
+  static const clockCountdown = IconData(0xed2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-counter-clockwise](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clock-counter-clockwise.svg)
-  static const clockCounterClockwise = PhosphorFlatIconData(0xe1a0, 'Regular');
+  static const clockCounterClockwise = IconData(0xe1a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-user](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clock-user.svg)
-  static const clockUser = PhosphorFlatIconData(0xedec, 'Regular');
+  static const clockUser = IconData(0xedec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![closed-captioning](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/closed-captioning.svg)
-  static const closedCaptioning = PhosphorFlatIconData(0xe1a4, 'Regular');
+  static const closedCaptioning = IconData(0xe1a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud.svg)
-  static const cloud = PhosphorFlatIconData(0xe1aa, 'Regular');
+  static const cloud = IconData(0xe1aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-arrow-down.svg)
-  static const cloudArrowDown = PhosphorFlatIconData(0xe1ac, 'Regular');
+  static const cloudArrowDown = IconData(0xe1ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-arrow-up.svg)
-  static const cloudArrowUp = PhosphorFlatIconData(0xe1ae, 'Regular');
+  static const cloudArrowUp = IconData(0xe1ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-check](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-check.svg)
-  static const cloudCheck = PhosphorFlatIconData(0xe1b0, 'Regular');
+  static const cloudCheck = IconData(0xe1b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-fog](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-fog.svg)
-  static const cloudFog = PhosphorFlatIconData(0xe53c, 'Regular');
+  static const cloudFog = IconData(0xe53c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-lightning](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-lightning.svg)
-  static const cloudLightning = PhosphorFlatIconData(0xe1b2, 'Regular');
+  static const cloudLightning = IconData(0xe1b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-moon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-moon.svg)
-  static const cloudMoon = PhosphorFlatIconData(0xe53e, 'Regular');
+  static const cloudMoon = IconData(0xe53e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-rain](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-rain.svg)
-  static const cloudRain = PhosphorFlatIconData(0xe1b4, 'Regular');
+  static const cloudRain = IconData(0xe1b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-slash.svg)
-  static const cloudSlash = PhosphorFlatIconData(0xe1b6, 'Regular');
+  static const cloudSlash = IconData(0xe1b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-snow](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-snow.svg)
-  static const cloudSnow = PhosphorFlatIconData(0xe1b8, 'Regular');
+  static const cloudSnow = IconData(0xe1b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-sun](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-sun.svg)
-  static const cloudSun = PhosphorFlatIconData(0xe540, 'Regular');
+  static const cloudSun = IconData(0xe540,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-warning](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-warning.svg)
-  static const cloudWarning = PhosphorFlatIconData(0xea98, 'Regular');
+  static const cloudWarning = IconData(0xea98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cloud-x.svg)
-  static const cloudX = PhosphorFlatIconData(0xea96, 'Regular');
+  static const cloudX = IconData(0xea96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clover](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/clover.svg)
-  static const clover = PhosphorFlatIconData(0xedc8, 'Regular');
+  static const clover = IconData(0xedc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![club](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/club.svg)
-  static const club = PhosphorFlatIconData(0xe1ba, 'Regular');
+  static const club = IconData(0xe1ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coat-hanger](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/coat-hanger.svg)
-  static const coatHanger = PhosphorFlatIconData(0xe7fe, 'Regular');
+  static const coatHanger = IconData(0xe7fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coda-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/coda-logo.svg)
-  static const codaLogo = PhosphorFlatIconData(0xe7ce, 'Regular');
+  static const codaLogo = IconData(0xe7ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/code.svg)
-  static const code = PhosphorFlatIconData(0xe1bc, 'Regular');
+  static const code = IconData(0xe1bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-block](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/code-block.svg)
-  static const codeBlock = PhosphorFlatIconData(0xeafe, 'Regular');
+  static const codeBlock = IconData(0xeafe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/code-simple.svg)
-  static const codeSimple = PhosphorFlatIconData(0xe1be, 'Regular');
+  static const codeSimple = IconData(0xe1be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codepen-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/codepen-logo.svg)
-  static const codepenLogo = PhosphorFlatIconData(0xe978, 'Regular');
+  static const codepenLogo = IconData(0xe978,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codesandbox-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/codesandbox-logo.svg)
-  static const codesandboxLogo = PhosphorFlatIconData(0xea06, 'Regular');
+  static const codesandboxLogo = IconData(0xea06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/coffee.svg)
-  static const coffee = PhosphorFlatIconData(0xe1c2, 'Regular');
+  static const coffee = IconData(0xe1c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-bean](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/coffee-bean.svg)
-  static const coffeeBean = PhosphorFlatIconData(0xe1c0, 'Regular');
+  static const coffeeBean = IconData(0xe1c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/coin.svg)
-  static const coin = PhosphorFlatIconData(0xe60e, 'Regular');
+  static const coin = IconData(0xe60e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/coin-vertical.svg)
-  static const coinVertical = PhosphorFlatIconData(0xeb48, 'Regular');
+  static const coinVertical = IconData(0xeb48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coins](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/coins.svg)
-  static const coins = PhosphorFlatIconData(0xe78e, 'Regular');
+  static const coins = IconData(0xe78e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/columns.svg)
-  static const columns = PhosphorFlatIconData(0xe546, 'Regular');
+  static const columns = IconData(0xe546,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/columns-plus-left.svg)
-  static const columnsPlusLeft = PhosphorFlatIconData(0xe544, 'Regular');
+  static const columnsPlusLeft = IconData(0xe544,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/columns-plus-right.svg)
-  static const columnsPlusRight = PhosphorFlatIconData(0xe542, 'Regular');
+  static const columnsPlusRight = IconData(0xe542,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![command](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/command.svg)
-  static const command = PhosphorFlatIconData(0xe1c4, 'Regular');
+  static const command = IconData(0xe1c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/compass.svg)
-  static const compass = PhosphorFlatIconData(0xe1c8, 'Regular');
+  static const compass = IconData(0xe1c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-rose](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/compass-rose.svg)
-  static const compassRose = PhosphorFlatIconData(0xe1c6, 'Regular');
+  static const compassRose = IconData(0xe1c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-tool](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/compass-tool.svg)
-  static const compassTool = PhosphorFlatIconData(0xea0e, 'Regular');
+  static const compassTool = IconData(0xea0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![computer-tower](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/computer-tower.svg)
-  static const computerTower = PhosphorFlatIconData(0xe548, 'Regular');
+  static const computerTower = IconData(0xe548,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![confetti](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/confetti.svg)
-  static const confetti = PhosphorFlatIconData(0xe81a, 'Regular');
+  static const confetti = IconData(0xe81a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![contactless-payment](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/contactless-payment.svg)
-  static const contactlessPayment = PhosphorFlatIconData(0xed42, 'Regular');
+  static const contactlessPayment = IconData(0xed42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![control](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/control.svg)
-  static const control = PhosphorFlatIconData(0xeca6, 'Regular');
+  static const control = IconData(0xeca6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cookie](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cookie.svg)
-  static const cookie = PhosphorFlatIconData(0xe6ca, 'Regular');
+  static const cookie = IconData(0xe6ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cooking-pot](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cooking-pot.svg)
-  static const cookingPot = PhosphorFlatIconData(0xe764, 'Regular');
+  static const cookingPot = IconData(0xe764,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/copy.svg)
-  static const copy = PhosphorFlatIconData(0xe1ca, 'Regular');
+  static const copy = IconData(0xe1ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/copy-simple.svg)
-  static const copySimple = PhosphorFlatIconData(0xe1cc, 'Regular');
+  static const copySimple = IconData(0xe1cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyleft](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/copyleft.svg)
-  static const copyleft = PhosphorFlatIconData(0xe86a, 'Regular');
+  static const copyleft = IconData(0xe86a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyright](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/copyright.svg)
-  static const copyright = PhosphorFlatIconData(0xe54a, 'Regular');
+  static const copyright = IconData(0xe54a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-in](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/corners-in.svg)
-  static const cornersIn = PhosphorFlatIconData(0xe1ce, 'Regular');
+  static const cornersIn = IconData(0xe1ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-out](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/corners-out.svg)
-  static const cornersOut = PhosphorFlatIconData(0xe1d0, 'Regular');
+  static const cornersOut = IconData(0xe1d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![couch](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/couch.svg)
-  static const couch = PhosphorFlatIconData(0xe7f6, 'Regular');
+  static const couch = IconData(0xe7f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![court-basketball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/court-basketball.svg)
-  static const courtBasketball = PhosphorFlatIconData(0xee36, 'Regular');
+  static const courtBasketball = IconData(0xee36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cow](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cow.svg)
-  static const cow = PhosphorFlatIconData(0xeabe, 'Regular');
+  static const cow = IconData(0xeabe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cowboy-hat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cowboy-hat.svg)
-  static const cowboyHat = PhosphorFlatIconData(0xed12, 'Regular');
+  static const cowboyHat = IconData(0xed12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cpu](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cpu.svg)
-  static const cpu = PhosphorFlatIconData(0xe610, 'Regular');
+  static const cpu = IconData(0xe610,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/crane.svg)
-  static const crane = PhosphorFlatIconData(0xed48, 'Regular');
+  static const crane = IconData(0xed48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-tower](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/crane-tower.svg)
-  static const craneTower = PhosphorFlatIconData(0xed49, 'Regular');
+  static const craneTower = IconData(0xed49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![credit-card](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/credit-card.svg)
-  static const creditCard = PhosphorFlatIconData(0xe1d2, 'Regular');
+  static const creditCard = IconData(0xe1d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cricket](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cricket.svg)
-  static const cricket = PhosphorFlatIconData(0xee12, 'Regular');
+  static const cricket = IconData(0xee12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crop](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/crop.svg)
-  static const crop = PhosphorFlatIconData(0xe1d4, 'Regular');
+  static const crop = IconData(0xe1d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cross](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cross.svg)
-  static const cross = PhosphorFlatIconData(0xe8a0, 'Regular');
+  static const cross = IconData(0xe8a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/crosshair.svg)
-  static const crosshair = PhosphorFlatIconData(0xe1d6, 'Regular');
+  static const crosshair = IconData(0xe1d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/crosshair-simple.svg)
-  static const crosshairSimple = PhosphorFlatIconData(0xe1d8, 'Regular');
+  static const crosshairSimple = IconData(0xe1d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/crown.svg)
-  static const crown = PhosphorFlatIconData(0xe614, 'Regular');
+  static const crown = IconData(0xe614,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-cross](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/crown-cross.svg)
-  static const crownCross = PhosphorFlatIconData(0xee5e, 'Regular');
+  static const crownCross = IconData(0xee5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/crown-simple.svg)
-  static const crownSimple = PhosphorFlatIconData(0xe616, 'Regular');
+  static const crownSimple = IconData(0xe616,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cube.svg)
-  static const cube = PhosphorFlatIconData(0xe1da, 'Regular');
+  static const cube = IconData(0xe1da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-focus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cube-focus.svg)
-  static const cubeFocus = PhosphorFlatIconData(0xed0a, 'Regular');
+  static const cubeFocus = IconData(0xed0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-transparent](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cube-transparent.svg)
-  static const cubeTransparent = PhosphorFlatIconData(0xec7c, 'Regular');
+  static const cubeTransparent = IconData(0xec7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-btc](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-btc.svg)
-  static const currencyBtc = PhosphorFlatIconData(0xe618, 'Regular');
+  static const currencyBtc = IconData(0xe618,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-circle-dollar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-circle-dollar.svg)
-  static const currencyCircleDollar = PhosphorFlatIconData(0xe54c, 'Regular');
+  static const currencyCircleDollar = IconData(0xe54c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-cny](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-cny.svg)
-  static const currencyCny = PhosphorFlatIconData(0xe54e, 'Regular');
+  static const currencyCny = IconData(0xe54e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-dollar.svg)
-  static const currencyDollar = PhosphorFlatIconData(0xe550, 'Regular');
+  static const currencyDollar = IconData(0xe550,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-dollar-simple.svg)
-  static const currencyDollarSimple = PhosphorFlatIconData(0xe552, 'Regular');
+  static const currencyDollarSimple = IconData(0xe552,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eth](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-eth.svg)
-  static const currencyEth = PhosphorFlatIconData(0xeada, 'Regular');
+  static const currencyEth = IconData(0xeada,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eur](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-eur.svg)
-  static const currencyEur = PhosphorFlatIconData(0xe554, 'Regular');
+  static const currencyEur = IconData(0xe554,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-gbp](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-gbp.svg)
-  static const currencyGbp = PhosphorFlatIconData(0xe556, 'Regular');
+  static const currencyGbp = IconData(0xe556,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-inr](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-inr.svg)
-  static const currencyInr = PhosphorFlatIconData(0xe558, 'Regular');
+  static const currencyInr = IconData(0xe558,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-jpy](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-jpy.svg)
-  static const currencyJpy = PhosphorFlatIconData(0xe55a, 'Regular');
+  static const currencyJpy = IconData(0xe55a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-krw](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-krw.svg)
-  static const currencyKrw = PhosphorFlatIconData(0xe55c, 'Regular');
+  static const currencyKrw = IconData(0xe55c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-kzt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-kzt.svg)
-  static const currencyKzt = PhosphorFlatIconData(0xec4c, 'Regular');
+  static const currencyKzt = IconData(0xec4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-ngn](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-ngn.svg)
-  static const currencyNgn = PhosphorFlatIconData(0xeb52, 'Regular');
+  static const currencyNgn = IconData(0xeb52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-rub](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/currency-rub.svg)
-  static const currencyRub = PhosphorFlatIconData(0xe55e, 'Regular');
+  static const currencyRub = IconData(0xe55e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cursor.svg)
-  static const cursor = PhosphorFlatIconData(0xe1dc, 'Regular');
+  static const cursor = IconData(0xe1dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-click](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cursor-click.svg)
-  static const cursorClick = PhosphorFlatIconData(0xe7c8, 'Regular');
+  static const cursorClick = IconData(0xe7c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-text](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cursor-text.svg)
-  static const cursorText = PhosphorFlatIconData(0xe7d8, 'Regular');
+  static const cursorText = IconData(0xe7d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cylinder](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/cylinder.svg)
-  static const cylinder = PhosphorFlatIconData(0xe8fc, 'Regular');
+  static const cylinder = IconData(0xe8fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![database](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/database.svg)
-  static const database = PhosphorFlatIconData(0xe1de, 'Regular');
+  static const database = IconData(0xe1de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desk](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/desk.svg)
-  static const desk = PhosphorFlatIconData(0xed16, 'Regular');
+  static const desk = IconData(0xed16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/desktop.svg)
-  static const desktop = PhosphorFlatIconData(0xe560, 'Regular');
+  static const desktop = IconData(0xe560,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-tower](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/desktop-tower.svg)
-  static const desktopTower = PhosphorFlatIconData(0xe562, 'Regular');
+  static const desktopTower = IconData(0xe562,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![detective](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/detective.svg)
-  static const detective = PhosphorFlatIconData(0xe83e, 'Regular');
+  static const detective = IconData(0xe83e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dev-to-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dev-to-logo.svg)
-  static const devToLogo = PhosphorFlatIconData(0xed0e, 'Regular');
+  static const devToLogo = IconData(0xed0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/device-mobile.svg)
-  static const deviceMobile = PhosphorFlatIconData(0xe1e0, 'Regular');
+  static const deviceMobile = IconData(0xe1e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-camera](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/device-mobile-camera.svg)
-  static const deviceMobileCamera = PhosphorFlatIconData(0xe1e2, 'Regular');
+  static const deviceMobileCamera = IconData(0xe1e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/device-mobile-slash.svg)
-  static const deviceMobileSlash = PhosphorFlatIconData(0xee46, 'Regular');
+  static const deviceMobileSlash = IconData(0xee46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-speaker](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/device-mobile-speaker.svg)
-  static const deviceMobileSpeaker = PhosphorFlatIconData(0xe1e4, 'Regular');
+  static const deviceMobileSpeaker = IconData(0xe1e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-rotate](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/device-rotate.svg)
-  static const deviceRotate = PhosphorFlatIconData(0xedf2, 'Regular');
+  static const deviceRotate = IconData(0xedf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/device-tablet.svg)
-  static const deviceTablet = PhosphorFlatIconData(0xe1e6, 'Regular');
+  static const deviceTablet = IconData(0xe1e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-camera](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/device-tablet-camera.svg)
-  static const deviceTabletCamera = PhosphorFlatIconData(0xe1e8, 'Regular');
+  static const deviceTabletCamera = IconData(0xe1e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-speaker](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/device-tablet-speaker.svg)
-  static const deviceTabletSpeaker = PhosphorFlatIconData(0xe1ea, 'Regular');
+  static const deviceTabletSpeaker = IconData(0xe1ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![devices](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/devices.svg)
-  static const devices = PhosphorFlatIconData(0xeba4, 'Regular');
+  static const devices = IconData(0xeba4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamond](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/diamond.svg)
-  static const diamond = PhosphorFlatIconData(0xe1ec, 'Regular');
+  static const diamond = IconData(0xe1ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamonds-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/diamonds-four.svg)
-  static const diamondsFour = PhosphorFlatIconData(0xe8f4, 'Regular');
+  static const diamondsFour = IconData(0xe8f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-five](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dice-five.svg)
-  static const diceFive = PhosphorFlatIconData(0xe1ee, 'Regular');
+  static const diceFive = IconData(0xe1ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dice-four.svg)
-  static const diceFour = PhosphorFlatIconData(0xe1f0, 'Regular');
+  static const diceFour = IconData(0xe1f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-one](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dice-one.svg)
-  static const diceOne = PhosphorFlatIconData(0xe1f2, 'Regular');
+  static const diceOne = IconData(0xe1f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-six](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dice-six.svg)
-  static const diceSix = PhosphorFlatIconData(0xe1f4, 'Regular');
+  static const diceSix = IconData(0xe1f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dice-three.svg)
-  static const diceThree = PhosphorFlatIconData(0xe1f6, 'Regular');
+  static const diceThree = IconData(0xe1f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-two](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dice-two.svg)
-  static const diceTwo = PhosphorFlatIconData(0xe1f8, 'Regular');
+  static const diceTwo = IconData(0xe1f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disc](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/disc.svg)
-  static const disc = PhosphorFlatIconData(0xe564, 'Regular');
+  static const disc = IconData(0xe564,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disco-ball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/disco-ball.svg)
-  static const discoBall = PhosphorFlatIconData(0xed98, 'Regular');
+  static const discoBall = IconData(0xed98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![discord-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/discord-logo.svg)
-  static const discordLogo = PhosphorFlatIconData(0xe61a, 'Regular');
+  static const discordLogo = IconData(0xe61a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![divide](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/divide.svg)
-  static const divide = PhosphorFlatIconData(0xe1fa, 'Regular');
+  static const divide = IconData(0xe1fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dna](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dna.svg)
-  static const dna = PhosphorFlatIconData(0xe924, 'Regular');
+  static const dna = IconData(0xe924,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dog](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dog.svg)
-  static const dog = PhosphorFlatIconData(0xe74a, 'Regular');
+  static const dog = IconData(0xe74a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/door.svg)
-  static const door = PhosphorFlatIconData(0xe61c, 'Regular');
+  static const door = IconData(0xe61c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/door-open.svg)
-  static const doorOpen = PhosphorFlatIconData(0xe7e6, 'Regular');
+  static const doorOpen = IconData(0xe7e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dot.svg)
-  static const dot = PhosphorFlatIconData(0xecde, 'Regular');
+  static const dot = IconData(0xecde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-outline](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dot-outline.svg)
-  static const dotOutline = PhosphorFlatIconData(0xece0, 'Regular');
+  static const dotOutline = IconData(0xece0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-nine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-nine.svg)
-  static const dotsNine = PhosphorFlatIconData(0xe1fc, 'Regular');
+  static const dotsNine = IconData(0xe1fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-six.svg)
-  static const dotsSix = PhosphorFlatIconData(0xe794, 'Regular');
+  static const dotsSix = IconData(0xe794,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-six-vertical.svg)
-  static const dotsSixVertical = PhosphorFlatIconData(0xeae2, 'Regular');
+  static const dotsSixVertical = IconData(0xeae2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-three.svg)
-  static const dotsThree = PhosphorFlatIconData(0xe1fe, 'Regular');
+  static const dotsThree = IconData(0xe1fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-three-circle.svg)
-  static const dotsThreeCircle = PhosphorFlatIconData(0xe200, 'Regular');
+  static const dotsThreeCircle = IconData(0xe200,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-three-circle-vertical.svg)
-  static const dotsThreeCircleVertical =
-      PhosphorFlatIconData(0xe202, 'Regular');
+  static const dotsThreeCircleVertical = IconData(0xe202,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-three-outline.svg)
-  static const dotsThreeOutline = PhosphorFlatIconData(0xe204, 'Regular');
+  static const dotsThreeOutline = IconData(0xe204,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-three-outline-vertical.svg)
-  static const dotsThreeOutlineVertical =
-      PhosphorFlatIconData(0xe206, 'Regular');
+  static const dotsThreeOutlineVertical = IconData(0xe206,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dots-three-vertical.svg)
-  static const dotsThreeVertical = PhosphorFlatIconData(0xe208, 'Regular');
+  static const dotsThreeVertical = IconData(0xe208,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/download.svg)
-  static const download = PhosphorFlatIconData(0xe20a, 'Regular');
+  static const download = IconData(0xe20a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/download-simple.svg)
-  static const downloadSimple = PhosphorFlatIconData(0xe20c, 'Regular');
+  static const downloadSimple = IconData(0xe20c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dress](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dress.svg)
-  static const dress = PhosphorFlatIconData(0xea7e, 'Regular');
+  static const dress = IconData(0xea7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dresser](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dresser.svg)
-  static const dresser = PhosphorFlatIconData(0xe94e, 'Regular');
+  static const dresser = IconData(0xe94e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dribbble-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dribbble-logo.svg)
-  static const dribbbleLogo = PhosphorFlatIconData(0xe20e, 'Regular');
+  static const dribbbleLogo = IconData(0xe20e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/drone.svg)
-  static const drone = PhosphorFlatIconData(0xed74, 'Regular');
+  static const drone = IconData(0xed74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/drop.svg)
-  static const drop = PhosphorFlatIconData(0xe210, 'Regular');
+  static const drop = IconData(0xe210,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/drop-half.svg)
-  static const dropHalf = PhosphorFlatIconData(0xe566, 'Regular');
+  static const dropHalf = IconData(0xe566,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-bottom](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/drop-half-bottom.svg)
-  static const dropHalfBottom = PhosphorFlatIconData(0xeb40, 'Regular');
+  static const dropHalfBottom = IconData(0xeb40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/drop-simple.svg)
-  static const dropSimple = PhosphorFlatIconData(0xee32, 'Regular');
+  static const dropSimple = IconData(0xee32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/drop-slash.svg)
-  static const dropSlash = PhosphorFlatIconData(0xe954, 'Regular');
+  static const dropSlash = IconData(0xe954,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dropbox-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/dropbox-logo.svg)
-  static const dropboxLogo = PhosphorFlatIconData(0xe7d0, 'Regular');
+  static const dropboxLogo = IconData(0xe7d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ear.svg)
-  static const ear = PhosphorFlatIconData(0xe70c, 'Regular');
+  static const ear = IconData(0xe70c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ear-slash.svg)
-  static const earSlash = PhosphorFlatIconData(0xe70e, 'Regular');
+  static const earSlash = IconData(0xe70e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/egg.svg)
-  static const egg = PhosphorFlatIconData(0xe812, 'Regular');
+  static const egg = IconData(0xe812,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-crack](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/egg-crack.svg)
-  static const eggCrack = PhosphorFlatIconData(0xeb64, 'Regular');
+  static const eggCrack = IconData(0xeb64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eject.svg)
-  static const eject = PhosphorFlatIconData(0xe212, 'Regular');
+  static const eject = IconData(0xe212,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eject-simple.svg)
-  static const ejectSimple = PhosphorFlatIconData(0xe6ae, 'Regular');
+  static const ejectSimple = IconData(0xe6ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![elevator](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/elevator.svg)
-  static const elevator = PhosphorFlatIconData(0xecc0, 'Regular');
+  static const elevator = IconData(0xecc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![empty](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/empty.svg)
-  static const empty = PhosphorFlatIconData(0xedbc, 'Regular');
+  static const empty = IconData(0xedbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![engine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/engine.svg)
-  static const engine = PhosphorFlatIconData(0xea80, 'Regular');
+  static const engine = IconData(0xea80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/envelope.svg)
-  static const envelope = PhosphorFlatIconData(0xe214, 'Regular');
+  static const envelope = IconData(0xe214,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/envelope-open.svg)
-  static const envelopeOpen = PhosphorFlatIconData(0xe216, 'Regular');
+  static const envelopeOpen = IconData(0xe216,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/envelope-simple.svg)
-  static const envelopeSimple = PhosphorFlatIconData(0xe218, 'Regular');
+  static const envelopeSimple = IconData(0xe218,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/envelope-simple-open.svg)
-  static const envelopeSimpleOpen = PhosphorFlatIconData(0xe21a, 'Regular');
+  static const envelopeSimpleOpen = IconData(0xe21a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equalizer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/equalizer.svg)
-  static const equalizer = PhosphorFlatIconData(0xebbc, 'Regular');
+  static const equalizer = IconData(0xebbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equals](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/equals.svg)
-  static const equals = PhosphorFlatIconData(0xe21c, 'Regular');
+  static const equals = IconData(0xe21c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eraser](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eraser.svg)
-  static const eraser = PhosphorFlatIconData(0xe21e, 'Regular');
+  static const eraser = IconData(0xe21e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/escalator-down.svg)
-  static const escalatorDown = PhosphorFlatIconData(0xecba, 'Regular');
+  static const escalatorDown = IconData(0xecba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/escalator-up.svg)
-  static const escalatorUp = PhosphorFlatIconData(0xecbc, 'Regular');
+  static const escalatorUp = IconData(0xecbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exam](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/exam.svg)
-  static const exam = PhosphorFlatIconData(0xe742, 'Regular');
+  static const exam = IconData(0xe742,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclamation-mark](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/exclamation-mark.svg)
-  static const exclamationMark = PhosphorFlatIconData(0xee44, 'Regular');
+  static const exclamationMark = IconData(0xee44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/exclude.svg)
-  static const exclude = PhosphorFlatIconData(0xe882, 'Regular');
+  static const exclude = IconData(0xe882,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/exclude-square.svg)
-  static const excludeSquare = PhosphorFlatIconData(0xe880, 'Regular');
+  static const excludeSquare = IconData(0xe880,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![export](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/export.svg)
-  static const export = PhosphorFlatIconData(0xeaf0, 'Regular');
+  static const export = IconData(0xeaf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eye.svg)
-  static const eye = PhosphorFlatIconData(0xe220, 'Regular');
+  static const eye = IconData(0xe220,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-closed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eye-closed.svg)
-  static const eyeClosed = PhosphorFlatIconData(0xe222, 'Regular');
+  static const eyeClosed = IconData(0xe222,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eye-slash.svg)
-  static const eyeSlash = PhosphorFlatIconData(0xe224, 'Regular');
+  static const eyeSlash = IconData(0xe224,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eyedropper.svg)
-  static const eyedropper = PhosphorFlatIconData(0xe568, 'Regular');
+  static const eyedropper = IconData(0xe568,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-sample](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eyedropper-sample.svg)
-  static const eyedropperSample = PhosphorFlatIconData(0xeac4, 'Regular');
+  static const eyedropperSample = IconData(0xeac4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyeglasses](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eyeglasses.svg)
-  static const eyeglasses = PhosphorFlatIconData(0xe7ba, 'Regular');
+  static const eyeglasses = IconData(0xe7ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyes](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/eyes.svg)
-  static const eyes = PhosphorFlatIconData(0xee5c, 'Regular');
+  static const eyes = IconData(0xee5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![face-mask](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/face-mask.svg)
-  static const faceMask = PhosphorFlatIconData(0xe56a, 'Regular');
+  static const faceMask = IconData(0xe56a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![facebook-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/facebook-logo.svg)
-  static const facebookLogo = PhosphorFlatIconData(0xe226, 'Regular');
+  static const facebookLogo = IconData(0xe226,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![factory](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/factory.svg)
-  static const factory = PhosphorFlatIconData(0xe760, 'Regular');
+  static const factory = IconData(0xe760,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/faders.svg)
-  static const faders = PhosphorFlatIconData(0xe228, 'Regular');
+  static const faders = IconData(0xe228,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/faders-horizontal.svg)
-  static const fadersHorizontal = PhosphorFlatIconData(0xe22a, 'Regular');
+  static const fadersHorizontal = IconData(0xe22a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fallout-shelter](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fallout-shelter.svg)
-  static const falloutShelter = PhosphorFlatIconData(0xe9de, 'Regular');
+  static const falloutShelter = IconData(0xe9de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fan](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fan.svg)
-  static const fan = PhosphorFlatIconData(0xe9f2, 'Regular');
+  static const fan = IconData(0xe9f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![farm](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/farm.svg)
-  static const farm = PhosphorFlatIconData(0xec70, 'Regular');
+  static const farm = IconData(0xec70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fast-forward.svg)
-  static const fastForward = PhosphorFlatIconData(0xe6a6, 'Regular');
+  static const fastForward = IconData(0xe6a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fast-forward-circle.svg)
-  static const fastForwardCircle = PhosphorFlatIconData(0xe22c, 'Regular');
+  static const fastForwardCircle = IconData(0xe22c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![feather](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/feather.svg)
-  static const feather = PhosphorFlatIconData(0xe9c0, 'Regular');
+  static const feather = IconData(0xe9c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fediverse-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fediverse-logo.svg)
-  static const fediverseLogo = PhosphorFlatIconData(0xed66, 'Regular');
+  static const fediverseLogo = IconData(0xed66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![figma-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/figma-logo.svg)
-  static const figmaLogo = PhosphorFlatIconData(0xe22e, 'Regular');
+  static const figmaLogo = IconData(0xe22e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file.svg)
-  static const file = PhosphorFlatIconData(0xe230, 'Regular');
+  static const file = IconData(0xe230,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-archive](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-archive.svg)
-  static const fileArchive = PhosphorFlatIconData(0xeb2a, 'Regular');
+  static const fileArchive = IconData(0xeb2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-arrow-down.svg)
-  static const fileArrowDown = PhosphorFlatIconData(0xe232, 'Regular');
+  static const fileArrowDown = IconData(0xe232,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-arrow-up.svg)
-  static const fileArrowUp = PhosphorFlatIconData(0xe61e, 'Regular');
+  static const fileArrowUp = IconData(0xe61e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-audio](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-audio.svg)
-  static const fileAudio = PhosphorFlatIconData(0xea20, 'Regular');
+  static const fileAudio = IconData(0xea20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-c.svg)
-  static const fileC = PhosphorFlatIconData(0xeb32, 'Regular');
+  static const fileC = IconData(0xeb32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-sharp](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-c-sharp.svg)
-  static const fileCSharp = PhosphorFlatIconData(0xeb30, 'Regular');
+  static const fileCSharp = IconData(0xeb30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cloud](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-cloud.svg)
-  static const fileCloud = PhosphorFlatIconData(0xe95e, 'Regular');
+  static const fileCloud = IconData(0xe95e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-code](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-code.svg)
-  static const fileCode = PhosphorFlatIconData(0xe914, 'Regular');
+  static const fileCode = IconData(0xe914,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cpp](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-cpp.svg)
-  static const fileCpp = PhosphorFlatIconData(0xeb2e, 'Regular');
+  static const fileCpp = IconData(0xeb2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-css](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-css.svg)
-  static const fileCss = PhosphorFlatIconData(0xeb34, 'Regular');
+  static const fileCss = IconData(0xeb34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-csv](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-csv.svg)
-  static const fileCsv = PhosphorFlatIconData(0xeb1c, 'Regular');
+  static const fileCsv = IconData(0xeb1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-dashed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-dashed.svg)
-  static const fileDashed = PhosphorFlatIconData(0xe704, 'Regular');
+  static const fileDashed = IconData(0xe704,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-doc](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-doc.svg)
-  static const fileDoc = PhosphorFlatIconData(0xeb1e, 'Regular');
+  static const fileDoc = IconData(0xeb1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-html](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-html.svg)
-  static const fileHtml = PhosphorFlatIconData(0xeb38, 'Regular');
+  static const fileHtml = IconData(0xeb38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-image](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-image.svg)
-  static const fileImage = PhosphorFlatIconData(0xea24, 'Regular');
+  static const fileImage = IconData(0xea24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ini](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-ini.svg)
-  static const fileIni = PhosphorFlatIconData(0xeb33, 'Regular');
+  static const fileIni = IconData(0xeb33,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jpg](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-jpg.svg)
-  static const fileJpg = PhosphorFlatIconData(0xeb1a, 'Regular');
+  static const fileJpg = IconData(0xeb1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-js](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-js.svg)
-  static const fileJs = PhosphorFlatIconData(0xeb24, 'Regular');
+  static const fileJs = IconData(0xeb24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jsx](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-jsx.svg)
-  static const fileJsx = PhosphorFlatIconData(0xeb3a, 'Regular');
+  static const fileJsx = IconData(0xeb3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-lock](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-lock.svg)
-  static const fileLock = PhosphorFlatIconData(0xe95c, 'Regular');
+  static const fileLock = IconData(0xe95c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-magnifying-glass](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-magnifying-glass.svg)
-  static const fileMagnifyingGlass = PhosphorFlatIconData(0xe238, 'Regular');
+  static const fileMagnifyingGlass = IconData(0xe238,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-md](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-md.svg)
-  static const fileMd = PhosphorFlatIconData(0xed50, 'Regular');
+  static const fileMd = IconData(0xed50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-minus.svg)
-  static const fileMinus = PhosphorFlatIconData(0xe234, 'Regular');
+  static const fileMinus = IconData(0xe234,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-pdf](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-pdf.svg)
-  static const filePdf = PhosphorFlatIconData(0xe702, 'Regular');
+  static const filePdf = IconData(0xe702,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-plus.svg)
-  static const filePlus = PhosphorFlatIconData(0xe236, 'Regular');
+  static const filePlus = IconData(0xe236,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-png](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-png.svg)
-  static const filePng = PhosphorFlatIconData(0xeb18, 'Regular');
+  static const filePng = IconData(0xeb18,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ppt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-ppt.svg)
-  static const filePpt = PhosphorFlatIconData(0xeb20, 'Regular');
+  static const filePpt = IconData(0xeb20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-py](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-py.svg)
-  static const filePy = PhosphorFlatIconData(0xeb2c, 'Regular');
+  static const filePy = IconData(0xeb2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-rs](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-rs.svg)
-  static const fileRs = PhosphorFlatIconData(0xeb28, 'Regular');
+  static const fileRs = IconData(0xeb28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-sql](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-sql.svg)
-  static const fileSql = PhosphorFlatIconData(0xed4e, 'Regular');
+  static const fileSql = IconData(0xed4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-svg](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-svg.svg)
-  static const fileSvg = PhosphorFlatIconData(0xed08, 'Regular');
+  static const fileSvg = IconData(0xed08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-text](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-text.svg)
-  static const fileText = PhosphorFlatIconData(0xe23a, 'Regular');
+  static const fileText = IconData(0xe23a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ts](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-ts.svg)
-  static const fileTs = PhosphorFlatIconData(0xeb26, 'Regular');
+  static const fileTs = IconData(0xeb26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-tsx](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-tsx.svg)
-  static const fileTsx = PhosphorFlatIconData(0xeb3c, 'Regular');
+  static const fileTsx = IconData(0xeb3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-txt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-txt.svg)
-  static const fileTxt = PhosphorFlatIconData(0xeb35, 'Regular');
+  static const fileTxt = IconData(0xeb35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-video](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-video.svg)
-  static const fileVideo = PhosphorFlatIconData(0xea22, 'Regular');
+  static const fileVideo = IconData(0xea22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-vue](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-vue.svg)
-  static const fileVue = PhosphorFlatIconData(0xeb3e, 'Regular');
+  static const fileVue = IconData(0xeb3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-x.svg)
-  static const fileX = PhosphorFlatIconData(0xe23c, 'Regular');
+  static const fileX = IconData(0xe23c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-xls](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-xls.svg)
-  static const fileXls = PhosphorFlatIconData(0xeb22, 'Regular');
+  static const fileXls = IconData(0xeb22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-zip](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/file-zip.svg)
-  static const fileZip = PhosphorFlatIconData(0xe958, 'Regular');
+  static const fileZip = IconData(0xe958,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![files](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/files.svg)
-  static const files = PhosphorFlatIconData(0xe710, 'Regular');
+  static const files = IconData(0xe710,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-reel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/film-reel.svg)
-  static const filmReel = PhosphorFlatIconData(0xe8c0, 'Regular');
+  static const filmReel = IconData(0xe8c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-script](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/film-script.svg)
-  static const filmScript = PhosphorFlatIconData(0xeb50, 'Regular');
+  static const filmScript = IconData(0xeb50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-slate](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/film-slate.svg)
-  static const filmSlate = PhosphorFlatIconData(0xe8c2, 'Regular');
+  static const filmSlate = IconData(0xe8c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-strip](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/film-strip.svg)
-  static const filmStrip = PhosphorFlatIconData(0xe792, 'Regular');
+  static const filmStrip = IconData(0xe792,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fingerprint.svg)
-  static const fingerprint = PhosphorFlatIconData(0xe23e, 'Regular');
+  static const fingerprint = IconData(0xe23e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fingerprint-simple.svg)
-  static const fingerprintSimple = PhosphorFlatIconData(0xe240, 'Regular');
+  static const fingerprintSimple = IconData(0xe240,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![finn-the-human](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/finn-the-human.svg)
-  static const finnTheHuman = PhosphorFlatIconData(0xe56c, 'Regular');
+  static const finnTheHuman = IconData(0xe56c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fire.svg)
-  static const fire = PhosphorFlatIconData(0xe242, 'Regular');
+  static const fire = IconData(0xe242,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-extinguisher](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fire-extinguisher.svg)
-  static const fireExtinguisher = PhosphorFlatIconData(0xe9e8, 'Regular');
+  static const fireExtinguisher = IconData(0xe9e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fire-simple.svg)
-  static const fireSimple = PhosphorFlatIconData(0xe620, 'Regular');
+  static const fireSimple = IconData(0xe620,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-truck](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fire-truck.svg)
-  static const fireTruck = PhosphorFlatIconData(0xe574, 'Regular');
+  static const fireTruck = IconData(0xe574,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/first-aid.svg)
-  static const firstAid = PhosphorFlatIconData(0xe56e, 'Regular');
+  static const firstAid = IconData(0xe56e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-kit](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/first-aid-kit.svg)
-  static const firstAidKit = PhosphorFlatIconData(0xe570, 'Regular');
+  static const firstAidKit = IconData(0xe570,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fish.svg)
-  static const fish = PhosphorFlatIconData(0xe728, 'Regular');
+  static const fish = IconData(0xe728,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fish-simple.svg)
-  static const fishSimple = PhosphorFlatIconData(0xe72a, 'Regular');
+  static const fishSimple = IconData(0xe72a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flag.svg)
-  static const flag = PhosphorFlatIconData(0xe244, 'Regular');
+  static const flag = IconData(0xe244,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flag-banner.svg)
-  static const flagBanner = PhosphorFlatIconData(0xe622, 'Regular');
+  static const flagBanner = IconData(0xe622,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-fold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flag-banner-fold.svg)
-  static const flagBannerFold = PhosphorFlatIconData(0xecf2, 'Regular');
+  static const flagBannerFold = IconData(0xecf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-checkered](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flag-checkered.svg)
-  static const flagCheckered = PhosphorFlatIconData(0xea38, 'Regular');
+  static const flagCheckered = IconData(0xea38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-pennant](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flag-pennant.svg)
-  static const flagPennant = PhosphorFlatIconData(0xecf0, 'Regular');
+  static const flagPennant = IconData(0xecf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flame](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flame.svg)
-  static const flame = PhosphorFlatIconData(0xe624, 'Regular');
+  static const flame = IconData(0xe624,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flashlight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flashlight.svg)
-  static const flashlight = PhosphorFlatIconData(0xe246, 'Regular');
+  static const flashlight = IconData(0xe246,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flask](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flask.svg)
-  static const flask = PhosphorFlatIconData(0xe79e, 'Regular');
+  static const flask = IconData(0xe79e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flip-horizontal.svg)
-  static const flipHorizontal = PhosphorFlatIconData(0xed6a, 'Regular');
+  static const flipHorizontal = IconData(0xed6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flip-vertical.svg)
-  static const flipVertical = PhosphorFlatIconData(0xed6c, 'Regular');
+  static const flipVertical = IconData(0xed6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/floppy-disk.svg)
-  static const floppyDisk = PhosphorFlatIconData(0xe248, 'Regular');
+  static const floppyDisk = IconData(0xe248,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-back](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/floppy-disk-back.svg)
-  static const floppyDiskBack = PhosphorFlatIconData(0xeaf4, 'Regular');
+  static const floppyDiskBack = IconData(0xeaf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flow-arrow](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flow-arrow.svg)
-  static const flowArrow = PhosphorFlatIconData(0xe6ec, 'Regular');
+  static const flowArrow = IconData(0xe6ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flower.svg)
-  static const flower = PhosphorFlatIconData(0xe75e, 'Regular');
+  static const flower = IconData(0xe75e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-lotus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flower-lotus.svg)
-  static const flowerLotus = PhosphorFlatIconData(0xe6cc, 'Regular');
+  static const flowerLotus = IconData(0xe6cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-tulip](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flower-tulip.svg)
-  static const flowerTulip = PhosphorFlatIconData(0xeacc, 'Regular');
+  static const flowerTulip = IconData(0xeacc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flying-saucer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/flying-saucer.svg)
-  static const flyingSaucer = PhosphorFlatIconData(0xeb4a, 'Regular');
+  static const flyingSaucer = IconData(0xeb4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder.svg)
-  static const folder = PhosphorFlatIconData(0xe24a, 'Regular');
+  static const folder = IconData(0xe24a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-dashed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-dashed.svg)
-  static const folderDashed = PhosphorFlatIconData(0xe8f8, 'Regular');
+  static const folderDashed = IconData(0xe8f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-lock](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-lock.svg)
-  static const folderLock = PhosphorFlatIconData(0xea3c, 'Regular');
+  static const folderLock = IconData(0xea3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-minus.svg)
-  static const folderMinus = PhosphorFlatIconData(0xe254, 'Regular');
+  static const folderMinus = IconData(0xe254,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-open.svg)
-  static const folderOpen = PhosphorFlatIconData(0xe256, 'Regular');
+  static const folderOpen = IconData(0xe256,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-plus.svg)
-  static const folderPlus = PhosphorFlatIconData(0xe258, 'Regular');
+  static const folderPlus = IconData(0xe258,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-simple.svg)
-  static const folderSimple = PhosphorFlatIconData(0xe25a, 'Regular');
+  static const folderSimple = IconData(0xe25a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-dashed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-simple-dashed.svg)
-  static const folderSimpleDashed = PhosphorFlatIconData(0xec2a, 'Regular');
+  static const folderSimpleDashed = IconData(0xec2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-lock](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-simple-lock.svg)
-  static const folderSimpleLock = PhosphorFlatIconData(0xeb5e, 'Regular');
+  static const folderSimpleLock = IconData(0xeb5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-simple-minus.svg)
-  static const folderSimpleMinus = PhosphorFlatIconData(0xe25c, 'Regular');
+  static const folderSimpleMinus = IconData(0xe25c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-simple-plus.svg)
-  static const folderSimplePlus = PhosphorFlatIconData(0xe25e, 'Regular');
+  static const folderSimplePlus = IconData(0xe25e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-star](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-simple-star.svg)
-  static const folderSimpleStar = PhosphorFlatIconData(0xec2e, 'Regular');
+  static const folderSimpleStar = IconData(0xec2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-user](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-simple-user.svg)
-  static const folderSimpleUser = PhosphorFlatIconData(0xeb60, 'Regular');
+  static const folderSimpleUser = IconData(0xeb60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-star](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-star.svg)
-  static const folderStar = PhosphorFlatIconData(0xea86, 'Regular');
+  static const folderStar = IconData(0xea86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-user](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folder-user.svg)
-  static const folderUser = PhosphorFlatIconData(0xeb46, 'Regular');
+  static const folderUser = IconData(0xeb46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folders](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/folders.svg)
-  static const folders = PhosphorFlatIconData(0xe260, 'Regular');
+  static const folders = IconData(0xe260,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/football.svg)
-  static const football = PhosphorFlatIconData(0xe718, 'Regular');
+  static const football = IconData(0xe718,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-helmet](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/football-helmet.svg)
-  static const footballHelmet = PhosphorFlatIconData(0xee4c, 'Regular');
+  static const footballHelmet = IconData(0xee4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![footprints](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/footprints.svg)
-  static const footprints = PhosphorFlatIconData(0xea88, 'Regular');
+  static const footprints = IconData(0xea88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fork-knife](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/fork-knife.svg)
-  static const forkKnife = PhosphorFlatIconData(0xe262, 'Regular');
+  static const forkKnife = IconData(0xe262,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![four-k](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/four-k.svg)
-  static const fourK = PhosphorFlatIconData(0xea5c, 'Regular');
+  static const fourK = IconData(0xea5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![frame-corners](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/frame-corners.svg)
-  static const frameCorners = PhosphorFlatIconData(0xe626, 'Regular');
+  static const frameCorners = IconData(0xe626,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![framer-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/framer-logo.svg)
-  static const framerLogo = PhosphorFlatIconData(0xe264, 'Regular');
+  static const framerLogo = IconData(0xe264,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![function](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/function.svg)
-  static const function = PhosphorFlatIconData(0xebe4, 'Regular');
+  static const function = IconData(0xebe4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/funnel.svg)
-  static const funnel = PhosphorFlatIconData(0xe266, 'Regular');
+  static const funnel = IconData(0xe266,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/funnel-simple.svg)
-  static const funnelSimple = PhosphorFlatIconData(0xe268, 'Regular');
+  static const funnelSimple = IconData(0xe268,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/funnel-simple-x.svg)
-  static const funnelSimpleX = PhosphorFlatIconData(0xe26a, 'Regular');
+  static const funnelSimpleX = IconData(0xe26a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/funnel-x.svg)
-  static const funnelX = PhosphorFlatIconData(0xe26c, 'Regular');
+  static const funnelX = IconData(0xe26c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![game-controller](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/game-controller.svg)
-  static const gameController = PhosphorFlatIconData(0xe26e, 'Regular');
+  static const gameController = IconData(0xe26e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![garage](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/garage.svg)
-  static const garage = PhosphorFlatIconData(0xecd6, 'Regular');
+  static const garage = IconData(0xecd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-can](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gas-can.svg)
-  static const gasCan = PhosphorFlatIconData(0xe8ce, 'Regular');
+  static const gasCan = IconData(0xe8ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-pump](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gas-pump.svg)
-  static const gasPump = PhosphorFlatIconData(0xe768, 'Regular');
+  static const gasPump = IconData(0xe768,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gauge](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gauge.svg)
-  static const gauge = PhosphorFlatIconData(0xe628, 'Regular');
+  static const gauge = IconData(0xe628,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gavel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gavel.svg)
-  static const gavel = PhosphorFlatIconData(0xea32, 'Regular');
+  static const gavel = IconData(0xea32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gear.svg)
-  static const gear = PhosphorFlatIconData(0xe270, 'Regular');
+  static const gear = IconData(0xe270,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-fine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gear-fine.svg)
-  static const gearFine = PhosphorFlatIconData(0xe87c, 'Regular');
+  static const gearFine = IconData(0xe87c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-six](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gear-six.svg)
-  static const gearSix = PhosphorFlatIconData(0xe272, 'Regular');
+  static const gearSix = IconData(0xe272,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-female](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gender-female.svg)
-  static const genderFemale = PhosphorFlatIconData(0xe6e0, 'Regular');
+  static const genderFemale = IconData(0xe6e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-intersex](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gender-intersex.svg)
-  static const genderIntersex = PhosphorFlatIconData(0xe6e6, 'Regular');
+  static const genderIntersex = IconData(0xe6e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-male](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gender-male.svg)
-  static const genderMale = PhosphorFlatIconData(0xe6e2, 'Regular');
+  static const genderMale = IconData(0xe6e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-neuter](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gender-neuter.svg)
-  static const genderNeuter = PhosphorFlatIconData(0xe6ea, 'Regular');
+  static const genderNeuter = IconData(0xe6ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-nonbinary](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gender-nonbinary.svg)
-  static const genderNonbinary = PhosphorFlatIconData(0xe6e4, 'Regular');
+  static const genderNonbinary = IconData(0xe6e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-transgender](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gender-transgender.svg)
-  static const genderTransgender = PhosphorFlatIconData(0xe6e8, 'Regular');
+  static const genderTransgender = IconData(0xe6e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ghost](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ghost.svg)
-  static const ghost = PhosphorFlatIconData(0xe62a, 'Regular');
+  static const ghost = IconData(0xe62a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gif](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gif.svg)
-  static const gif = PhosphorFlatIconData(0xe274, 'Regular');
+  static const gif = IconData(0xe274,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gift](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gift.svg)
-  static const gift = PhosphorFlatIconData(0xe276, 'Regular');
+  static const gift = IconData(0xe276,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-branch](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/git-branch.svg)
-  static const gitBranch = PhosphorFlatIconData(0xe278, 'Regular');
+  static const gitBranch = IconData(0xe278,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-commit](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/git-commit.svg)
-  static const gitCommit = PhosphorFlatIconData(0xe27a, 'Regular');
+  static const gitCommit = IconData(0xe27a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-diff](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/git-diff.svg)
-  static const gitDiff = PhosphorFlatIconData(0xe27c, 'Regular');
+  static const gitDiff = IconData(0xe27c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-fork](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/git-fork.svg)
-  static const gitFork = PhosphorFlatIconData(0xe27e, 'Regular');
+  static const gitFork = IconData(0xe27e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-merge](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/git-merge.svg)
-  static const gitMerge = PhosphorFlatIconData(0xe280, 'Regular');
+  static const gitMerge = IconData(0xe280,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-pull-request](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/git-pull-request.svg)
-  static const gitPullRequest = PhosphorFlatIconData(0xe282, 'Regular');
+  static const gitPullRequest = IconData(0xe282,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![github-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/github-logo.svg)
-  static const githubLogo = PhosphorFlatIconData(0xe576, 'Regular');
+  static const githubLogo = IconData(0xe576,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gitlab-logo.svg)
-  static const gitlabLogo = PhosphorFlatIconData(0xe694, 'Regular');
+  static const gitlabLogo = IconData(0xe694,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gitlab-logo-simple.svg)
-  static const gitlabLogoSimple = PhosphorFlatIconData(0xe696, 'Regular');
+  static const gitlabLogoSimple = IconData(0xe696,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/globe.svg)
-  static const globe = PhosphorFlatIconData(0xe288, 'Regular');
+  static const globe = IconData(0xe288,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-east](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/globe-hemisphere-east.svg)
-  static const globeHemisphereEast = PhosphorFlatIconData(0xe28a, 'Regular');
+  static const globeHemisphereEast = IconData(0xe28a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-west](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/globe-hemisphere-west.svg)
-  static const globeHemisphereWest = PhosphorFlatIconData(0xe28c, 'Regular');
+  static const globeHemisphereWest = IconData(0xe28c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/globe-simple.svg)
-  static const globeSimple = PhosphorFlatIconData(0xe28e, 'Regular');
+  static const globeSimple = IconData(0xe28e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/globe-simple-x.svg)
-  static const globeSimpleX = PhosphorFlatIconData(0xe284, 'Regular');
+  static const globeSimpleX = IconData(0xe284,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-stand](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/globe-stand.svg)
-  static const globeStand = PhosphorFlatIconData(0xe290, 'Regular');
+  static const globeStand = IconData(0xe290,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/globe-x.svg)
-  static const globeX = PhosphorFlatIconData(0xe286, 'Regular');
+  static const globeX = IconData(0xe286,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goggles](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/goggles.svg)
-  static const goggles = PhosphorFlatIconData(0xecb4, 'Regular');
+  static const goggles = IconData(0xecb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![golf](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/golf.svg)
-  static const golf = PhosphorFlatIconData(0xea3e, 'Regular');
+  static const golf = IconData(0xea3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goodreads-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/goodreads-logo.svg)
-  static const goodreadsLogo = PhosphorFlatIconData(0xed10, 'Regular');
+  static const goodreadsLogo = IconData(0xed10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-cardboard-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/google-cardboard-logo.svg)
-  static const googleCardboardLogo = PhosphorFlatIconData(0xe7b6, 'Regular');
+  static const googleCardboardLogo = IconData(0xe7b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-chrome-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/google-chrome-logo.svg)
-  static const googleChromeLogo = PhosphorFlatIconData(0xe976, 'Regular');
+  static const googleChromeLogo = IconData(0xe976,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-drive-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/google-drive-logo.svg)
-  static const googleDriveLogo = PhosphorFlatIconData(0xe8f6, 'Regular');
+  static const googleDriveLogo = IconData(0xe8f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/google-logo.svg)
-  static const googleLogo = PhosphorFlatIconData(0xe292, 'Regular');
+  static const googleLogo = IconData(0xe292,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-photos-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/google-photos-logo.svg)
-  static const googlePhotosLogo = PhosphorFlatIconData(0xeb92, 'Regular');
+  static const googlePhotosLogo = IconData(0xeb92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-play-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/google-play-logo.svg)
-  static const googlePlayLogo = PhosphorFlatIconData(0xe294, 'Regular');
+  static const googlePlayLogo = IconData(0xe294,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-podcasts-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/google-podcasts-logo.svg)
-  static const googlePodcastsLogo = PhosphorFlatIconData(0xeb94, 'Regular');
+  static const googlePodcastsLogo = IconData(0xeb94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gps.svg)
-  static const gps = PhosphorFlatIconData(0xedd8, 'Regular');
+  static const gps = IconData(0xedd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-fix](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gps-fix.svg)
-  static const gpsFix = PhosphorFlatIconData(0xedd6, 'Regular');
+  static const gpsFix = IconData(0xedd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gps-slash.svg)
-  static const gpsSlash = PhosphorFlatIconData(0xedd4, 'Regular');
+  static const gpsSlash = IconData(0xedd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gradient](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/gradient.svg)
-  static const gradient = PhosphorFlatIconData(0xeb42, 'Regular');
+  static const gradient = IconData(0xeb42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graduation-cap](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/graduation-cap.svg)
-  static const graduationCap = PhosphorFlatIconData(0xe62c, 'Regular');
+  static const graduationCap = IconData(0xe62c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/grains.svg)
-  static const grains = PhosphorFlatIconData(0xec68, 'Regular');
+  static const grains = IconData(0xec68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/grains-slash.svg)
-  static const grainsSlash = PhosphorFlatIconData(0xec6a, 'Regular');
+  static const grainsSlash = IconData(0xec6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graph](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/graph.svg)
-  static const graph = PhosphorFlatIconData(0xeb58, 'Regular');
+  static const graph = IconData(0xeb58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graphics-card](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/graphics-card.svg)
-  static const graphicsCard = PhosphorFlatIconData(0xe612, 'Regular');
+  static const graphicsCard = IconData(0xe612,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/greater-than.svg)
-  static const greaterThan = PhosphorFlatIconData(0xedc4, 'Regular');
+  static const greaterThan = IconData(0xedc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-or-equal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/greater-than-or-equal.svg)
-  static const greaterThanOrEqual = PhosphorFlatIconData(0xeda2, 'Regular');
+  static const greaterThanOrEqual = IconData(0xeda2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/grid-four.svg)
-  static const gridFour = PhosphorFlatIconData(0xe296, 'Regular');
+  static const gridFour = IconData(0xe296,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-nine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/grid-nine.svg)
-  static const gridNine = PhosphorFlatIconData(0xec8c, 'Regular');
+  static const gridNine = IconData(0xec8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![guitar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/guitar.svg)
-  static const guitar = PhosphorFlatIconData(0xea8a, 'Regular');
+  static const guitar = IconData(0xea8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hair-dryer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hair-dryer.svg)
-  static const hairDryer = PhosphorFlatIconData(0xea66, 'Regular');
+  static const hairDryer = IconData(0xea66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hamburger](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hamburger.svg)
-  static const hamburger = PhosphorFlatIconData(0xe790, 'Regular');
+  static const hamburger = IconData(0xe790,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hammer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hammer.svg)
-  static const hammer = PhosphorFlatIconData(0xe80e, 'Regular');
+  static const hammer = IconData(0xe80e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand.svg)
-  static const hand = PhosphorFlatIconData(0xe298, 'Regular');
+  static const hand = IconData(0xe298,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-arrow-down.svg)
-  static const handArrowDown = PhosphorFlatIconData(0xea4e, 'Regular');
+  static const handArrowDown = IconData(0xea4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-arrow-up.svg)
-  static const handArrowUp = PhosphorFlatIconData(0xee5a, 'Regular');
+  static const handArrowUp = IconData(0xee5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-coins](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-coins.svg)
-  static const handCoins = PhosphorFlatIconData(0xea8c, 'Regular');
+  static const handCoins = IconData(0xea8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-deposit](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-deposit.svg)
-  static const handDeposit = PhosphorFlatIconData(0xee82, 'Regular');
+  static const handDeposit = IconData(0xee82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-eye](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-eye.svg)
-  static const handEye = PhosphorFlatIconData(0xea4c, 'Regular');
+  static const handEye = IconData(0xea4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-fist](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-fist.svg)
-  static const handFist = PhosphorFlatIconData(0xe57a, 'Regular');
+  static const handFist = IconData(0xe57a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-grabbing](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-grabbing.svg)
-  static const handGrabbing = PhosphorFlatIconData(0xe57c, 'Regular');
+  static const handGrabbing = IconData(0xe57c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-heart](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-heart.svg)
-  static const handHeart = PhosphorFlatIconData(0xe810, 'Regular');
+  static const handHeart = IconData(0xe810,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-palm](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-palm.svg)
-  static const handPalm = PhosphorFlatIconData(0xe57e, 'Regular');
+  static const handPalm = IconData(0xe57e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-peace](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-peace.svg)
-  static const handPeace = PhosphorFlatIconData(0xe7cc, 'Regular');
+  static const handPeace = IconData(0xe7cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-pointing](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-pointing.svg)
-  static const handPointing = PhosphorFlatIconData(0xe29a, 'Regular');
+  static const handPointing = IconData(0xe29a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-soap](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-soap.svg)
-  static const handSoap = PhosphorFlatIconData(0xe630, 'Regular');
+  static const handSoap = IconData(0xe630,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-swipe-left.svg)
-  static const handSwipeLeft = PhosphorFlatIconData(0xec94, 'Regular');
+  static const handSwipeLeft = IconData(0xec94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-swipe-right.svg)
-  static const handSwipeRight = PhosphorFlatIconData(0xec92, 'Regular');
+  static const handSwipeRight = IconData(0xec92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-tap](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-tap.svg)
-  static const handTap = PhosphorFlatIconData(0xec90, 'Regular');
+  static const handTap = IconData(0xec90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-waving](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-waving.svg)
-  static const handWaving = PhosphorFlatIconData(0xe580, 'Regular');
+  static const handWaving = IconData(0xe580,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-withdraw](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hand-withdraw.svg)
-  static const handWithdraw = PhosphorFlatIconData(0xee80, 'Regular');
+  static const handWithdraw = IconData(0xee80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/handbag.svg)
-  static const handbag = PhosphorFlatIconData(0xe29c, 'Regular');
+  static const handbag = IconData(0xe29c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/handbag-simple.svg)
-  static const handbagSimple = PhosphorFlatIconData(0xe62e, 'Regular');
+  static const handbagSimple = IconData(0xe62e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-clapping](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hands-clapping.svg)
-  static const handsClapping = PhosphorFlatIconData(0xe6a0, 'Regular');
+  static const handsClapping = IconData(0xe6a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-praying](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hands-praying.svg)
-  static const handsPraying = PhosphorFlatIconData(0xecc8, 'Regular');
+  static const handsPraying = IconData(0xecc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handshake](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/handshake.svg)
-  static const handshake = PhosphorFlatIconData(0xe582, 'Regular');
+  static const handshake = IconData(0xe582,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drive](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hard-drive.svg)
-  static const hardDrive = PhosphorFlatIconData(0xe29e, 'Regular');
+  static const hardDrive = IconData(0xe29e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drives](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hard-drives.svg)
-  static const hardDrives = PhosphorFlatIconData(0xe2a0, 'Regular');
+  static const hardDrives = IconData(0xe2a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-hat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hard-hat.svg)
-  static const hardHat = PhosphorFlatIconData(0xed46, 'Regular');
+  static const hardHat = IconData(0xed46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hash.svg)
-  static const hash = PhosphorFlatIconData(0xe2a2, 'Regular');
+  static const hash = IconData(0xe2a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-straight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hash-straight.svg)
-  static const hashStraight = PhosphorFlatIconData(0xe2a4, 'Regular');
+  static const hashStraight = IconData(0xe2a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![head-circuit](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/head-circuit.svg)
-  static const headCircuit = PhosphorFlatIconData(0xe7d4, 'Regular');
+  static const headCircuit = IconData(0xe7d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headlights](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/headlights.svg)
-  static const headlights = PhosphorFlatIconData(0xe6fe, 'Regular');
+  static const headlights = IconData(0xe6fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headphones](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/headphones.svg)
-  static const headphones = PhosphorFlatIconData(0xe2a6, 'Regular');
+  static const headphones = IconData(0xe2a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headset](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/headset.svg)
-  static const headset = PhosphorFlatIconData(0xe584, 'Regular');
+  static const headset = IconData(0xe584,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/heart.svg)
-  static const heart = PhosphorFlatIconData(0xe2a8, 'Regular');
+  static const heart = IconData(0xe2a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-break](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/heart-break.svg)
-  static const heartBreak = PhosphorFlatIconData(0xebe8, 'Regular');
+  static const heartBreak = IconData(0xebe8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-half](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/heart-half.svg)
-  static const heartHalf = PhosphorFlatIconData(0xec48, 'Regular');
+  static const heartHalf = IconData(0xec48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/heart-straight.svg)
-  static const heartStraight = PhosphorFlatIconData(0xe2aa, 'Regular');
+  static const heartStraight = IconData(0xe2aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-break](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/heart-straight-break.svg)
-  static const heartStraightBreak = PhosphorFlatIconData(0xeb98, 'Regular');
+  static const heartStraightBreak = IconData(0xeb98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heartbeat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/heartbeat.svg)
-  static const heartbeat = PhosphorFlatIconData(0xe2ac, 'Regular');
+  static const heartbeat = IconData(0xe2ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hexagon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hexagon.svg)
-  static const hexagon = PhosphorFlatIconData(0xe2ae, 'Regular');
+  static const hexagon = IconData(0xe2ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-definition](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/high-definition.svg)
-  static const highDefinition = PhosphorFlatIconData(0xea8e, 'Regular');
+  static const highDefinition = IconData(0xea8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-heel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/high-heel.svg)
-  static const highHeel = PhosphorFlatIconData(0xe8e8, 'Regular');
+  static const highHeel = IconData(0xe8e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/highlighter.svg)
-  static const highlighter = PhosphorFlatIconData(0xec76, 'Regular');
+  static const highlighter = IconData(0xec76,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/highlighter-circle.svg)
-  static const highlighterCircle = PhosphorFlatIconData(0xe632, 'Regular');
+  static const highlighterCircle = IconData(0xe632,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hockey](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hockey.svg)
-  static const hockey = PhosphorFlatIconData(0xec86, 'Regular');
+  static const hockey = IconData(0xec86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hoodie](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hoodie.svg)
-  static const hoodie = PhosphorFlatIconData(0xecd0, 'Regular');
+  static const hoodie = IconData(0xecd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![horse](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/horse.svg)
-  static const horse = PhosphorFlatIconData(0xe2b0, 'Regular');
+  static const horse = IconData(0xe2b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hospital](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hospital.svg)
-  static const hospital = PhosphorFlatIconData(0xe844, 'Regular');
+  static const hospital = IconData(0xe844,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hourglass.svg)
-  static const hourglass = PhosphorFlatIconData(0xe2b2, 'Regular');
+  static const hourglass = IconData(0xe2b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-high](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hourglass-high.svg)
-  static const hourglassHigh = PhosphorFlatIconData(0xe2b4, 'Regular');
+  static const hourglassHigh = IconData(0xe2b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-low](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hourglass-low.svg)
-  static const hourglassLow = PhosphorFlatIconData(0xe2b6, 'Regular');
+  static const hourglassLow = IconData(0xe2b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-medium](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hourglass-medium.svg)
-  static const hourglassMedium = PhosphorFlatIconData(0xe2b8, 'Regular');
+  static const hourglassMedium = IconData(0xe2b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hourglass-simple.svg)
-  static const hourglassSimple = PhosphorFlatIconData(0xe2ba, 'Regular');
+  static const hourglassSimple = IconData(0xe2ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-high](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hourglass-simple-high.svg)
-  static const hourglassSimpleHigh = PhosphorFlatIconData(0xe2bc, 'Regular');
+  static const hourglassSimpleHigh = IconData(0xe2bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-low](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hourglass-simple-low.svg)
-  static const hourglassSimpleLow = PhosphorFlatIconData(0xe2be, 'Regular');
+  static const hourglassSimpleLow = IconData(0xe2be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-medium](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hourglass-simple-medium.svg)
-  static const hourglassSimpleMedium = PhosphorFlatIconData(0xe2c0, 'Regular');
+  static const hourglassSimpleMedium = IconData(0xe2c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/house.svg)
-  static const house = PhosphorFlatIconData(0xe2c2, 'Regular');
+  static const house = IconData(0xe2c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-line](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/house-line.svg)
-  static const houseLine = PhosphorFlatIconData(0xe2c4, 'Regular');
+  static const houseLine = IconData(0xe2c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/house-simple.svg)
-  static const houseSimple = PhosphorFlatIconData(0xe2c6, 'Regular');
+  static const houseSimple = IconData(0xe2c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hurricane](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/hurricane.svg)
-  static const hurricane = PhosphorFlatIconData(0xe88e, 'Regular');
+  static const hurricane = IconData(0xe88e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ice-cream](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ice-cream.svg)
-  static const iceCream = PhosphorFlatIconData(0xe804, 'Regular');
+  static const iceCream = IconData(0xe804,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-badge](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/identification-badge.svg)
-  static const identificationBadge = PhosphorFlatIconData(0xe6f6, 'Regular');
+  static const identificationBadge = IconData(0xe6f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-card](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/identification-card.svg)
-  static const identificationCard = PhosphorFlatIconData(0xe2c8, 'Regular');
+  static const identificationCard = IconData(0xe2c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/image.svg)
-  static const image = PhosphorFlatIconData(0xe2ca, 'Regular');
+  static const image = IconData(0xe2ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-broken](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/image-broken.svg)
-  static const imageBroken = PhosphorFlatIconData(0xe7a8, 'Regular');
+  static const imageBroken = IconData(0xe7a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/image-square.svg)
-  static const imageSquare = PhosphorFlatIconData(0xe2cc, 'Regular');
+  static const imageSquare = IconData(0xe2cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/images.svg)
-  static const images = PhosphorFlatIconData(0xe836, 'Regular');
+  static const images = IconData(0xe836,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/images-square.svg)
-  static const imagesSquare = PhosphorFlatIconData(0xe834, 'Regular');
+  static const imagesSquare = IconData(0xe834,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![infinity](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/infinity.svg)
-  static const infinity = PhosphorFlatIconData(0xe634, 'Regular');
+  static const infinity = IconData(0xe634,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![info](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/info.svg)
-  static const info = PhosphorFlatIconData(0xe2ce, 'Regular');
+  static const info = IconData(0xe2ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![instagram-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/instagram-logo.svg)
-  static const instagramLogo = PhosphorFlatIconData(0xe2d0, 'Regular');
+  static const instagramLogo = IconData(0xe2d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/intersect.svg)
-  static const intersect = PhosphorFlatIconData(0xe2d2, 'Regular');
+  static const intersect = IconData(0xe2d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/intersect-square.svg)
-  static const intersectSquare = PhosphorFlatIconData(0xe87a, 'Regular');
+  static const intersectSquare = IconData(0xe87a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/intersect-three.svg)
-  static const intersectThree = PhosphorFlatIconData(0xecc4, 'Regular');
+  static const intersectThree = IconData(0xecc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersection](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/intersection.svg)
-  static const intersection = PhosphorFlatIconData(0xedba, 'Regular');
+  static const intersection = IconData(0xedba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![invoice](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/invoice.svg)
-  static const invoice = PhosphorFlatIconData(0xee42, 'Regular');
+  static const invoice = IconData(0xee42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![island](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/island.svg)
-  static const island = PhosphorFlatIconData(0xee06, 'Regular');
+  static const island = IconData(0xee06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/jar.svg)
-  static const jar = PhosphorFlatIconData(0xe7e0, 'Regular');
+  static const jar = IconData(0xe7e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-label](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/jar-label.svg)
-  static const jarLabel = PhosphorFlatIconData(0xe7e1, 'Regular');
+  static const jarLabel = IconData(0xe7e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jeep](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/jeep.svg)
-  static const jeep = PhosphorFlatIconData(0xe2d4, 'Regular');
+  static const jeep = IconData(0xe2d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![joystick](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/joystick.svg)
-  static const joystick = PhosphorFlatIconData(0xea5e, 'Regular');
+  static const joystick = IconData(0xea5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![kanban](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/kanban.svg)
-  static const kanban = PhosphorFlatIconData(0xeb54, 'Regular');
+  static const kanban = IconData(0xeb54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/key.svg)
-  static const key = PhosphorFlatIconData(0xe2d6, 'Regular');
+  static const key = IconData(0xe2d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-return](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/key-return.svg)
-  static const keyReturn = PhosphorFlatIconData(0xe782, 'Regular');
+  static const keyReturn = IconData(0xe782,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyboard](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/keyboard.svg)
-  static const keyboard = PhosphorFlatIconData(0xe2d8, 'Regular');
+  static const keyboard = IconData(0xe2d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyhole](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/keyhole.svg)
-  static const keyhole = PhosphorFlatIconData(0xea78, 'Regular');
+  static const keyhole = IconData(0xea78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![knife](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/knife.svg)
-  static const knife = PhosphorFlatIconData(0xe636, 'Regular');
+  static const knife = IconData(0xe636,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ladder.svg)
-  static const ladder = PhosphorFlatIconData(0xe9e4, 'Regular');
+  static const ladder = IconData(0xe9e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ladder-simple.svg)
-  static const ladderSimple = PhosphorFlatIconData(0xec26, 'Regular');
+  static const ladderSimple = IconData(0xec26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lamp.svg)
-  static const lamp = PhosphorFlatIconData(0xe638, 'Regular');
+  static const lamp = IconData(0xe638,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-pendant](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lamp-pendant.svg)
-  static const lampPendant = PhosphorFlatIconData(0xee2e, 'Regular');
+  static const lampPendant = IconData(0xee2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![laptop](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/laptop.svg)
-  static const laptop = PhosphorFlatIconData(0xe586, 'Regular');
+  static const laptop = IconData(0xe586,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lasso](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lasso.svg)
-  static const lasso = PhosphorFlatIconData(0xedc6, 'Regular');
+  static const lasso = IconData(0xedc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lastfm-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lastfm-logo.svg)
-  static const lastfmLogo = PhosphorFlatIconData(0xe842, 'Regular');
+  static const lastfmLogo = IconData(0xe842,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![layout](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/layout.svg)
-  static const layout = PhosphorFlatIconData(0xe6d6, 'Regular');
+  static const layout = IconData(0xe6d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![leaf](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/leaf.svg)
-  static const leaf = PhosphorFlatIconData(0xe2da, 'Regular');
+  static const leaf = IconData(0xe2da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lectern](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lectern.svg)
-  static const lectern = PhosphorFlatIconData(0xe95a, 'Regular');
+  static const lectern = IconData(0xe95a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lego.svg)
-  static const lego = PhosphorFlatIconData(0xe8c6, 'Regular');
+  static const lego = IconData(0xe8c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-smiley](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lego-smiley.svg)
-  static const legoSmiley = PhosphorFlatIconData(0xe8c7, 'Regular');
+  static const legoSmiley = IconData(0xe8c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/less-than.svg)
-  static const lessThan = PhosphorFlatIconData(0xedac, 'Regular');
+  static const lessThan = IconData(0xedac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-or-equal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/less-than-or-equal.svg)
-  static const lessThanOrEqual = PhosphorFlatIconData(0xeda4, 'Regular');
+  static const lessThanOrEqual = IconData(0xeda4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-h](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/letter-circle-h.svg)
-  static const letterCircleH = PhosphorFlatIconData(0xebf8, 'Regular');
+  static const letterCircleH = IconData(0xebf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-p](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/letter-circle-p.svg)
-  static const letterCircleP = PhosphorFlatIconData(0xec08, 'Regular');
+  static const letterCircleP = IconData(0xec08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-v](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/letter-circle-v.svg)
-  static const letterCircleV = PhosphorFlatIconData(0xec14, 'Regular');
+  static const letterCircleV = IconData(0xec14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lifebuoy](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lifebuoy.svg)
-  static const lifebuoy = PhosphorFlatIconData(0xe63a, 'Regular');
+  static const lifebuoy = IconData(0xe63a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lightbulb.svg)
-  static const lightbulb = PhosphorFlatIconData(0xe2dc, 'Regular');
+  static const lightbulb = IconData(0xe2dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-filament](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lightbulb-filament.svg)
-  static const lightbulbFilament = PhosphorFlatIconData(0xe63c, 'Regular');
+  static const lightbulbFilament = IconData(0xe63c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lighthouse](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lighthouse.svg)
-  static const lighthouse = PhosphorFlatIconData(0xe9f6, 'Regular');
+  static const lighthouse = IconData(0xe9f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lightning.svg)
-  static const lightning = PhosphorFlatIconData(0xe2de, 'Regular');
+  static const lightning = IconData(0xe2de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-a](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lightning-a.svg)
-  static const lightningA = PhosphorFlatIconData(0xea84, 'Regular');
+  static const lightningA = IconData(0xea84,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lightning-slash.svg)
-  static const lightningSlash = PhosphorFlatIconData(0xe2e0, 'Regular');
+  static const lightningSlash = IconData(0xe2e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segment](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/line-segment.svg)
-  static const lineSegment = PhosphorFlatIconData(0xe6d2, 'Regular');
+  static const lineSegment = IconData(0xe6d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segments](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/line-segments.svg)
-  static const lineSegments = PhosphorFlatIconData(0xe6d4, 'Regular');
+  static const lineSegments = IconData(0xe6d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/line-vertical.svg)
-  static const lineVertical = PhosphorFlatIconData(0xed70, 'Regular');
+  static const lineVertical = IconData(0xed70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/link.svg)
-  static const link = PhosphorFlatIconData(0xe2e2, 'Regular');
+  static const link = IconData(0xe2e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-break](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/link-break.svg)
-  static const linkBreak = PhosphorFlatIconData(0xe2e4, 'Regular');
+  static const linkBreak = IconData(0xe2e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/link-simple.svg)
-  static const linkSimple = PhosphorFlatIconData(0xe2e6, 'Regular');
+  static const linkSimple = IconData(0xe2e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-break](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/link-simple-break.svg)
-  static const linkSimpleBreak = PhosphorFlatIconData(0xe2e8, 'Regular');
+  static const linkSimpleBreak = IconData(0xe2e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/link-simple-horizontal.svg)
-  static const linkSimpleHorizontal = PhosphorFlatIconData(0xe2ea, 'Regular');
+  static const linkSimpleHorizontal = IconData(0xe2ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-break](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/link-simple-horizontal-break.svg)
-  static const linkSimpleHorizontalBreak =
-      PhosphorFlatIconData(0xe2ec, 'Regular');
+  static const linkSimpleHorizontalBreak = IconData(0xe2ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linkedin-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/linkedin-logo.svg)
-  static const linkedinLogo = PhosphorFlatIconData(0xe2ee, 'Regular');
+  static const linkedinLogo = IconData(0xe2ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linktree-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/linktree-logo.svg)
-  static const linktreeLogo = PhosphorFlatIconData(0xedee, 'Regular');
+  static const linktreeLogo = IconData(0xedee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linux-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/linux-logo.svg)
-  static const linuxLogo = PhosphorFlatIconData(0xeb02, 'Regular');
+  static const linuxLogo = IconData(0xeb02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list.svg)
-  static const list = PhosphorFlatIconData(0xe2f0, 'Regular');
+  static const list = IconData(0xe2f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-bullets](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list-bullets.svg)
-  static const listBullets = PhosphorFlatIconData(0xe2f2, 'Regular');
+  static const listBullets = IconData(0xe2f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-checks](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list-checks.svg)
-  static const listChecks = PhosphorFlatIconData(0xeadc, 'Regular');
+  static const listChecks = IconData(0xeadc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-dashes](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list-dashes.svg)
-  static const listDashes = PhosphorFlatIconData(0xe2f4, 'Regular');
+  static const listDashes = IconData(0xe2f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-heart](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list-heart.svg)
-  static const listHeart = PhosphorFlatIconData(0xebde, 'Regular');
+  static const listHeart = IconData(0xebde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-magnifying-glass](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list-magnifying-glass.svg)
-  static const listMagnifyingGlass = PhosphorFlatIconData(0xebe0, 'Regular');
+  static const listMagnifyingGlass = IconData(0xebe0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-numbers](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list-numbers.svg)
-  static const listNumbers = PhosphorFlatIconData(0xe2f6, 'Regular');
+  static const listNumbers = IconData(0xe2f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list-plus.svg)
-  static const listPlus = PhosphorFlatIconData(0xe2f8, 'Regular');
+  static const listPlus = IconData(0xe2f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-star](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/list-star.svg)
-  static const listStar = PhosphorFlatIconData(0xebdc, 'Regular');
+  static const listStar = IconData(0xebdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lock.svg)
-  static const lock = PhosphorFlatIconData(0xe2fa, 'Regular');
+  static const lock = IconData(0xe2fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lock-key.svg)
-  static const lockKey = PhosphorFlatIconData(0xe2fe, 'Regular');
+  static const lockKey = IconData(0xe2fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lock-key-open.svg)
-  static const lockKeyOpen = PhosphorFlatIconData(0xe300, 'Regular');
+  static const lockKeyOpen = IconData(0xe300,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lock-laminated.svg)
-  static const lockLaminated = PhosphorFlatIconData(0xe302, 'Regular');
+  static const lockLaminated = IconData(0xe302,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lock-laminated-open.svg)
-  static const lockLaminatedOpen = PhosphorFlatIconData(0xe304, 'Regular');
+  static const lockLaminatedOpen = IconData(0xe304,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lock-open.svg)
-  static const lockOpen = PhosphorFlatIconData(0xe306, 'Regular');
+  static const lockOpen = IconData(0xe306,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lock-simple.svg)
-  static const lockSimple = PhosphorFlatIconData(0xe308, 'Regular');
+  static const lockSimple = IconData(0xe308,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lock-simple-open.svg)
-  static const lockSimpleOpen = PhosphorFlatIconData(0xe30a, 'Regular');
+  static const lockSimpleOpen = IconData(0xe30a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lockers](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/lockers.svg)
-  static const lockers = PhosphorFlatIconData(0xecb8, 'Regular');
+  static const lockers = IconData(0xecb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![log](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/log.svg)
-  static const log = PhosphorFlatIconData(0xed82, 'Regular');
+  static const log = IconData(0xed82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magic-wand](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/magic-wand.svg)
-  static const magicWand = PhosphorFlatIconData(0xe6b6, 'Regular');
+  static const magicWand = IconData(0xe6b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/magnet.svg)
-  static const magnet = PhosphorFlatIconData(0xe680, 'Regular');
+  static const magnet = IconData(0xe680,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-straight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/magnet-straight.svg)
-  static const magnetStraight = PhosphorFlatIconData(0xe682, 'Regular');
+  static const magnetStraight = IconData(0xe682,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/magnifying-glass.svg)
-  static const magnifyingGlass = PhosphorFlatIconData(0xe30c, 'Regular');
+  static const magnifyingGlass = IconData(0xe30c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/magnifying-glass-minus.svg)
-  static const magnifyingGlassMinus = PhosphorFlatIconData(0xe30e, 'Regular');
+  static const magnifyingGlassMinus = IconData(0xe30e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/magnifying-glass-plus.svg)
-  static const magnifyingGlassPlus = PhosphorFlatIconData(0xe310, 'Regular');
+  static const magnifyingGlassPlus = IconData(0xe310,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mailbox](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mailbox.svg)
-  static const mailbox = PhosphorFlatIconData(0xec1e, 'Regular');
+  static const mailbox = IconData(0xec1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/map-pin.svg)
-  static const mapPin = PhosphorFlatIconData(0xe316, 'Regular');
+  static const mapPin = IconData(0xe316,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-area](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/map-pin-area.svg)
-  static const mapPinArea = PhosphorFlatIconData(0xee3a, 'Regular');
+  static const mapPinArea = IconData(0xee3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-line](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/map-pin-line.svg)
-  static const mapPinLine = PhosphorFlatIconData(0xe318, 'Regular');
+  static const mapPinLine = IconData(0xe318,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/map-pin-plus.svg)
-  static const mapPinPlus = PhosphorFlatIconData(0xe314, 'Regular');
+  static const mapPinPlus = IconData(0xe314,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/map-pin-simple.svg)
-  static const mapPinSimple = PhosphorFlatIconData(0xee3e, 'Regular');
+  static const mapPinSimple = IconData(0xee3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-area](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/map-pin-simple-area.svg)
-  static const mapPinSimpleArea = PhosphorFlatIconData(0xee3c, 'Regular');
+  static const mapPinSimpleArea = IconData(0xee3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-line](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/map-pin-simple-line.svg)
-  static const mapPinSimpleLine = PhosphorFlatIconData(0xee38, 'Regular');
+  static const mapPinSimpleLine = IconData(0xee38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-trifold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/map-trifold.svg)
-  static const mapTrifold = PhosphorFlatIconData(0xe31a, 'Regular');
+  static const mapTrifold = IconData(0xe31a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![markdown-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/markdown-logo.svg)
-  static const markdownLogo = PhosphorFlatIconData(0xe508, 'Regular');
+  static const markdownLogo = IconData(0xe508,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![marker-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/marker-circle.svg)
-  static const markerCircle = PhosphorFlatIconData(0xe640, 'Regular');
+  static const markerCircle = IconData(0xe640,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![martini](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/martini.svg)
-  static const martini = PhosphorFlatIconData(0xe31c, 'Regular');
+  static const martini = IconData(0xe31c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-happy](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mask-happy.svg)
-  static const maskHappy = PhosphorFlatIconData(0xe9f4, 'Regular');
+  static const maskHappy = IconData(0xe9f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-sad](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mask-sad.svg)
-  static const maskSad = PhosphorFlatIconData(0xeb9e, 'Regular');
+  static const maskSad = IconData(0xeb9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mastodon-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mastodon-logo.svg)
-  static const mastodonLogo = PhosphorFlatIconData(0xed68, 'Regular');
+  static const mastodonLogo = IconData(0xed68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![math-operations](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/math-operations.svg)
-  static const mathOperations = PhosphorFlatIconData(0xe31e, 'Regular');
+  static const mathOperations = IconData(0xe31e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![matrix-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/matrix-logo.svg)
-  static const matrixLogo = PhosphorFlatIconData(0xed64, 'Regular');
+  static const matrixLogo = IconData(0xed64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/medal.svg)
-  static const medal = PhosphorFlatIconData(0xe320, 'Regular');
+  static const medal = IconData(0xe320,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-military](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/medal-military.svg)
-  static const medalMilitary = PhosphorFlatIconData(0xecfc, 'Regular');
+  static const medalMilitary = IconData(0xecfc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medium-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/medium-logo.svg)
-  static const mediumLogo = PhosphorFlatIconData(0xe322, 'Regular');
+  static const mediumLogo = IconData(0xe322,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/megaphone.svg)
-  static const megaphone = PhosphorFlatIconData(0xe324, 'Regular');
+  static const megaphone = IconData(0xe324,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/megaphone-simple.svg)
-  static const megaphoneSimple = PhosphorFlatIconData(0xe642, 'Regular');
+  static const megaphoneSimple = IconData(0xe642,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![member-of](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/member-of.svg)
-  static const memberOf = PhosphorFlatIconData(0xedc2, 'Regular');
+  static const memberOf = IconData(0xedc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![memory](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/memory.svg)
-  static const memory = PhosphorFlatIconData(0xe9c4, 'Regular');
+  static const memory = IconData(0xe9c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![messenger-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/messenger-logo.svg)
-  static const messengerLogo = PhosphorFlatIconData(0xe6d8, 'Regular');
+  static const messengerLogo = IconData(0xe6d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meta-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/meta-logo.svg)
-  static const metaLogo = PhosphorFlatIconData(0xed02, 'Regular');
+  static const metaLogo = IconData(0xed02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meteor](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/meteor.svg)
-  static const meteor = PhosphorFlatIconData(0xe9ba, 'Regular');
+  static const meteor = IconData(0xe9ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![metronome](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/metronome.svg)
-  static const metronome = PhosphorFlatIconData(0xec8e, 'Regular');
+  static const metronome = IconData(0xec8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microphone.svg)
-  static const microphone = PhosphorFlatIconData(0xe326, 'Regular');
+  static const microphone = IconData(0xe326,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microphone-slash.svg)
-  static const microphoneSlash = PhosphorFlatIconData(0xe328, 'Regular');
+  static const microphoneSlash = IconData(0xe328,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-stage](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microphone-stage.svg)
-  static const microphoneStage = PhosphorFlatIconData(0xe75c, 'Regular');
+  static const microphoneStage = IconData(0xe75c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microscope](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microscope.svg)
-  static const microscope = PhosphorFlatIconData(0xec7a, 'Regular');
+  static const microscope = IconData(0xec7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-excel-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microsoft-excel-logo.svg)
-  static const microsoftExcelLogo = PhosphorFlatIconData(0xeb6c, 'Regular');
+  static const microsoftExcelLogo = IconData(0xeb6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-outlook-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microsoft-outlook-logo.svg)
-  static const microsoftOutlookLogo = PhosphorFlatIconData(0xeb70, 'Regular');
+  static const microsoftOutlookLogo = IconData(0xeb70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-powerpoint-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microsoft-powerpoint-logo.svg)
-  static const microsoftPowerpointLogo =
-      PhosphorFlatIconData(0xeace, 'Regular');
+  static const microsoftPowerpointLogo = IconData(0xeace,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-teams-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microsoft-teams-logo.svg)
-  static const microsoftTeamsLogo = PhosphorFlatIconData(0xeb66, 'Regular');
+  static const microsoftTeamsLogo = IconData(0xeb66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-word-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/microsoft-word-logo.svg)
-  static const microsoftWordLogo = PhosphorFlatIconData(0xeb6a, 'Regular');
+  static const microsoftWordLogo = IconData(0xeb6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/minus.svg)
-  static const minus = PhosphorFlatIconData(0xe32a, 'Regular');
+  static const minus = IconData(0xe32a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/minus-circle.svg)
-  static const minusCircle = PhosphorFlatIconData(0xe32c, 'Regular');
+  static const minusCircle = IconData(0xe32c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/minus-square.svg)
-  static const minusSquare = PhosphorFlatIconData(0xed4c, 'Regular');
+  static const minusSquare = IconData(0xed4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/money.svg)
-  static const money = PhosphorFlatIconData(0xe588, 'Regular');
+  static const money = IconData(0xe588,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-wavy](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/money-wavy.svg)
-  static const moneyWavy = PhosphorFlatIconData(0xee68, 'Regular');
+  static const moneyWavy = IconData(0xee68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/monitor.svg)
-  static const monitor = PhosphorFlatIconData(0xe32e, 'Regular');
+  static const monitor = IconData(0xe32e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-arrow-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/monitor-arrow-up.svg)
-  static const monitorArrowUp = PhosphorFlatIconData(0xe58a, 'Regular');
+  static const monitorArrowUp = IconData(0xe58a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-play](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/monitor-play.svg)
-  static const monitorPlay = PhosphorFlatIconData(0xe58c, 'Regular');
+  static const monitorPlay = IconData(0xe58c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/moon.svg)
-  static const moon = PhosphorFlatIconData(0xe330, 'Regular');
+  static const moon = IconData(0xe330,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-stars](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/moon-stars.svg)
-  static const moonStars = PhosphorFlatIconData(0xe58e, 'Regular');
+  static const moonStars = IconData(0xe58e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/moped.svg)
-  static const moped = PhosphorFlatIconData(0xe824, 'Regular');
+  static const moped = IconData(0xe824,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-front](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/moped-front.svg)
-  static const mopedFront = PhosphorFlatIconData(0xe822, 'Regular');
+  static const mopedFront = IconData(0xe822,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mosque](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mosque.svg)
-  static const mosque = PhosphorFlatIconData(0xecee, 'Regular');
+  static const mosque = IconData(0xecee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![motorcycle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/motorcycle.svg)
-  static const motorcycle = PhosphorFlatIconData(0xe80a, 'Regular');
+  static const motorcycle = IconData(0xe80a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mountains](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mountains.svg)
-  static const mountains = PhosphorFlatIconData(0xe7ae, 'Regular');
+  static const mountains = IconData(0xe7ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mouse.svg)
-  static const mouse = PhosphorFlatIconData(0xe33a, 'Regular');
+  static const mouse = IconData(0xe33a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-left-click](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mouse-left-click.svg)
-  static const mouseLeftClick = PhosphorFlatIconData(0xe334, 'Regular');
+  static const mouseLeftClick = IconData(0xe334,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-middle-click](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mouse-middle-click.svg)
-  static const mouseMiddleClick = PhosphorFlatIconData(0xe338, 'Regular');
+  static const mouseMiddleClick = IconData(0xe338,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-right-click](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mouse-right-click.svg)
-  static const mouseRightClick = PhosphorFlatIconData(0xe336, 'Regular');
+  static const mouseRightClick = IconData(0xe336,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-scroll](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mouse-scroll.svg)
-  static const mouseScroll = PhosphorFlatIconData(0xe332, 'Regular');
+  static const mouseScroll = IconData(0xe332,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/mouse-simple.svg)
-  static const mouseSimple = PhosphorFlatIconData(0xe644, 'Regular');
+  static const mouseSimple = IconData(0xe644,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/music-note.svg)
-  static const musicNote = PhosphorFlatIconData(0xe33c, 'Regular');
+  static const musicNote = IconData(0xe33c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/music-note-simple.svg)
-  static const musicNoteSimple = PhosphorFlatIconData(0xe33e, 'Regular');
+  static const musicNoteSimple = IconData(0xe33e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/music-notes.svg)
-  static const musicNotes = PhosphorFlatIconData(0xe340, 'Regular');
+  static const musicNotes = IconData(0xe340,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/music-notes-minus.svg)
-  static const musicNotesMinus = PhosphorFlatIconData(0xee0c, 'Regular');
+  static const musicNotesMinus = IconData(0xee0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/music-notes-plus.svg)
-  static const musicNotesPlus = PhosphorFlatIconData(0xeb7c, 'Regular');
+  static const musicNotesPlus = IconData(0xeb7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/music-notes-simple.svg)
-  static const musicNotesSimple = PhosphorFlatIconData(0xe342, 'Regular');
+  static const musicNotesSimple = IconData(0xe342,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![navigation-arrow](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/navigation-arrow.svg)
-  static const navigationArrow = PhosphorFlatIconData(0xeade, 'Regular');
+  static const navigationArrow = IconData(0xeade,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![needle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/needle.svg)
-  static const needle = PhosphorFlatIconData(0xe82e, 'Regular');
+  static const needle = IconData(0xe82e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/network.svg)
-  static const network = PhosphorFlatIconData(0xedde, 'Regular');
+  static const network = IconData(0xedde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/network-slash.svg)
-  static const networkSlash = PhosphorFlatIconData(0xeddc, 'Regular');
+  static const networkSlash = IconData(0xeddc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/network-x.svg)
-  static const networkX = PhosphorFlatIconData(0xedda, 'Regular');
+  static const networkX = IconData(0xedda,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/newspaper.svg)
-  static const newspaper = PhosphorFlatIconData(0xe344, 'Regular');
+  static const newspaper = IconData(0xe344,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-clipping](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/newspaper-clipping.svg)
-  static const newspaperClipping = PhosphorFlatIconData(0xe346, 'Regular');
+  static const newspaperClipping = IconData(0xe346,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-equals](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/not-equals.svg)
-  static const notEquals = PhosphorFlatIconData(0xeda6, 'Regular');
+  static const notEquals = IconData(0xeda6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-member-of](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/not-member-of.svg)
-  static const notMemberOf = PhosphorFlatIconData(0xedae, 'Regular');
+  static const notMemberOf = IconData(0xedae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-subset-of](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/not-subset-of.svg)
-  static const notSubsetOf = PhosphorFlatIconData(0xedb0, 'Regular');
+  static const notSubsetOf = IconData(0xedb0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-superset-of](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/not-superset-of.svg)
-  static const notSupersetOf = PhosphorFlatIconData(0xedb2, 'Regular');
+  static const notSupersetOf = IconData(0xedb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notches](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/notches.svg)
-  static const notches = PhosphorFlatIconData(0xed3a, 'Regular');
+  static const notches = IconData(0xed3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/note.svg)
-  static const note = PhosphorFlatIconData(0xe348, 'Regular');
+  static const note = IconData(0xe348,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-blank](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/note-blank.svg)
-  static const noteBlank = PhosphorFlatIconData(0xe34a, 'Regular');
+  static const noteBlank = IconData(0xe34a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-pencil](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/note-pencil.svg)
-  static const notePencil = PhosphorFlatIconData(0xe34c, 'Regular');
+  static const notePencil = IconData(0xe34c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notebook](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/notebook.svg)
-  static const notebook = PhosphorFlatIconData(0xe34e, 'Regular');
+  static const notebook = IconData(0xe34e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notepad](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/notepad.svg)
-  static const notepad = PhosphorFlatIconData(0xe63e, 'Regular');
+  static const notepad = IconData(0xe63e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notification](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/notification.svg)
-  static const notification = PhosphorFlatIconData(0xe6fa, 'Regular');
+  static const notification = IconData(0xe6fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notion-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/notion-logo.svg)
-  static const notionLogo = PhosphorFlatIconData(0xe9a0, 'Regular');
+  static const notionLogo = IconData(0xe9a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nuclear-plant](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/nuclear-plant.svg)
-  static const nuclearPlant = PhosphorFlatIconData(0xed7c, 'Regular');
+  static const nuclearPlant = IconData(0xed7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-eight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-eight.svg)
-  static const numberCircleEight = PhosphorFlatIconData(0xe352, 'Regular');
+  static const numberCircleEight = IconData(0xe352,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-five](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-five.svg)
-  static const numberCircleFive = PhosphorFlatIconData(0xe358, 'Regular');
+  static const numberCircleFive = IconData(0xe358,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-four.svg)
-  static const numberCircleFour = PhosphorFlatIconData(0xe35e, 'Regular');
+  static const numberCircleFour = IconData(0xe35e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-nine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-nine.svg)
-  static const numberCircleNine = PhosphorFlatIconData(0xe364, 'Regular');
+  static const numberCircleNine = IconData(0xe364,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-one](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-one.svg)
-  static const numberCircleOne = PhosphorFlatIconData(0xe36a, 'Regular');
+  static const numberCircleOne = IconData(0xe36a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-seven](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-seven.svg)
-  static const numberCircleSeven = PhosphorFlatIconData(0xe370, 'Regular');
+  static const numberCircleSeven = IconData(0xe370,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-six](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-six.svg)
-  static const numberCircleSix = PhosphorFlatIconData(0xe376, 'Regular');
+  static const numberCircleSix = IconData(0xe376,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-three.svg)
-  static const numberCircleThree = PhosphorFlatIconData(0xe37c, 'Regular');
+  static const numberCircleThree = IconData(0xe37c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-two](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-two.svg)
-  static const numberCircleTwo = PhosphorFlatIconData(0xe382, 'Regular');
+  static const numberCircleTwo = IconData(0xe382,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-zero](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-circle-zero.svg)
-  static const numberCircleZero = PhosphorFlatIconData(0xe388, 'Regular');
+  static const numberCircleZero = IconData(0xe388,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-eight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-eight.svg)
-  static const numberEight = PhosphorFlatIconData(0xe350, 'Regular');
+  static const numberEight = IconData(0xe350,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-five](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-five.svg)
-  static const numberFive = PhosphorFlatIconData(0xe356, 'Regular');
+  static const numberFive = IconData(0xe356,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-four.svg)
-  static const numberFour = PhosphorFlatIconData(0xe35c, 'Regular');
+  static const numberFour = IconData(0xe35c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-nine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-nine.svg)
-  static const numberNine = PhosphorFlatIconData(0xe362, 'Regular');
+  static const numberNine = IconData(0xe362,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-one](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-one.svg)
-  static const numberOne = PhosphorFlatIconData(0xe368, 'Regular');
+  static const numberOne = IconData(0xe368,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-seven](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-seven.svg)
-  static const numberSeven = PhosphorFlatIconData(0xe36e, 'Regular');
+  static const numberSeven = IconData(0xe36e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-six](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-six.svg)
-  static const numberSix = PhosphorFlatIconData(0xe374, 'Regular');
+  static const numberSix = IconData(0xe374,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-eight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-eight.svg)
-  static const numberSquareEight = PhosphorFlatIconData(0xe354, 'Regular');
+  static const numberSquareEight = IconData(0xe354,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-five](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-five.svg)
-  static const numberSquareFive = PhosphorFlatIconData(0xe35a, 'Regular');
+  static const numberSquareFive = IconData(0xe35a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-four.svg)
-  static const numberSquareFour = PhosphorFlatIconData(0xe360, 'Regular');
+  static const numberSquareFour = IconData(0xe360,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-nine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-nine.svg)
-  static const numberSquareNine = PhosphorFlatIconData(0xe366, 'Regular');
+  static const numberSquareNine = IconData(0xe366,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-one](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-one.svg)
-  static const numberSquareOne = PhosphorFlatIconData(0xe36c, 'Regular');
+  static const numberSquareOne = IconData(0xe36c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-seven](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-seven.svg)
-  static const numberSquareSeven = PhosphorFlatIconData(0xe372, 'Regular');
+  static const numberSquareSeven = IconData(0xe372,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-six](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-six.svg)
-  static const numberSquareSix = PhosphorFlatIconData(0xe378, 'Regular');
+  static const numberSquareSix = IconData(0xe378,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-three.svg)
-  static const numberSquareThree = PhosphorFlatIconData(0xe37e, 'Regular');
+  static const numberSquareThree = IconData(0xe37e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-two](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-two.svg)
-  static const numberSquareTwo = PhosphorFlatIconData(0xe384, 'Regular');
+  static const numberSquareTwo = IconData(0xe384,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-zero](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-square-zero.svg)
-  static const numberSquareZero = PhosphorFlatIconData(0xe38a, 'Regular');
+  static const numberSquareZero = IconData(0xe38a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-three.svg)
-  static const numberThree = PhosphorFlatIconData(0xe37a, 'Regular');
+  static const numberThree = IconData(0xe37a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-two](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-two.svg)
-  static const numberTwo = PhosphorFlatIconData(0xe380, 'Regular');
+  static const numberTwo = IconData(0xe380,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-zero](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/number-zero.svg)
-  static const numberZero = PhosphorFlatIconData(0xe386, 'Regular');
+  static const numberZero = IconData(0xe386,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![numpad](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/numpad.svg)
-  static const numpad = PhosphorFlatIconData(0xe3c8, 'Regular');
+  static const numpad = IconData(0xe3c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nut](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/nut.svg)
-  static const nut = PhosphorFlatIconData(0xe38c, 'Regular');
+  static const nut = IconData(0xe38c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ny-times-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ny-times-logo.svg)
-  static const nyTimesLogo = PhosphorFlatIconData(0xe646, 'Regular');
+  static const nyTimesLogo = IconData(0xe646,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![octagon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/octagon.svg)
-  static const octagon = PhosphorFlatIconData(0xe38e, 'Regular');
+  static const octagon = IconData(0xe38e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![office-chair](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/office-chair.svg)
-  static const officeChair = PhosphorFlatIconData(0xea46, 'Regular');
+  static const officeChair = IconData(0xea46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![onigiri](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/onigiri.svg)
-  static const onigiri = PhosphorFlatIconData(0xee2c, 'Regular');
+  static const onigiri = IconData(0xee2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![open-ai-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/open-ai-logo.svg)
-  static const openAiLogo = PhosphorFlatIconData(0xe7d2, 'Regular');
+  static const openAiLogo = IconData(0xe7d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![option](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/option.svg)
-  static const option = PhosphorFlatIconData(0xe8a8, 'Regular');
+  static const option = IconData(0xe8a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/orange.svg)
-  static const orange = PhosphorFlatIconData(0xee40, 'Regular');
+  static const orange = IconData(0xee40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-slice](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/orange-slice.svg)
-  static const orangeSlice = PhosphorFlatIconData(0xed36, 'Regular');
+  static const orangeSlice = IconData(0xed36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![oven](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/oven.svg)
-  static const oven = PhosphorFlatIconData(0xed8c, 'Regular');
+  static const oven = IconData(0xed8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![package](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/package.svg)
-  static const package = PhosphorFlatIconData(0xe390, 'Regular');
+  static const package = IconData(0xe390,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paint-brush.svg)
-  static const paintBrush = PhosphorFlatIconData(0xe6f0, 'Regular');
+  static const paintBrush = IconData(0xe6f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-broad](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paint-brush-broad.svg)
-  static const paintBrushBroad = PhosphorFlatIconData(0xe590, 'Regular');
+  static const paintBrushBroad = IconData(0xe590,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-household](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paint-brush-household.svg)
-  static const paintBrushHousehold = PhosphorFlatIconData(0xe6f2, 'Regular');
+  static const paintBrushHousehold = IconData(0xe6f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-bucket](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paint-bucket.svg)
-  static const paintBucket = PhosphorFlatIconData(0xe392, 'Regular');
+  static const paintBucket = IconData(0xe392,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-roller](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paint-roller.svg)
-  static const paintRoller = PhosphorFlatIconData(0xe6f4, 'Regular');
+  static const paintRoller = IconData(0xe6f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![palette](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/palette.svg)
-  static const palette = PhosphorFlatIconData(0xe6c8, 'Regular');
+  static const palette = IconData(0xe6c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![panorama](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/panorama.svg)
-  static const panorama = PhosphorFlatIconData(0xeaa2, 'Regular');
+  static const panorama = IconData(0xeaa2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pants](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pants.svg)
-  static const pants = PhosphorFlatIconData(0xec88, 'Regular');
+  static const pants = IconData(0xec88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paper-plane.svg)
-  static const paperPlane = PhosphorFlatIconData(0xe394, 'Regular');
+  static const paperPlane = IconData(0xe394,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paper-plane-right.svg)
-  static const paperPlaneRight = PhosphorFlatIconData(0xe396, 'Regular');
+  static const paperPlaneRight = IconData(0xe396,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-tilt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paper-plane-tilt.svg)
-  static const paperPlaneTilt = PhosphorFlatIconData(0xe398, 'Regular');
+  static const paperPlaneTilt = IconData(0xe398,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paperclip.svg)
-  static const paperclip = PhosphorFlatIconData(0xe39a, 'Regular');
+  static const paperclip = IconData(0xe39a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paperclip-horizontal.svg)
-  static const paperclipHorizontal = PhosphorFlatIconData(0xe592, 'Regular');
+  static const paperclipHorizontal = IconData(0xe592,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parachute](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/parachute.svg)
-  static const parachute = PhosphorFlatIconData(0xea7c, 'Regular');
+  static const parachute = IconData(0xea7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paragraph](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paragraph.svg)
-  static const paragraph = PhosphorFlatIconData(0xe960, 'Regular');
+  static const paragraph = IconData(0xe960,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parallelogram](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/parallelogram.svg)
-  static const parallelogram = PhosphorFlatIconData(0xecc6, 'Regular');
+  static const parallelogram = IconData(0xecc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![park](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/park.svg)
-  static const park = PhosphorFlatIconData(0xecb2, 'Regular');
+  static const park = IconData(0xecb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![password](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/password.svg)
-  static const password = PhosphorFlatIconData(0xe752, 'Regular');
+  static const password = IconData(0xe752,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![path](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/path.svg)
-  static const path = PhosphorFlatIconData(0xe39c, 'Regular');
+  static const path = IconData(0xe39c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![patreon-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/patreon-logo.svg)
-  static const patreonLogo = PhosphorFlatIconData(0xe98a, 'Regular');
+  static const patreonLogo = IconData(0xe98a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pause.svg)
-  static const pause = PhosphorFlatIconData(0xe39e, 'Regular');
+  static const pause = IconData(0xe39e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pause-circle.svg)
-  static const pauseCircle = PhosphorFlatIconData(0xe3a0, 'Regular');
+  static const pauseCircle = IconData(0xe3a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paw-print](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paw-print.svg)
-  static const pawPrint = PhosphorFlatIconData(0xe648, 'Regular');
+  static const pawPrint = IconData(0xe648,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paypal-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/paypal-logo.svg)
-  static const paypalLogo = PhosphorFlatIconData(0xe98c, 'Regular');
+  static const paypalLogo = IconData(0xe98c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![peace](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/peace.svg)
-  static const peace = PhosphorFlatIconData(0xe3a2, 'Regular');
+  static const peace = IconData(0xe3a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pen.svg)
-  static const pen = PhosphorFlatIconData(0xe3aa, 'Regular');
+  static const pen = IconData(0xe3aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pen-nib.svg)
-  static const penNib = PhosphorFlatIconData(0xe3ac, 'Regular');
+  static const penNib = IconData(0xe3ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-straight](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pen-nib-straight.svg)
-  static const penNibStraight = PhosphorFlatIconData(0xe64a, 'Regular');
+  static const penNibStraight = IconData(0xe64a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pencil.svg)
-  static const pencil = PhosphorFlatIconData(0xe3ae, 'Regular');
+  static const pencil = IconData(0xe3ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pencil-circle.svg)
-  static const pencilCircle = PhosphorFlatIconData(0xe3b0, 'Regular');
+  static const pencilCircle = IconData(0xe3b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-line](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pencil-line.svg)
-  static const pencilLine = PhosphorFlatIconData(0xe3b2, 'Regular');
+  static const pencilLine = IconData(0xe3b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-ruler](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pencil-ruler.svg)
-  static const pencilRuler = PhosphorFlatIconData(0xe906, 'Regular');
+  static const pencilRuler = IconData(0xe906,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pencil-simple.svg)
-  static const pencilSimple = PhosphorFlatIconData(0xe3b4, 'Regular');
+  static const pencilSimple = IconData(0xe3b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-line](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pencil-simple-line.svg)
-  static const pencilSimpleLine = PhosphorFlatIconData(0xebc6, 'Regular');
+  static const pencilSimpleLine = IconData(0xebc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pencil-simple-slash.svg)
-  static const pencilSimpleSlash = PhosphorFlatIconData(0xecf6, 'Regular');
+  static const pencilSimpleSlash = IconData(0xecf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pencil-slash.svg)
-  static const pencilSlash = PhosphorFlatIconData(0xecf8, 'Regular');
+  static const pencilSlash = IconData(0xecf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pentagon.svg)
-  static const pentagon = PhosphorFlatIconData(0xec7e, 'Regular');
+  static const pentagon = IconData(0xec7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagram](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pentagram.svg)
-  static const pentagram = PhosphorFlatIconData(0xec5c, 'Regular');
+  static const pentagram = IconData(0xec5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pepper](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pepper.svg)
-  static const pepper = PhosphorFlatIconData(0xe94a, 'Regular');
+  static const pepper = IconData(0xe94a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![percent](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/percent.svg)
-  static const percent = PhosphorFlatIconData(0xe3b6, 'Regular');
+  static const percent = IconData(0xe3b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person.svg)
-  static const person = PhosphorFlatIconData(0xe3a8, 'Regular');
+  static const person = IconData(0xe3a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-arms-spread](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-arms-spread.svg)
-  static const personArmsSpread = PhosphorFlatIconData(0xecfe, 'Regular');
+  static const personArmsSpread = IconData(0xecfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple.svg)
-  static const personSimple = PhosphorFlatIconData(0xe72e, 'Regular');
+  static const personSimple = IconData(0xe72e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-bike](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-bike.svg)
-  static const personSimpleBike = PhosphorFlatIconData(0xe734, 'Regular');
+  static const personSimpleBike = IconData(0xe734,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-circle.svg)
-  static const personSimpleCircle = PhosphorFlatIconData(0xee58, 'Regular');
+  static const personSimpleCircle = IconData(0xee58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-hike](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-hike.svg)
-  static const personSimpleHike = PhosphorFlatIconData(0xed54, 'Regular');
+  static const personSimpleHike = IconData(0xed54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-run](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-run.svg)
-  static const personSimpleRun = PhosphorFlatIconData(0xe730, 'Regular');
+  static const personSimpleRun = IconData(0xe730,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-ski](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-ski.svg)
-  static const personSimpleSki = PhosphorFlatIconData(0xe71c, 'Regular');
+  static const personSimpleSki = IconData(0xe71c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-snowboard](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-snowboard.svg)
-  static const personSimpleSnowboard = PhosphorFlatIconData(0xe71e, 'Regular');
+  static const personSimpleSnowboard = IconData(0xe71e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-swim](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-swim.svg)
-  static const personSimpleSwim = PhosphorFlatIconData(0xe736, 'Regular');
+  static const personSimpleSwim = IconData(0xe736,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-tai-chi](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-tai-chi.svg)
-  static const personSimpleTaiChi = PhosphorFlatIconData(0xed5c, 'Regular');
+  static const personSimpleTaiChi = IconData(0xed5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-throw](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-throw.svg)
-  static const personSimpleThrow = PhosphorFlatIconData(0xe732, 'Regular');
+  static const personSimpleThrow = IconData(0xe732,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-walk](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/person-simple-walk.svg)
-  static const personSimpleWalk = PhosphorFlatIconData(0xe73a, 'Regular');
+  static const personSimpleWalk = IconData(0xe73a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![perspective](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/perspective.svg)
-  static const perspective = PhosphorFlatIconData(0xebe6, 'Regular');
+  static const perspective = IconData(0xebe6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone.svg)
-  static const phone = PhosphorFlatIconData(0xe3b8, 'Regular');
+  static const phone = IconData(0xe3b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-call](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-call.svg)
-  static const phoneCall = PhosphorFlatIconData(0xe3ba, 'Regular');
+  static const phoneCall = IconData(0xe3ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-disconnect](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-disconnect.svg)
-  static const phoneDisconnect = PhosphorFlatIconData(0xe3bc, 'Regular');
+  static const phoneDisconnect = IconData(0xe3bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-incoming](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-incoming.svg)
-  static const phoneIncoming = PhosphorFlatIconData(0xe3be, 'Regular');
+  static const phoneIncoming = IconData(0xe3be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-list](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-list.svg)
-  static const phoneList = PhosphorFlatIconData(0xe3cc, 'Regular');
+  static const phoneList = IconData(0xe3cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-outgoing](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-outgoing.svg)
-  static const phoneOutgoing = PhosphorFlatIconData(0xe3c0, 'Regular');
+  static const phoneOutgoing = IconData(0xe3c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-pause](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-pause.svg)
-  static const phonePause = PhosphorFlatIconData(0xe3ca, 'Regular');
+  static const phonePause = IconData(0xe3ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-plus.svg)
-  static const phonePlus = PhosphorFlatIconData(0xec56, 'Regular');
+  static const phonePlus = IconData(0xec56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-slash.svg)
-  static const phoneSlash = PhosphorFlatIconData(0xe3c2, 'Regular');
+  static const phoneSlash = IconData(0xe3c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-transfer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-transfer.svg)
-  static const phoneTransfer = PhosphorFlatIconData(0xe3c6, 'Regular');
+  static const phoneTransfer = IconData(0xe3c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phone-x.svg)
-  static const phoneX = PhosphorFlatIconData(0xe3c4, 'Regular');
+  static const phoneX = IconData(0xe3c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phosphor-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/phosphor-logo.svg)
-  static const phosphorLogo = PhosphorFlatIconData(0xe3ce, 'Regular');
+  static const phosphorLogo = IconData(0xe3ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pi](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pi.svg)
-  static const pi = PhosphorFlatIconData(0xec80, 'Regular');
+  static const pi = IconData(0xec80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piano-keys](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/piano-keys.svg)
-  static const pianoKeys = PhosphorFlatIconData(0xe9c8, 'Regular');
+  static const pianoKeys = IconData(0xe9c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picnic-table](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/picnic-table.svg)
-  static const picnicTable = PhosphorFlatIconData(0xee26, 'Regular');
+  static const picnicTable = IconData(0xee26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picture-in-picture](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/picture-in-picture.svg)
-  static const pictureInpicture = PhosphorFlatIconData(0xe64c, 'Regular');
+  static const pictureInpicture = IconData(0xe64c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piggy-bank](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/piggy-bank.svg)
-  static const piggyBank = PhosphorFlatIconData(0xea04, 'Regular');
+  static const piggyBank = IconData(0xea04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pill.svg)
-  static const pill = PhosphorFlatIconData(0xe700, 'Regular');
+  static const pill = IconData(0xe700,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ping-pong](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ping-pong.svg)
-  static const pingPong = PhosphorFlatIconData(0xea42, 'Regular');
+  static const pingPong = IconData(0xea42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pint-glass](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pint-glass.svg)
-  static const pintGlass = PhosphorFlatIconData(0xedd0, 'Regular');
+  static const pintGlass = IconData(0xedd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinterest-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pinterest-logo.svg)
-  static const pinterestLogo = PhosphorFlatIconData(0xe64e, 'Regular');
+  static const pinterestLogo = IconData(0xe64e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinwheel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pinwheel.svg)
-  static const pinwheel = PhosphorFlatIconData(0xeb9c, 'Regular');
+  static const pinwheel = IconData(0xeb9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pipe.svg)
-  static const pipe = PhosphorFlatIconData(0xed86, 'Regular');
+  static const pipe = IconData(0xed86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-wrench](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pipe-wrench.svg)
-  static const pipeWrench = PhosphorFlatIconData(0xed88, 'Regular');
+  static const pipeWrench = IconData(0xed88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pix-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pix-logo.svg)
-  static const pixLogo = PhosphorFlatIconData(0xecc2, 'Regular');
+  static const pixLogo = IconData(0xecc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pizza](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pizza.svg)
-  static const pizza = PhosphorFlatIconData(0xe796, 'Regular');
+  static const pizza = IconData(0xe796,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![placeholder](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/placeholder.svg)
-  static const placeholder = PhosphorFlatIconData(0xe650, 'Regular');
+  static const placeholder = IconData(0xe650,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![planet](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/planet.svg)
-  static const planet = PhosphorFlatIconData(0xe652, 'Regular');
+  static const planet = IconData(0xe652,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plant](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plant.svg)
-  static const plant = PhosphorFlatIconData(0xebae, 'Regular');
+  static const plant = IconData(0xebae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/play.svg)
-  static const play = PhosphorFlatIconData(0xe3d0, 'Regular');
+  static const play = IconData(0xe3d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/play-circle.svg)
-  static const playCircle = PhosphorFlatIconData(0xe3d2, 'Regular');
+  static const playCircle = IconData(0xe3d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-pause](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/play-pause.svg)
-  static const playPause = PhosphorFlatIconData(0xe8be, 'Regular');
+  static const playPause = IconData(0xe8be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![playlist](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/playlist.svg)
-  static const playlist = PhosphorFlatIconData(0xe6aa, 'Regular');
+  static const playlist = IconData(0xe6aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plug.svg)
-  static const plug = PhosphorFlatIconData(0xe946, 'Regular');
+  static const plug = IconData(0xe946,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-charging](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plug-charging.svg)
-  static const plugCharging = PhosphorFlatIconData(0xeb5c, 'Regular');
+  static const plugCharging = IconData(0xeb5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plugs.svg)
-  static const plugs = PhosphorFlatIconData(0xeb56, 'Regular');
+  static const plugs = IconData(0xeb56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-connected](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plugs-connected.svg)
-  static const plugsConnected = PhosphorFlatIconData(0xeb5a, 'Regular');
+  static const plugsConnected = IconData(0xeb5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plus.svg)
-  static const plus = PhosphorFlatIconData(0xe3d4, 'Regular');
+  static const plus = IconData(0xe3d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plus-circle.svg)
-  static const plusCircle = PhosphorFlatIconData(0xe3d6, 'Regular');
+  static const plusCircle = IconData(0xe3d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plus-minus.svg)
-  static const plusMinus = PhosphorFlatIconData(0xe3d8, 'Regular');
+  static const plusMinus = IconData(0xe3d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/plus-square.svg)
-  static const plusSquare = PhosphorFlatIconData(0xed4a, 'Regular');
+  static const plusSquare = IconData(0xed4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![poker-chip](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/poker-chip.svg)
-  static const pokerChip = PhosphorFlatIconData(0xe594, 'Regular');
+  static const pokerChip = IconData(0xe594,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![police-car](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/police-car.svg)
-  static const policeCar = PhosphorFlatIconData(0xec4a, 'Regular');
+  static const policeCar = IconData(0xec4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![polygon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/polygon.svg)
-  static const polygon = PhosphorFlatIconData(0xe6d0, 'Regular');
+  static const polygon = IconData(0xe6d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popcorn](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/popcorn.svg)
-  static const popcorn = PhosphorFlatIconData(0xeb4e, 'Regular');
+  static const popcorn = IconData(0xeb4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popsicle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/popsicle.svg)
-  static const popsicle = PhosphorFlatIconData(0xebbe, 'Regular');
+  static const popsicle = IconData(0xebbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![potted-plant](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/potted-plant.svg)
-  static const pottedPlant = PhosphorFlatIconData(0xec22, 'Regular');
+  static const pottedPlant = IconData(0xec22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![power](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/power.svg)
-  static const power = PhosphorFlatIconData(0xe3da, 'Regular');
+  static const power = IconData(0xe3da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prescription](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/prescription.svg)
-  static const prescription = PhosphorFlatIconData(0xe7a2, 'Regular');
+  static const prescription = IconData(0xe7a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/presentation.svg)
-  static const presentation = PhosphorFlatIconData(0xe654, 'Regular');
+  static const presentation = IconData(0xe654,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-chart](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/presentation-chart.svg)
-  static const presentationChart = PhosphorFlatIconData(0xe656, 'Regular');
+  static const presentationChart = IconData(0xe656,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![printer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/printer.svg)
-  static const printer = PhosphorFlatIconData(0xe3dc, 'Regular');
+  static const printer = IconData(0xe3dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/prohibit.svg)
-  static const prohibit = PhosphorFlatIconData(0xe3de, 'Regular');
+  static const prohibit = IconData(0xe3de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-inset](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/prohibit-inset.svg)
-  static const prohibitInset = PhosphorFlatIconData(0xe3e0, 'Regular');
+  static const prohibitInset = IconData(0xe3e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/projector-screen.svg)
-  static const projectorScreen = PhosphorFlatIconData(0xe658, 'Regular');
+  static const projectorScreen = IconData(0xe658,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-chart](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/projector-screen-chart.svg)
-  static const projectorScreenChart = PhosphorFlatIconData(0xe65a, 'Regular');
+  static const projectorScreenChart = IconData(0xe65a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pulse](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/pulse.svg)
-  static const pulse = PhosphorFlatIconData(0xe000, 'Regular');
+  static const pulse = IconData(0xe000,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/push-pin.svg)
-  static const pushPin = PhosphorFlatIconData(0xe3e2, 'Regular');
+  static const pushPin = IconData(0xe3e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/push-pin-simple.svg)
-  static const pushPinSimple = PhosphorFlatIconData(0xe65c, 'Regular');
+  static const pushPinSimple = IconData(0xe65c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/push-pin-simple-slash.svg)
-  static const pushPinSimpleSlash = PhosphorFlatIconData(0xe65e, 'Regular');
+  static const pushPinSimpleSlash = IconData(0xe65e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/push-pin-slash.svg)
-  static const pushPinSlash = PhosphorFlatIconData(0xe3e4, 'Regular');
+  static const pushPinSlash = IconData(0xe3e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![puzzle-piece](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/puzzle-piece.svg)
-  static const puzzlePiece = PhosphorFlatIconData(0xe596, 'Regular');
+  static const puzzlePiece = IconData(0xe596,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![qr-code](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/qr-code.svg)
-  static const qrCode = PhosphorFlatIconData(0xe3e6, 'Regular');
+  static const qrCode = IconData(0xe3e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/question.svg)
-  static const question = PhosphorFlatIconData(0xe3e8, 'Regular');
+  static const question = IconData(0xe3e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-mark](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/question-mark.svg)
-  static const questionMark = PhosphorFlatIconData(0xe3e9, 'Regular');
+  static const questionMark = IconData(0xe3e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![queue](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/queue.svg)
-  static const queue = PhosphorFlatIconData(0xe6ac, 'Regular');
+  static const queue = IconData(0xe6ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![quotes](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/quotes.svg)
-  static const quotes = PhosphorFlatIconData(0xe660, 'Regular');
+  static const quotes = IconData(0xe660,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rabbit](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rabbit.svg)
-  static const rabbit = PhosphorFlatIconData(0xeac2, 'Regular');
+  static const rabbit = IconData(0xeac2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![racquet](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/racquet.svg)
-  static const racquet = PhosphorFlatIconData(0xee02, 'Regular');
+  static const racquet = IconData(0xee02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/radical.svg)
-  static const radical = PhosphorFlatIconData(0xe3ea, 'Regular');
+  static const radical = IconData(0xe3ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/radio.svg)
-  static const radio = PhosphorFlatIconData(0xe77e, 'Regular');
+  static const radio = IconData(0xe77e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-button](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/radio-button.svg)
-  static const radioButton = PhosphorFlatIconData(0xeb08, 'Regular');
+  static const radioButton = IconData(0xeb08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radioactive](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/radioactive.svg)
-  static const radioactive = PhosphorFlatIconData(0xe9dc, 'Regular');
+  static const radioactive = IconData(0xe9dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rainbow.svg)
-  static const rainbow = PhosphorFlatIconData(0xe598, 'Regular');
+  static const rainbow = IconData(0xe598,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-cloud](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rainbow-cloud.svg)
-  static const rainbowCloud = PhosphorFlatIconData(0xe59a, 'Regular');
+  static const rainbowCloud = IconData(0xe59a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ranking](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ranking.svg)
-  static const ranking = PhosphorFlatIconData(0xed62, 'Regular');
+  static const ranking = IconData(0xed62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![read-cv-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/read-cv-logo.svg)
-  static const readCvLogo = PhosphorFlatIconData(0xed0c, 'Regular');
+  static const readCvLogo = IconData(0xed0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/receipt.svg)
-  static const receipt = PhosphorFlatIconData(0xe3ec, 'Regular');
+  static const receipt = IconData(0xe3ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/receipt-x.svg)
-  static const receiptX = PhosphorFlatIconData(0xed40, 'Regular');
+  static const receiptX = IconData(0xed40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![record](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/record.svg)
-  static const record = PhosphorFlatIconData(0xe3ee, 'Regular');
+  static const record = IconData(0xe3ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rectangle.svg)
-  static const rectangle = PhosphorFlatIconData(0xe3f0, 'Regular');
+  static const rectangle = IconData(0xe3f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-dashed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rectangle-dashed.svg)
-  static const rectangleDashed = PhosphorFlatIconData(0xe3f2, 'Regular');
+  static const rectangleDashed = IconData(0xe3f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![recycle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/recycle.svg)
-  static const recycle = PhosphorFlatIconData(0xe75a, 'Regular');
+  static const recycle = IconData(0xe75a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![reddit-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/reddit-logo.svg)
-  static const redditLogo = PhosphorFlatIconData(0xe59c, 'Regular');
+  static const redditLogo = IconData(0xe59c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/repeat.svg)
-  static const repeat = PhosphorFlatIconData(0xe3f6, 'Regular');
+  static const repeat = IconData(0xe3f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-once](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/repeat-once.svg)
-  static const repeatOnce = PhosphorFlatIconData(0xe3f8, 'Regular');
+  static const repeatOnce = IconData(0xe3f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![replit-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/replit-logo.svg)
-  static const replitLogo = PhosphorFlatIconData(0xeb8a, 'Regular');
+  static const replitLogo = IconData(0xeb8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![resize](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/resize.svg)
-  static const resize = PhosphorFlatIconData(0xed6e, 'Regular');
+  static const resize = IconData(0xed6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rewind.svg)
-  static const rewind = PhosphorFlatIconData(0xe6a8, 'Regular');
+  static const rewind = IconData(0xe6a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rewind-circle.svg)
-  static const rewindCircle = PhosphorFlatIconData(0xe3fa, 'Regular');
+  static const rewindCircle = IconData(0xe3fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![road-horizon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/road-horizon.svg)
-  static const roadHorizon = PhosphorFlatIconData(0xe838, 'Regular');
+  static const roadHorizon = IconData(0xe838,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![robot](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/robot.svg)
-  static const robot = PhosphorFlatIconData(0xe762, 'Regular');
+  static const robot = IconData(0xe762,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rocket.svg)
-  static const rocket = PhosphorFlatIconData(0xe3fc, 'Regular');
+  static const rocket = IconData(0xe3fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-launch](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rocket-launch.svg)
-  static const rocketLaunch = PhosphorFlatIconData(0xe3fe, 'Regular');
+  static const rocketLaunch = IconData(0xe3fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rows.svg)
-  static const rows = PhosphorFlatIconData(0xe5a2, 'Regular');
+  static const rows = IconData(0xe5a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-bottom](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rows-plus-bottom.svg)
-  static const rowsPlusBottom = PhosphorFlatIconData(0xe59e, 'Regular');
+  static const rowsPlusBottom = IconData(0xe59e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-top](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rows-plus-top.svg)
-  static const rowsPlusTop = PhosphorFlatIconData(0xe5a0, 'Regular');
+  static const rowsPlusTop = IconData(0xe5a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rss.svg)
-  static const rss = PhosphorFlatIconData(0xe400, 'Regular');
+  static const rss = IconData(0xe400,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rss-simple.svg)
-  static const rssSimple = PhosphorFlatIconData(0xe402, 'Regular');
+  static const rssSimple = IconData(0xe402,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rug](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/rug.svg)
-  static const rug = PhosphorFlatIconData(0xea1a, 'Regular');
+  static const rug = IconData(0xea1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ruler](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ruler.svg)
-  static const ruler = PhosphorFlatIconData(0xe6b8, 'Regular');
+  static const ruler = IconData(0xe6b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sailboat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sailboat.svg)
-  static const sailboat = PhosphorFlatIconData(0xe78a, 'Regular');
+  static const sailboat = IconData(0xe78a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scales](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/scales.svg)
-  static const scales = PhosphorFlatIconData(0xe750, 'Regular');
+  static const scales = IconData(0xe750,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/scan.svg)
-  static const scan = PhosphorFlatIconData(0xebb6, 'Regular');
+  static const scan = IconData(0xebb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-smiley](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/scan-smiley.svg)
-  static const scanSmiley = PhosphorFlatIconData(0xebb4, 'Regular');
+  static const scanSmiley = IconData(0xebb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scissors](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/scissors.svg)
-  static const scissors = PhosphorFlatIconData(0xeae0, 'Regular');
+  static const scissors = IconData(0xeae0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scooter](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/scooter.svg)
-  static const scooter = PhosphorFlatIconData(0xe820, 'Regular');
+  static const scooter = IconData(0xe820,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screencast](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/screencast.svg)
-  static const screencast = PhosphorFlatIconData(0xe404, 'Regular');
+  static const screencast = IconData(0xe404,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screwdriver](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/screwdriver.svg)
-  static const screwdriver = PhosphorFlatIconData(0xe86e, 'Regular');
+  static const screwdriver = IconData(0xe86e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/scribble.svg)
-  static const scribble = PhosphorFlatIconData(0xe806, 'Regular');
+  static const scribble = IconData(0xe806,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-loop](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/scribble-loop.svg)
-  static const scribbleLoop = PhosphorFlatIconData(0xe662, 'Regular');
+  static const scribbleLoop = IconData(0xe662,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scroll](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/scroll.svg)
-  static const scroll = PhosphorFlatIconData(0xeb7a, 'Regular');
+  static const scroll = IconData(0xeb7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/seal.svg)
-  static const seal = PhosphorFlatIconData(0xe604, 'Regular');
+  static const seal = IconData(0xe604,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-check](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/seal-check.svg)
-  static const sealCheck = PhosphorFlatIconData(0xe606, 'Regular');
+  static const sealCheck = IconData(0xe606,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-percent](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/seal-percent.svg)
-  static const sealPercent = PhosphorFlatIconData(0xe60a, 'Regular');
+  static const sealPercent = IconData(0xe60a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-question](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/seal-question.svg)
-  static const sealQuestion = PhosphorFlatIconData(0xe608, 'Regular');
+  static const sealQuestion = IconData(0xe608,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-warning](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/seal-warning.svg)
-  static const sealWarning = PhosphorFlatIconData(0xe60c, 'Regular');
+  static const sealWarning = IconData(0xe60c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/seat.svg)
-  static const seat = PhosphorFlatIconData(0xeb8e, 'Regular');
+  static const seat = IconData(0xeb8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seatbelt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/seatbelt.svg)
-  static const seatbelt = PhosphorFlatIconData(0xedfe, 'Regular');
+  static const seatbelt = IconData(0xedfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![security-camera](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/security-camera.svg)
-  static const securityCamera = PhosphorFlatIconData(0xeca4, 'Regular');
+  static const securityCamera = IconData(0xeca4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/selection.svg)
-  static const selection = PhosphorFlatIconData(0xe69a, 'Regular');
+  static const selection = IconData(0xe69a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-all](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/selection-all.svg)
-  static const selectionAll = PhosphorFlatIconData(0xe746, 'Regular');
+  static const selectionAll = IconData(0xe746,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-background](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/selection-background.svg)
-  static const selectionBackground = PhosphorFlatIconData(0xeaf8, 'Regular');
+  static const selectionBackground = IconData(0xeaf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-foreground](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/selection-foreground.svg)
-  static const selectionForeground = PhosphorFlatIconData(0xeaf6, 'Regular');
+  static const selectionForeground = IconData(0xeaf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-inverse](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/selection-inverse.svg)
-  static const selectionInverse = PhosphorFlatIconData(0xe744, 'Regular');
+  static const selectionInverse = IconData(0xe744,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/selection-plus.svg)
-  static const selectionPlus = PhosphorFlatIconData(0xe69c, 'Regular');
+  static const selectionPlus = IconData(0xe69c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/selection-slash.svg)
-  static const selectionSlash = PhosphorFlatIconData(0xe69e, 'Regular');
+  static const selectionSlash = IconData(0xe69e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shapes](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shapes.svg)
-  static const shapes = PhosphorFlatIconData(0xec5e, 'Regular');
+  static const shapes = IconData(0xec5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/share.svg)
-  static const share = PhosphorFlatIconData(0xe406, 'Regular');
+  static const share = IconData(0xe406,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-fat](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/share-fat.svg)
-  static const shareFat = PhosphorFlatIconData(0xed52, 'Regular');
+  static const shareFat = IconData(0xed52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-network](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/share-network.svg)
-  static const shareNetwork = PhosphorFlatIconData(0xe408, 'Regular');
+  static const shareNetwork = IconData(0xe408,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shield.svg)
-  static const shield = PhosphorFlatIconData(0xe40a, 'Regular');
+  static const shield = IconData(0xe40a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-check](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shield-check.svg)
-  static const shieldCheck = PhosphorFlatIconData(0xe40c, 'Regular');
+  static const shieldCheck = IconData(0xe40c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-checkered](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shield-checkered.svg)
-  static const shieldCheckered = PhosphorFlatIconData(0xe708, 'Regular');
+  static const shieldCheckered = IconData(0xe708,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-chevron](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shield-chevron.svg)
-  static const shieldChevron = PhosphorFlatIconData(0xe40e, 'Regular');
+  static const shieldChevron = IconData(0xe40e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shield-plus.svg)
-  static const shieldPlus = PhosphorFlatIconData(0xe706, 'Regular');
+  static const shieldPlus = IconData(0xe706,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shield-slash.svg)
-  static const shieldSlash = PhosphorFlatIconData(0xe410, 'Regular');
+  static const shieldSlash = IconData(0xe410,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-star](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shield-star.svg)
-  static const shieldStar = PhosphorFlatIconData(0xec34, 'Regular');
+  static const shieldStar = IconData(0xec34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-warning](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shield-warning.svg)
-  static const shieldWarning = PhosphorFlatIconData(0xe412, 'Regular');
+  static const shieldWarning = IconData(0xe412,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shipping-container](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shipping-container.svg)
-  static const shippingContainer = PhosphorFlatIconData(0xe78c, 'Regular');
+  static const shippingContainer = IconData(0xe78c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shirt-folded](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shirt-folded.svg)
-  static const shirtFolded = PhosphorFlatIconData(0xea92, 'Regular');
+  static const shirtFolded = IconData(0xea92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shooting-star](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shooting-star.svg)
-  static const shootingStar = PhosphorFlatIconData(0xecfa, 'Regular');
+  static const shootingStar = IconData(0xecfa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shopping-bag.svg)
-  static const shoppingBag = PhosphorFlatIconData(0xe416, 'Regular');
+  static const shoppingBag = IconData(0xe416,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-open](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shopping-bag-open.svg)
-  static const shoppingBagOpen = PhosphorFlatIconData(0xe418, 'Regular');
+  static const shoppingBagOpen = IconData(0xe418,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shopping-cart.svg)
-  static const shoppingCart = PhosphorFlatIconData(0xe41e, 'Regular');
+  static const shoppingCart = IconData(0xe41e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shopping-cart-simple.svg)
-  static const shoppingCartSimple = PhosphorFlatIconData(0xe420, 'Regular');
+  static const shoppingCartSimple = IconData(0xe420,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shovel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shovel.svg)
-  static const shovel = PhosphorFlatIconData(0xe9e6, 'Regular');
+  static const shovel = IconData(0xe9e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shower](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shower.svg)
-  static const shower = PhosphorFlatIconData(0xe776, 'Regular');
+  static const shower = IconData(0xe776,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shrimp](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shrimp.svg)
-  static const shrimp = PhosphorFlatIconData(0xeab4, 'Regular');
+  static const shrimp = IconData(0xeab4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shuffle.svg)
-  static const shuffle = PhosphorFlatIconData(0xe422, 'Regular');
+  static const shuffle = IconData(0xe422,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-angular](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shuffle-angular.svg)
-  static const shuffleAngular = PhosphorFlatIconData(0xe424, 'Regular');
+  static const shuffleAngular = IconData(0xe424,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/shuffle-simple.svg)
-  static const shuffleSimple = PhosphorFlatIconData(0xe426, 'Regular');
+  static const shuffleSimple = IconData(0xe426,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sidebar.svg)
-  static const sidebar = PhosphorFlatIconData(0xeab6, 'Regular');
+  static const sidebar = IconData(0xeab6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sidebar-simple.svg)
-  static const sidebarSimple = PhosphorFlatIconData(0xec24, 'Regular');
+  static const sidebarSimple = IconData(0xec24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sigma](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sigma.svg)
-  static const sigma = PhosphorFlatIconData(0xeab8, 'Regular');
+  static const sigma = IconData(0xeab8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-in](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sign-in.svg)
-  static const signIn = PhosphorFlatIconData(0xe428, 'Regular');
+  static const signIn = IconData(0xe428,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-out](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sign-out.svg)
-  static const signOut = PhosphorFlatIconData(0xe42a, 'Regular');
+  static const signOut = IconData(0xe42a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signature](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/signature.svg)
-  static const signature = PhosphorFlatIconData(0xebac, 'Regular');
+  static const signature = IconData(0xebac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signpost](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/signpost.svg)
-  static const signpost = PhosphorFlatIconData(0xe89c, 'Regular');
+  static const signpost = IconData(0xe89c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sim-card](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sim-card.svg)
-  static const simCard = PhosphorFlatIconData(0xe664, 'Regular');
+  static const simCard = IconData(0xe664,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![siren](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/siren.svg)
-  static const siren = PhosphorFlatIconData(0xe9b8, 'Regular');
+  static const siren = IconData(0xe9b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sketch-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sketch-logo.svg)
-  static const sketchLogo = PhosphorFlatIconData(0xe42c, 'Regular');
+  static const sketchLogo = IconData(0xe42c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/skip-back.svg)
-  static const skipBack = PhosphorFlatIconData(0xe5a4, 'Regular');
+  static const skipBack = IconData(0xe5a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/skip-back-circle.svg)
-  static const skipBackCircle = PhosphorFlatIconData(0xe42e, 'Regular');
+  static const skipBackCircle = IconData(0xe42e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/skip-forward.svg)
-  static const skipForward = PhosphorFlatIconData(0xe5a6, 'Regular');
+  static const skipForward = IconData(0xe5a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/skip-forward-circle.svg)
-  static const skipForwardCircle = PhosphorFlatIconData(0xe430, 'Regular');
+  static const skipForwardCircle = IconData(0xe430,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skull](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/skull.svg)
-  static const skull = PhosphorFlatIconData(0xe916, 'Regular');
+  static const skull = IconData(0xe916,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skype-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/skype-logo.svg)
-  static const skypeLogo = PhosphorFlatIconData(0xe8dc, 'Regular');
+  static const skypeLogo = IconData(0xe8dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slack-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/slack-logo.svg)
-  static const slackLogo = PhosphorFlatIconData(0xe5a8, 'Regular');
+  static const slackLogo = IconData(0xe5a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sliders.svg)
-  static const sliders = PhosphorFlatIconData(0xe432, 'Regular');
+  static const sliders = IconData(0xe432,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sliders-horizontal.svg)
-  static const slidersHorizontal = PhosphorFlatIconData(0xe434, 'Regular');
+  static const slidersHorizontal = IconData(0xe434,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slideshow](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/slideshow.svg)
-  static const slideshow = PhosphorFlatIconData(0xed32, 'Regular');
+  static const slideshow = IconData(0xed32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley.svg)
-  static const smiley = PhosphorFlatIconData(0xe436, 'Regular');
+  static const smiley = IconData(0xe436,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-angry](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-angry.svg)
-  static const smileyAngry = PhosphorFlatIconData(0xec62, 'Regular');
+  static const smileyAngry = IconData(0xec62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-blank](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-blank.svg)
-  static const smileyBlank = PhosphorFlatIconData(0xe438, 'Regular');
+  static const smileyBlank = IconData(0xe438,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-meh](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-meh.svg)
-  static const smileyMeh = PhosphorFlatIconData(0xe43a, 'Regular');
+  static const smileyMeh = IconData(0xe43a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-melting](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-melting.svg)
-  static const smileyMelting = PhosphorFlatIconData(0xee56, 'Regular');
+  static const smileyMelting = IconData(0xee56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-nervous](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-nervous.svg)
-  static const smileyNervous = PhosphorFlatIconData(0xe43c, 'Regular');
+  static const smileyNervous = IconData(0xe43c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sad](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-sad.svg)
-  static const smileySad = PhosphorFlatIconData(0xe43e, 'Regular');
+  static const smileySad = IconData(0xe43e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sticker](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-sticker.svg)
-  static const smileySticker = PhosphorFlatIconData(0xe440, 'Regular');
+  static const smileySticker = IconData(0xe440,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-wink](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-wink.svg)
-  static const smileyWink = PhosphorFlatIconData(0xe666, 'Regular');
+  static const smileyWink = IconData(0xe666,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-x-eyes](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/smiley-x-eyes.svg)
-  static const smileyXEyes = PhosphorFlatIconData(0xe442, 'Regular');
+  static const smileyXEyes = IconData(0xe442,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snapchat-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/snapchat-logo.svg)
-  static const snapchatLogo = PhosphorFlatIconData(0xe668, 'Regular');
+  static const snapchatLogo = IconData(0xe668,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sneaker.svg)
-  static const sneaker = PhosphorFlatIconData(0xe80c, 'Regular');
+  static const sneaker = IconData(0xe80c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-move](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sneaker-move.svg)
-  static const sneakerMove = PhosphorFlatIconData(0xed60, 'Regular');
+  static const sneakerMove = IconData(0xed60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snowflake](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/snowflake.svg)
-  static const snowflake = PhosphorFlatIconData(0xe5aa, 'Regular');
+  static const snowflake = IconData(0xe5aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soccer-ball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/soccer-ball.svg)
-  static const soccerBall = PhosphorFlatIconData(0xe716, 'Regular');
+  static const soccerBall = IconData(0xe716,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sock](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sock.svg)
-  static const sock = PhosphorFlatIconData(0xecce, 'Regular');
+  static const sock = IconData(0xecce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-panel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/solar-panel.svg)
-  static const solarPanel = PhosphorFlatIconData(0xed7a, 'Regular');
+  static const solarPanel = IconData(0xed7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-roof](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/solar-roof.svg)
-  static const solarRoof = PhosphorFlatIconData(0xed7b, 'Regular');
+  static const solarRoof = IconData(0xed7b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-ascending](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sort-ascending.svg)
-  static const sortAscending = PhosphorFlatIconData(0xe444, 'Regular');
+  static const sortAscending = IconData(0xe444,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-descending](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sort-descending.svg)
-  static const sortDescending = PhosphorFlatIconData(0xe446, 'Regular');
+  static const sortDescending = IconData(0xe446,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soundcloud-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/soundcloud-logo.svg)
-  static const soundcloudLogo = PhosphorFlatIconData(0xe8de, 'Regular');
+  static const soundcloudLogo = IconData(0xe8de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spade](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/spade.svg)
-  static const spade = PhosphorFlatIconData(0xe448, 'Regular');
+  static const spade = IconData(0xe448,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sparkle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sparkle.svg)
-  static const sparkle = PhosphorFlatIconData(0xe6a2, 'Regular');
+  static const sparkle = IconData(0xe6a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-hifi](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-hifi.svg)
-  static const speakerHifi = PhosphorFlatIconData(0xea08, 'Regular');
+  static const speakerHifi = IconData(0xea08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-high](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-high.svg)
-  static const speakerHigh = PhosphorFlatIconData(0xe44a, 'Regular');
+  static const speakerHigh = IconData(0xe44a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-low](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-low.svg)
-  static const speakerLow = PhosphorFlatIconData(0xe44c, 'Regular');
+  static const speakerLow = IconData(0xe44c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-none](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-none.svg)
-  static const speakerNone = PhosphorFlatIconData(0xe44e, 'Regular');
+  static const speakerNone = IconData(0xe44e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-high](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-simple-high.svg)
-  static const speakerSimpleHigh = PhosphorFlatIconData(0xe450, 'Regular');
+  static const speakerSimpleHigh = IconData(0xe450,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-low](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-simple-low.svg)
-  static const speakerSimpleLow = PhosphorFlatIconData(0xe452, 'Regular');
+  static const speakerSimpleLow = IconData(0xe452,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-none](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-simple-none.svg)
-  static const speakerSimpleNone = PhosphorFlatIconData(0xe454, 'Regular');
+  static const speakerSimpleNone = IconData(0xe454,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-simple-slash.svg)
-  static const speakerSimpleSlash = PhosphorFlatIconData(0xe456, 'Regular');
+  static const speakerSimpleSlash = IconData(0xe456,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-simple-x.svg)
-  static const speakerSimpleX = PhosphorFlatIconData(0xe458, 'Regular');
+  static const speakerSimpleX = IconData(0xe458,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-slash.svg)
-  static const speakerSlash = PhosphorFlatIconData(0xe45a, 'Regular');
+  static const speakerSlash = IconData(0xe45a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speaker-x.svg)
-  static const speakerX = PhosphorFlatIconData(0xe45c, 'Regular');
+  static const speakerX = IconData(0xe45c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speedometer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/speedometer.svg)
-  static const speedometer = PhosphorFlatIconData(0xee74, 'Regular');
+  static const speedometer = IconData(0xee74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sphere](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sphere.svg)
-  static const sphere = PhosphorFlatIconData(0xee66, 'Regular');
+  static const sphere = IconData(0xee66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/spinner.svg)
-  static const spinner = PhosphorFlatIconData(0xe66a, 'Regular');
+  static const spinner = IconData(0xe66a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-ball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/spinner-ball.svg)
-  static const spinnerBall = PhosphorFlatIconData(0xee28, 'Regular');
+  static const spinnerBall = IconData(0xee28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-gap](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/spinner-gap.svg)
-  static const spinnerGap = PhosphorFlatIconData(0xe66c, 'Regular');
+  static const spinnerGap = IconData(0xe66c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spiral](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/spiral.svg)
-  static const spiral = PhosphorFlatIconData(0xe9fa, 'Regular');
+  static const spiral = IconData(0xe9fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/split-horizontal.svg)
-  static const splitHorizontal = PhosphorFlatIconData(0xe872, 'Regular');
+  static const splitHorizontal = IconData(0xe872,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/split-vertical.svg)
-  static const splitVertical = PhosphorFlatIconData(0xe876, 'Regular');
+  static const splitVertical = IconData(0xe876,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spotify-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/spotify-logo.svg)
-  static const spotifyLogo = PhosphorFlatIconData(0xe66e, 'Regular');
+  static const spotifyLogo = IconData(0xe66e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spray-bottle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/spray-bottle.svg)
-  static const sprayBottle = PhosphorFlatIconData(0xe7e4, 'Regular');
+  static const sprayBottle = IconData(0xe7e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/square.svg)
-  static const square = PhosphorFlatIconData(0xe45e, 'Regular');
+  static const square = IconData(0xe45e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/square-half.svg)
-  static const squareHalf = PhosphorFlatIconData(0xe462, 'Regular');
+  static const squareHalf = IconData(0xe462,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-bottom](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/square-half-bottom.svg)
-  static const squareHalfBottom = PhosphorFlatIconData(0xeb16, 'Regular');
+  static const squareHalfBottom = IconData(0xeb16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/square-logo.svg)
-  static const squareLogo = PhosphorFlatIconData(0xe690, 'Regular');
+  static const squareLogo = IconData(0xe690,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-horizontal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/square-split-horizontal.svg)
-  static const squareSplitHorizontal = PhosphorFlatIconData(0xe870, 'Regular');
+  static const squareSplitHorizontal = IconData(0xe870,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-vertical](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/square-split-vertical.svg)
-  static const squareSplitVertical = PhosphorFlatIconData(0xe874, 'Regular');
+  static const squareSplitVertical = IconData(0xe874,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![squares-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/squares-four.svg)
-  static const squaresFour = PhosphorFlatIconData(0xe464, 'Regular');
+  static const squaresFour = IconData(0xe464,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stack.svg)
-  static const stack = PhosphorFlatIconData(0xe466, 'Regular');
+  static const stack = IconData(0xe466,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stack-minus.svg)
-  static const stackMinus = PhosphorFlatIconData(0xedf4, 'Regular');
+  static const stackMinus = IconData(0xedf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-overflow-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stack-overflow-logo.svg)
-  static const stackOverflowLogo = PhosphorFlatIconData(0xeb78, 'Regular');
+  static const stackOverflowLogo = IconData(0xeb78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stack-plus.svg)
-  static const stackPlus = PhosphorFlatIconData(0xedf6, 'Regular');
+  static const stackPlus = IconData(0xedf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stack-simple.svg)
-  static const stackSimple = PhosphorFlatIconData(0xe468, 'Regular');
+  static const stackSimple = IconData(0xe468,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stairs](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stairs.svg)
-  static const stairs = PhosphorFlatIconData(0xe8ec, 'Regular');
+  static const stairs = IconData(0xe8ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stamp](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stamp.svg)
-  static const stamp = PhosphorFlatIconData(0xea48, 'Regular');
+  static const stamp = IconData(0xea48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![standard-definition](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/standard-definition.svg)
-  static const standardDefinition = PhosphorFlatIconData(0xea90, 'Regular');
+  static const standardDefinition = IconData(0xea90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/star.svg)
-  static const star = PhosphorFlatIconData(0xe46a, 'Regular');
+  static const star = IconData(0xe46a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-and-crescent](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/star-and-crescent.svg)
-  static const starAndCrescent = PhosphorFlatIconData(0xecf4, 'Regular');
+  static const starAndCrescent = IconData(0xecf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/star-four.svg)
-  static const starFour = PhosphorFlatIconData(0xe6a4, 'Regular');
+  static const starFour = IconData(0xe6a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-half](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/star-half.svg)
-  static const starHalf = PhosphorFlatIconData(0xe70a, 'Regular');
+  static const starHalf = IconData(0xe70a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-of-david](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/star-of-david.svg)
-  static const starOfDavid = PhosphorFlatIconData(0xe89e, 'Regular');
+  static const starOfDavid = IconData(0xe89e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steam-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/steam-logo.svg)
-  static const steamLogo = PhosphorFlatIconData(0xead4, 'Regular');
+  static const steamLogo = IconData(0xead4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steering-wheel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/steering-wheel.svg)
-  static const steeringWheel = PhosphorFlatIconData(0xe9ac, 'Regular');
+  static const steeringWheel = IconData(0xe9ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steps](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/steps.svg)
-  static const steps = PhosphorFlatIconData(0xecbe, 'Regular');
+  static const steps = IconData(0xecbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stethoscope](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stethoscope.svg)
-  static const stethoscope = PhosphorFlatIconData(0xe7ea, 'Regular');
+  static const stethoscope = IconData(0xe7ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sticker](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sticker.svg)
-  static const sticker = PhosphorFlatIconData(0xe5ac, 'Regular');
+  static const sticker = IconData(0xe5ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stool](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stool.svg)
-  static const stool = PhosphorFlatIconData(0xea44, 'Regular');
+  static const stool = IconData(0xea44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stop.svg)
-  static const stop = PhosphorFlatIconData(0xe46c, 'Regular');
+  static const stop = IconData(0xe46c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stop-circle.svg)
-  static const stopCircle = PhosphorFlatIconData(0xe46e, 'Regular');
+  static const stopCircle = IconData(0xe46e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![storefront](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/storefront.svg)
-  static const storefront = PhosphorFlatIconData(0xe470, 'Regular');
+  static const storefront = IconData(0xe470,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![strategy](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/strategy.svg)
-  static const strategy = PhosphorFlatIconData(0xea3a, 'Regular');
+  static const strategy = IconData(0xea3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stripe-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/stripe-logo.svg)
-  static const stripeLogo = PhosphorFlatIconData(0xe698, 'Regular');
+  static const stripeLogo = IconData(0xe698,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![student](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/student.svg)
-  static const student = PhosphorFlatIconData(0xe73e, 'Regular');
+  static const student = IconData(0xe73e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-of](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/subset-of.svg)
-  static const subsetOf = PhosphorFlatIconData(0xedc0, 'Regular');
+  static const subsetOf = IconData(0xedc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-proper-of](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/subset-proper-of.svg)
-  static const subsetProperOf = PhosphorFlatIconData(0xedb6, 'Regular');
+  static const subsetProperOf = IconData(0xedb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/subtitles.svg)
-  static const subtitles = PhosphorFlatIconData(0xe1a8, 'Regular');
+  static const subtitles = IconData(0xe1a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/subtitles-slash.svg)
-  static const subtitlesSlash = PhosphorFlatIconData(0xe1a6, 'Regular');
+  static const subtitlesSlash = IconData(0xe1a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/subtract.svg)
-  static const subtract = PhosphorFlatIconData(0xebd6, 'Regular');
+  static const subtract = IconData(0xebd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/subtract-square.svg)
-  static const subtractSquare = PhosphorFlatIconData(0xebd4, 'Regular');
+  static const subtractSquare = IconData(0xebd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subway](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/subway.svg)
-  static const subway = PhosphorFlatIconData(0xe498, 'Regular');
+  static const subway = IconData(0xe498,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/suitcase.svg)
-  static const suitcase = PhosphorFlatIconData(0xe5ae, 'Regular');
+  static const suitcase = IconData(0xe5ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-rolling](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/suitcase-rolling.svg)
-  static const suitcaseRolling = PhosphorFlatIconData(0xe9b0, 'Regular');
+  static const suitcaseRolling = IconData(0xe9b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/suitcase-simple.svg)
-  static const suitcaseSimple = PhosphorFlatIconData(0xe5b0, 'Regular');
+  static const suitcaseSimple = IconData(0xe5b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sun.svg)
-  static const sun = PhosphorFlatIconData(0xe472, 'Regular');
+  static const sun = IconData(0xe472,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-dim](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sun-dim.svg)
-  static const sunDim = PhosphorFlatIconData(0xe474, 'Regular');
+  static const sunDim = IconData(0xe474,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-horizon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sun-horizon.svg)
-  static const sunHorizon = PhosphorFlatIconData(0xe5b6, 'Regular');
+  static const sunHorizon = IconData(0xe5b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sunglasses](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sunglasses.svg)
-  static const sunglasses = PhosphorFlatIconData(0xe816, 'Regular');
+  static const sunglasses = IconData(0xe816,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-of](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/superset-of.svg)
-  static const supersetOf = PhosphorFlatIconData(0xedb8, 'Regular');
+  static const supersetOf = IconData(0xedb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-proper-of](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/superset-proper-of.svg)
-  static const supersetProperOf = PhosphorFlatIconData(0xedb4, 'Regular');
+  static const supersetProperOf = IconData(0xedb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swap](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/swap.svg)
-  static const swap = PhosphorFlatIconData(0xe83c, 'Regular');
+  static const swap = IconData(0xe83c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swatches](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/swatches.svg)
-  static const swatches = PhosphorFlatIconData(0xe5b8, 'Regular');
+  static const swatches = IconData(0xe5b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swimming-pool](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/swimming-pool.svg)
-  static const swimmingPool = PhosphorFlatIconData(0xecb6, 'Regular');
+  static const swimmingPool = IconData(0xecb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sword](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/sword.svg)
-  static const sword = PhosphorFlatIconData(0xe5ba, 'Regular');
+  static const sword = IconData(0xe5ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![synagogue](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/synagogue.svg)
-  static const synagogue = PhosphorFlatIconData(0xecec, 'Regular');
+  static const synagogue = IconData(0xecec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![syringe](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/syringe.svg)
-  static const syringe = PhosphorFlatIconData(0xe968, 'Regular');
+  static const syringe = IconData(0xe968,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![t-shirt](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/t-shirt.svg)
-  static const tShirt = PhosphorFlatIconData(0xe670, 'Regular');
+  static const tShirt = IconData(0xe670,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![table](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/table.svg)
-  static const table = PhosphorFlatIconData(0xe476, 'Regular');
+  static const table = IconData(0xe476,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tabs](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tabs.svg)
-  static const tabs = PhosphorFlatIconData(0xe778, 'Regular');
+  static const tabs = IconData(0xe778,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tag.svg)
-  static const tag = PhosphorFlatIconData(0xe478, 'Regular');
+  static const tag = IconData(0xe478,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-chevron](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tag-chevron.svg)
-  static const tagChevron = PhosphorFlatIconData(0xe672, 'Regular');
+  static const tagChevron = IconData(0xe672,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tag-simple.svg)
-  static const tagSimple = PhosphorFlatIconData(0xe47a, 'Regular');
+  static const tagSimple = IconData(0xe47a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![target](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/target.svg)
-  static const target = PhosphorFlatIconData(0xe47c, 'Regular');
+  static const target = IconData(0xe47c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![taxi](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/taxi.svg)
-  static const taxi = PhosphorFlatIconData(0xe902, 'Regular');
+  static const taxi = IconData(0xe902,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tea-bag](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tea-bag.svg)
-  static const teaBag = PhosphorFlatIconData(0xe8e6, 'Regular');
+  static const teaBag = IconData(0xe8e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![telegram-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/telegram-logo.svg)
-  static const telegramLogo = PhosphorFlatIconData(0xe5bc, 'Regular');
+  static const telegramLogo = IconData(0xe5bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/television.svg)
-  static const television = PhosphorFlatIconData(0xe754, 'Regular');
+  static const television = IconData(0xe754,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/television-simple.svg)
-  static const televisionSimple = PhosphorFlatIconData(0xeae6, 'Regular');
+  static const televisionSimple = IconData(0xeae6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tennis-ball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tennis-ball.svg)
-  static const tennisBall = PhosphorFlatIconData(0xe720, 'Regular');
+  static const tennisBall = IconData(0xe720,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tent](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tent.svg)
-  static const tent = PhosphorFlatIconData(0xe8ba, 'Regular');
+  static const tent = IconData(0xe8ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/terminal.svg)
-  static const terminal = PhosphorFlatIconData(0xe47e, 'Regular');
+  static const terminal = IconData(0xe47e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-window](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/terminal-window.svg)
-  static const terminalWindow = PhosphorFlatIconData(0xeae8, 'Regular');
+  static const terminalWindow = IconData(0xeae8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![test-tube](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/test-tube.svg)
-  static const testTube = PhosphorFlatIconData(0xe7a0, 'Regular');
+  static const testTube = IconData(0xe7a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-a-underline](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-a-underline.svg)
-  static const textAUnderline = PhosphorFlatIconData(0xed34, 'Regular');
+  static const textAUnderline = IconData(0xed34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-aa](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-aa.svg)
-  static const textAa = PhosphorFlatIconData(0xe6ee, 'Regular');
+  static const textAa = IconData(0xe6ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-center](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-align-center.svg)
-  static const textAlignCenter = PhosphorFlatIconData(0xe480, 'Regular');
+  static const textAlignCenter = IconData(0xe480,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-justify](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-align-justify.svg)
-  static const textAlignJustify = PhosphorFlatIconData(0xe482, 'Regular');
+  static const textAlignJustify = IconData(0xe482,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-align-left.svg)
-  static const textAlignLeft = PhosphorFlatIconData(0xe484, 'Regular');
+  static const textAlignLeft = IconData(0xe484,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-align-right.svg)
-  static const textAlignRight = PhosphorFlatIconData(0xe486, 'Regular');
+  static const textAlignRight = IconData(0xe486,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-b](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-b.svg)
-  static const textB = PhosphorFlatIconData(0xe5be, 'Regular');
+  static const textB = IconData(0xe5be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-columns](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-columns.svg)
-  static const textColumns = PhosphorFlatIconData(0xec96, 'Regular');
+  static const textColumns = IconData(0xec96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-h.svg)
-  static const textH = PhosphorFlatIconData(0xe6ba, 'Regular');
+  static const textH = IconData(0xe6ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-five](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-h-five.svg)
-  static const textHFive = PhosphorFlatIconData(0xe6c4, 'Regular');
+  static const textHFive = IconData(0xe6c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-h-four.svg)
-  static const textHFour = PhosphorFlatIconData(0xe6c2, 'Regular');
+  static const textHFour = IconData(0xe6c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-one](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-h-one.svg)
-  static const textHOne = PhosphorFlatIconData(0xe6bc, 'Regular');
+  static const textHOne = IconData(0xe6bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-six](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-h-six.svg)
-  static const textHSix = PhosphorFlatIconData(0xe6c6, 'Regular');
+  static const textHSix = IconData(0xe6c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-h-three.svg)
-  static const textHThree = PhosphorFlatIconData(0xe6c0, 'Regular');
+  static const textHThree = IconData(0xe6c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-two](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-h-two.svg)
-  static const textHTwo = PhosphorFlatIconData(0xe6be, 'Regular');
+  static const textHTwo = IconData(0xe6be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-indent](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-indent.svg)
-  static const textIndent = PhosphorFlatIconData(0xea1e, 'Regular');
+  static const textIndent = IconData(0xea1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-italic](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-italic.svg)
-  static const textItalic = PhosphorFlatIconData(0xe5c0, 'Regular');
+  static const textItalic = IconData(0xe5c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-outdent](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-outdent.svg)
-  static const textOutdent = PhosphorFlatIconData(0xea1c, 'Regular');
+  static const textOutdent = IconData(0xea1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-strikethrough](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-strikethrough.svg)
-  static const textStrikethrough = PhosphorFlatIconData(0xe5c2, 'Regular');
+  static const textStrikethrough = IconData(0xe5c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-subscript](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-subscript.svg)
-  static const textSubscript = PhosphorFlatIconData(0xec98, 'Regular');
+  static const textSubscript = IconData(0xec98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-superscript](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-superscript.svg)
-  static const textSuperscript = PhosphorFlatIconData(0xec9a, 'Regular');
+  static const textSuperscript = IconData(0xec9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-t.svg)
-  static const textT = PhosphorFlatIconData(0xe48a, 'Regular');
+  static const textT = IconData(0xe48a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-t-slash.svg)
-  static const textTSlash = PhosphorFlatIconData(0xe488, 'Regular');
+  static const textTSlash = IconData(0xe488,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-underline](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/text-underline.svg)
-  static const textUnderline = PhosphorFlatIconData(0xe5c4, 'Regular');
+  static const textUnderline = IconData(0xe5c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![textbox](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/textbox.svg)
-  static const textbox = PhosphorFlatIconData(0xeb0a, 'Regular');
+  static const textbox = IconData(0xeb0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/thermometer.svg)
-  static const thermometer = PhosphorFlatIconData(0xe5c6, 'Regular');
+  static const thermometer = IconData(0xe5c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-cold](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/thermometer-cold.svg)
-  static const thermometerCold = PhosphorFlatIconData(0xe5c8, 'Regular');
+  static const thermometerCold = IconData(0xe5c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-hot](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/thermometer-hot.svg)
-  static const thermometerHot = PhosphorFlatIconData(0xe5ca, 'Regular');
+  static const thermometerHot = IconData(0xe5ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/thermometer-simple.svg)
-  static const thermometerSimple = PhosphorFlatIconData(0xe5cc, 'Regular');
+  static const thermometerSimple = IconData(0xe5cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![threads-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/threads-logo.svg)
-  static const threadsLogo = PhosphorFlatIconData(0xed9e, 'Regular');
+  static const threadsLogo = IconData(0xed9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![three-d](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/three-d.svg)
-  static const threeD = PhosphorFlatIconData(0xea5a, 'Regular');
+  static const threeD = IconData(0xea5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/thumbs-down.svg)
-  static const thumbsDown = PhosphorFlatIconData(0xe48c, 'Regular');
+  static const thumbsDown = IconData(0xe48c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/thumbs-up.svg)
-  static const thumbsUp = PhosphorFlatIconData(0xe48e, 'Regular');
+  static const thumbsUp = IconData(0xe48e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ticket](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/ticket.svg)
-  static const ticket = PhosphorFlatIconData(0xe490, 'Regular');
+  static const ticket = IconData(0xe490,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tidal-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tidal-logo.svg)
-  static const tidalLogo = PhosphorFlatIconData(0xed1c, 'Regular');
+  static const tidalLogo = IconData(0xed1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tiktok-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tiktok-logo.svg)
-  static const tiktokLogo = PhosphorFlatIconData(0xeaf2, 'Regular');
+  static const tiktokLogo = IconData(0xeaf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tilde](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tilde.svg)
-  static const tilde = PhosphorFlatIconData(0xeda8, 'Regular');
+  static const tilde = IconData(0xeda8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![timer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/timer.svg)
-  static const timer = PhosphorFlatIconData(0xe492, 'Regular');
+  static const timer = IconData(0xe492,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tip-jar](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tip-jar.svg)
-  static const tipJar = PhosphorFlatIconData(0xe7e2, 'Regular');
+  static const tipJar = IconData(0xe7e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tipi](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tipi.svg)
-  static const tipi = PhosphorFlatIconData(0xed30, 'Regular');
+  static const tipi = IconData(0xed30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tire](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tire.svg)
-  static const tire = PhosphorFlatIconData(0xedd2, 'Regular');
+  static const tire = IconData(0xedd2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-left](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/toggle-left.svg)
-  static const toggleLeft = PhosphorFlatIconData(0xe674, 'Regular');
+  static const toggleLeft = IconData(0xe674,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-right](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/toggle-right.svg)
-  static const toggleRight = PhosphorFlatIconData(0xe676, 'Regular');
+  static const toggleRight = IconData(0xe676,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/toilet.svg)
-  static const toilet = PhosphorFlatIconData(0xe79a, 'Regular');
+  static const toilet = IconData(0xe79a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-paper](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/toilet-paper.svg)
-  static const toiletPaper = PhosphorFlatIconData(0xe79c, 'Regular');
+  static const toiletPaper = IconData(0xe79c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toolbox](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/toolbox.svg)
-  static const toolbox = PhosphorFlatIconData(0xeca0, 'Regular');
+  static const toolbox = IconData(0xeca0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tooth](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tooth.svg)
-  static const tooth = PhosphorFlatIconData(0xe9cc, 'Regular');
+  static const tooth = IconData(0xe9cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tornado](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tornado.svg)
-  static const tornado = PhosphorFlatIconData(0xe88c, 'Regular');
+  static const tornado = IconData(0xe88c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tote.svg)
-  static const tote = PhosphorFlatIconData(0xe494, 'Regular');
+  static const tote = IconData(0xe494,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tote-simple.svg)
-  static const toteSimple = PhosphorFlatIconData(0xe678, 'Regular');
+  static const toteSimple = IconData(0xe678,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![towel](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/towel.svg)
-  static const towel = PhosphorFlatIconData(0xede6, 'Regular');
+  static const towel = IconData(0xede6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tractor](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tractor.svg)
-  static const tractor = PhosphorFlatIconData(0xec6e, 'Regular');
+  static const tractor = IconData(0xec6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trademark.svg)
-  static const trademark = PhosphorFlatIconData(0xe9f0, 'Regular');
+  static const trademark = IconData(0xe9f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-registered](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trademark-registered.svg)
-  static const trademarkRegistered = PhosphorFlatIconData(0xe3f4, 'Regular');
+  static const trademarkRegistered = IconData(0xe3f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-cone](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/traffic-cone.svg)
-  static const trafficCone = PhosphorFlatIconData(0xe9a8, 'Regular');
+  static const trafficCone = IconData(0xe9a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-sign](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/traffic-sign.svg)
-  static const trafficSign = PhosphorFlatIconData(0xe67a, 'Regular');
+  static const trafficSign = IconData(0xe67a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-signal](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/traffic-signal.svg)
-  static const trafficSignal = PhosphorFlatIconData(0xe9aa, 'Regular');
+  static const trafficSignal = IconData(0xe9aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/train.svg)
-  static const train = PhosphorFlatIconData(0xe496, 'Regular');
+  static const train = IconData(0xe496,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-regional](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/train-regional.svg)
-  static const trainRegional = PhosphorFlatIconData(0xe49e, 'Regular');
+  static const trainRegional = IconData(0xe49e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/train-simple.svg)
-  static const trainSimple = PhosphorFlatIconData(0xe4a0, 'Regular');
+  static const trainSimple = IconData(0xe4a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tram](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tram.svg)
-  static const tram = PhosphorFlatIconData(0xe9ec, 'Regular');
+  static const tram = IconData(0xe9ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![translate](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/translate.svg)
-  static const translate = PhosphorFlatIconData(0xe4a2, 'Regular');
+  static const translate = IconData(0xe4a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trash.svg)
-  static const trash = PhosphorFlatIconData(0xe4a6, 'Regular');
+  static const trash = IconData(0xe4a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trash-simple.svg)
-  static const trashSimple = PhosphorFlatIconData(0xe4a8, 'Regular');
+  static const trashSimple = IconData(0xe4a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tray.svg)
-  static const tray = PhosphorFlatIconData(0xe4aa, 'Regular');
+  static const tray = IconData(0xe4aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tray-arrow-down.svg)
-  static const trayArrowDown = PhosphorFlatIconData(0xe010, 'Regular');
+  static const trayArrowDown = IconData(0xe010,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tray-arrow-up.svg)
-  static const trayArrowUp = PhosphorFlatIconData(0xee52, 'Regular');
+  static const trayArrowUp = IconData(0xee52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![treasure-chest](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/treasure-chest.svg)
-  static const treasureChest = PhosphorFlatIconData(0xede2, 'Regular');
+  static const treasureChest = IconData(0xede2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tree.svg)
-  static const tree = PhosphorFlatIconData(0xe6da, 'Regular');
+  static const tree = IconData(0xe6da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-evergreen](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tree-evergreen.svg)
-  static const treeEvergreen = PhosphorFlatIconData(0xe6dc, 'Regular');
+  static const treeEvergreen = IconData(0xe6dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-palm](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tree-palm.svg)
-  static const treePalm = PhosphorFlatIconData(0xe91a, 'Regular');
+  static const treePalm = IconData(0xe91a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-structure](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tree-structure.svg)
-  static const treeStructure = PhosphorFlatIconData(0xe67c, 'Regular');
+  static const treeStructure = IconData(0xe67c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-view](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tree-view.svg)
-  static const treeView = PhosphorFlatIconData(0xee48, 'Regular');
+  static const treeView = IconData(0xee48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-down](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trend-down.svg)
-  static const trendDown = PhosphorFlatIconData(0xe4ac, 'Regular');
+  static const trendDown = IconData(0xe4ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-up](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trend-up.svg)
-  static const trendUp = PhosphorFlatIconData(0xe4ae, 'Regular');
+  static const trendUp = IconData(0xe4ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/triangle.svg)
-  static const triangle = PhosphorFlatIconData(0xe4b0, 'Regular');
+  static const triangle = IconData(0xe4b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-dashed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/triangle-dashed.svg)
-  static const triangleDashed = PhosphorFlatIconData(0xe4b2, 'Regular');
+  static const triangleDashed = IconData(0xe4b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trolley.svg)
-  static const trolley = PhosphorFlatIconData(0xe5b2, 'Regular');
+  static const trolley = IconData(0xe5b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-suitcase](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trolley-suitcase.svg)
-  static const trolleySuitcase = PhosphorFlatIconData(0xe5b4, 'Regular');
+  static const trolleySuitcase = IconData(0xe5b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trophy](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/trophy.svg)
-  static const trophy = PhosphorFlatIconData(0xe67e, 'Regular');
+  static const trophy = IconData(0xe67e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/truck.svg)
-  static const truck = PhosphorFlatIconData(0xe4b4, 'Regular');
+  static const truck = IconData(0xe4b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-trailer](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/truck-trailer.svg)
-  static const truckTrailer = PhosphorFlatIconData(0xe4b6, 'Regular');
+  static const truckTrailer = IconData(0xe4b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tumblr-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/tumblr-logo.svg)
-  static const tumblrLogo = PhosphorFlatIconData(0xe8d4, 'Regular');
+  static const tumblrLogo = IconData(0xe8d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitch-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/twitch-logo.svg)
-  static const twitchLogo = PhosphorFlatIconData(0xe5ce, 'Regular');
+  static const twitchLogo = IconData(0xe5ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitter-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/twitter-logo.svg)
-  static const twitterLogo = PhosphorFlatIconData(0xe4ba, 'Regular');
+  static const twitterLogo = IconData(0xe4ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/umbrella.svg)
-  static const umbrella = PhosphorFlatIconData(0xe684, 'Regular');
+  static const umbrella = IconData(0xe684,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/umbrella-simple.svg)
-  static const umbrellaSimple = PhosphorFlatIconData(0xe686, 'Regular');
+  static const umbrellaSimple = IconData(0xe686,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![union](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/union.svg)
-  static const union = PhosphorFlatIconData(0xedbe, 'Regular');
+  static const union = IconData(0xedbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/unite.svg)
-  static const unite = PhosphorFlatIconData(0xe87e, 'Regular');
+  static const unite = IconData(0xe87e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/unite-square.svg)
-  static const uniteSquare = PhosphorFlatIconData(0xe878, 'Regular');
+  static const uniteSquare = IconData(0xe878,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/upload.svg)
-  static const upload = PhosphorFlatIconData(0xe4be, 'Regular');
+  static const upload = IconData(0xe4be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-simple](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/upload-simple.svg)
-  static const uploadSimple = PhosphorFlatIconData(0xe4c0, 'Regular');
+  static const uploadSimple = IconData(0xe4c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![usb](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/usb.svg)
-  static const usb = PhosphorFlatIconData(0xe956, 'Regular');
+  static const usb = IconData(0xe956,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user.svg)
-  static const user = PhosphorFlatIconData(0xe4c2, 'Regular');
+  static const user = IconData(0xe4c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-check](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-check.svg)
-  static const userCheck = PhosphorFlatIconData(0xeafa, 'Regular');
+  static const userCheck = IconData(0xeafa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-circle.svg)
-  static const userCircle = PhosphorFlatIconData(0xe4c4, 'Regular');
+  static const userCircle = IconData(0xe4c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-check](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-circle-check.svg)
-  static const userCircleCheck = PhosphorFlatIconData(0xec38, 'Regular');
+  static const userCircleCheck = IconData(0xec38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-dashed](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-circle-dashed.svg)
-  static const userCircleDashed = PhosphorFlatIconData(0xec36, 'Regular');
+  static const userCircleDashed = IconData(0xec36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-gear](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-circle-gear.svg)
-  static const userCircleGear = PhosphorFlatIconData(0xe4c6, 'Regular');
+  static const userCircleGear = IconData(0xe4c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-circle-minus.svg)
-  static const userCircleMinus = PhosphorFlatIconData(0xe4c8, 'Regular');
+  static const userCircleMinus = IconData(0xe4c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-circle-plus.svg)
-  static const userCirclePlus = PhosphorFlatIconData(0xe4ca, 'Regular');
+  static const userCirclePlus = IconData(0xe4ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-focus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-focus.svg)
-  static const userFocus = PhosphorFlatIconData(0xe6fc, 'Regular');
+  static const userFocus = IconData(0xe6fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-gear](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-gear.svg)
-  static const userGear = PhosphorFlatIconData(0xe4cc, 'Regular');
+  static const userGear = IconData(0xe4cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-list](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-list.svg)
-  static const userList = PhosphorFlatIconData(0xe73c, 'Regular');
+  static const userList = IconData(0xe73c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-minus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-minus.svg)
-  static const userMinus = PhosphorFlatIconData(0xe4ce, 'Regular');
+  static const userMinus = IconData(0xe4ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-plus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-plus.svg)
-  static const userPlus = PhosphorFlatIconData(0xe4d0, 'Regular');
+  static const userPlus = IconData(0xe4d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-rectangle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-rectangle.svg)
-  static const userRectangle = PhosphorFlatIconData(0xe4d2, 'Regular');
+  static const userRectangle = IconData(0xe4d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-sound](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-sound.svg)
-  static const userSound = PhosphorFlatIconData(0xeca8, 'Regular');
+  static const userSound = IconData(0xeca8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-square.svg)
-  static const userSquare = PhosphorFlatIconData(0xe4d4, 'Regular');
+  static const userSquare = IconData(0xe4d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-switch](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/user-switch.svg)
-  static const userSwitch = PhosphorFlatIconData(0xe756, 'Regular');
+  static const userSwitch = IconData(0xe756,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/users.svg)
-  static const users = PhosphorFlatIconData(0xe4d6, 'Regular');
+  static const users = IconData(0xe4d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-four](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/users-four.svg)
-  static const usersFour = PhosphorFlatIconData(0xe68c, 'Regular');
+  static const usersFour = IconData(0xe68c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/users-three.svg)
-  static const usersThree = PhosphorFlatIconData(0xe68e, 'Regular');
+  static const usersThree = IconData(0xe68e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![van](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/van.svg)
-  static const van = PhosphorFlatIconData(0xe826, 'Regular');
+  static const van = IconData(0xe826,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vault](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/vault.svg)
-  static const vault = PhosphorFlatIconData(0xe76e, 'Regular');
+  static const vault = IconData(0xe76e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-three](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/vector-three.svg)
-  static const vectorThree = PhosphorFlatIconData(0xee62, 'Regular');
+  static const vectorThree = IconData(0xee62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-two](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/vector-two.svg)
-  static const vectorTwo = PhosphorFlatIconData(0xee64, 'Regular');
+  static const vectorTwo = IconData(0xee64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vibrate](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/vibrate.svg)
-  static const vibrate = PhosphorFlatIconData(0xe4d8, 'Regular');
+  static const vibrate = IconData(0xe4d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/video.svg)
-  static const video = PhosphorFlatIconData(0xe740, 'Regular');
+  static const video = IconData(0xe740,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/video-camera.svg)
-  static const videoCamera = PhosphorFlatIconData(0xe4da, 'Regular');
+  static const videoCamera = IconData(0xe4da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/video-camera-slash.svg)
-  static const videoCameraSlash = PhosphorFlatIconData(0xe4dc, 'Regular');
+  static const videoCameraSlash = IconData(0xe4dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-conference](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/video-conference.svg)
-  static const videoConference = PhosphorFlatIconData(0xedce, 'Regular');
+  static const videoConference = IconData(0xedce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vignette](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/vignette.svg)
-  static const vignette = PhosphorFlatIconData(0xeba2, 'Regular');
+  static const vignette = IconData(0xeba2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vinyl-record](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/vinyl-record.svg)
-  static const vinylRecord = PhosphorFlatIconData(0xecac, 'Regular');
+  static const vinylRecord = IconData(0xecac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virtual-reality](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/virtual-reality.svg)
-  static const virtualReality = PhosphorFlatIconData(0xe7b8, 'Regular');
+  static const virtualReality = IconData(0xe7b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virus](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/virus.svg)
-  static const virus = PhosphorFlatIconData(0xe7d6, 'Regular');
+  static const virus = IconData(0xe7d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![visor](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/visor.svg)
-  static const visor = PhosphorFlatIconData(0xee2a, 'Regular');
+  static const visor = IconData(0xee2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![voicemail](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/voicemail.svg)
-  static const voicemail = PhosphorFlatIconData(0xe4de, 'Regular');
+  static const voicemail = IconData(0xe4de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![volleyball](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/volleyball.svg)
-  static const volleyball = PhosphorFlatIconData(0xe726, 'Regular');
+  static const volleyball = IconData(0xe726,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wall](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wall.svg)
-  static const wall = PhosphorFlatIconData(0xe688, 'Regular');
+  static const wall = IconData(0xe688,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wallet](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wallet.svg)
-  static const wallet = PhosphorFlatIconData(0xe68a, 'Regular');
+  static const wallet = IconData(0xe68a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warehouse](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/warehouse.svg)
-  static const warehouse = PhosphorFlatIconData(0xecd4, 'Regular');
+  static const warehouse = IconData(0xecd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/warning.svg)
-  static const warning = PhosphorFlatIconData(0xe4e0, 'Regular');
+  static const warning = IconData(0xe4e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/warning-circle.svg)
-  static const warningCircle = PhosphorFlatIconData(0xe4e2, 'Regular');
+  static const warningCircle = IconData(0xe4e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-diamond](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/warning-diamond.svg)
-  static const warningDiamond = PhosphorFlatIconData(0xe7fc, 'Regular');
+  static const warningDiamond = IconData(0xe7fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-octagon](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/warning-octagon.svg)
-  static const warningOctagon = PhosphorFlatIconData(0xe4e4, 'Regular');
+  static const warningOctagon = IconData(0xe4e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![washing-machine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/washing-machine.svg)
-  static const washingMachine = PhosphorFlatIconData(0xede8, 'Regular');
+  static const washingMachine = IconData(0xede8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![watch](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/watch.svg)
-  static const watch = PhosphorFlatIconData(0xe4e6, 'Regular');
+  static const watch = IconData(0xe4e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sawtooth](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wave-sawtooth.svg)
-  static const waveSawtooth = PhosphorFlatIconData(0xea9c, 'Regular');
+  static const waveSawtooth = IconData(0xea9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wave-sine.svg)
-  static const waveSine = PhosphorFlatIconData(0xea9a, 'Regular');
+  static const waveSine = IconData(0xea9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wave-square.svg)
-  static const waveSquare = PhosphorFlatIconData(0xea9e, 'Regular');
+  static const waveSquare = IconData(0xea9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-triangle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wave-triangle.svg)
-  static const waveTriangle = PhosphorFlatIconData(0xeaa0, 'Regular');
+  static const waveTriangle = IconData(0xeaa0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/waveform.svg)
-  static const waveform = PhosphorFlatIconData(0xe802, 'Regular');
+  static const waveform = IconData(0xe802,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/waveform-slash.svg)
-  static const waveformSlash = PhosphorFlatIconData(0xe800, 'Regular');
+  static const waveformSlash = IconData(0xe800,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waves](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/waves.svg)
-  static const waves = PhosphorFlatIconData(0xe6de, 'Regular');
+  static const waves = IconData(0xe6de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/webcam.svg)
-  static const webcam = PhosphorFlatIconData(0xe9b2, 'Regular');
+  static const webcam = IconData(0xe9b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/webcam-slash.svg)
-  static const webcamSlash = PhosphorFlatIconData(0xecdc, 'Regular');
+  static const webcamSlash = IconData(0xecdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webhooks-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/webhooks-logo.svg)
-  static const webhooksLogo = PhosphorFlatIconData(0xecae, 'Regular');
+  static const webhooksLogo = IconData(0xecae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wechat-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wechat-logo.svg)
-  static const wechatLogo = PhosphorFlatIconData(0xe8d2, 'Regular');
+  static const wechatLogo = IconData(0xe8d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![whatsapp-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/whatsapp-logo.svg)
-  static const whatsappLogo = PhosphorFlatIconData(0xe5d0, 'Regular');
+  static const whatsappLogo = IconData(0xe5d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wheelchair.svg)
-  static const wheelchair = PhosphorFlatIconData(0xe4e8, 'Regular');
+  static const wheelchair = IconData(0xe4e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-motion](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wheelchair-motion.svg)
-  static const wheelchairMotion = PhosphorFlatIconData(0xe89a, 'Regular');
+  static const wheelchairMotion = IconData(0xe89a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-high](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wifi-high.svg)
-  static const wifiHigh = PhosphorFlatIconData(0xe4ea, 'Regular');
+  static const wifiHigh = IconData(0xe4ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-low](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wifi-low.svg)
-  static const wifiLow = PhosphorFlatIconData(0xe4ec, 'Regular');
+  static const wifiLow = IconData(0xe4ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-medium](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wifi-medium.svg)
-  static const wifiMedium = PhosphorFlatIconData(0xe4ee, 'Regular');
+  static const wifiMedium = IconData(0xe4ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-none](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wifi-none.svg)
-  static const wifiNone = PhosphorFlatIconData(0xe4f0, 'Regular');
+  static const wifiNone = IconData(0xe4f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-slash](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wifi-slash.svg)
-  static const wifiSlash = PhosphorFlatIconData(0xe4f2, 'Regular');
+  static const wifiSlash = IconData(0xe4f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wifi-x.svg)
-  static const wifiX = PhosphorFlatIconData(0xe4f4, 'Regular');
+  static const wifiX = IconData(0xe4f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wind](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wind.svg)
-  static const wind = PhosphorFlatIconData(0xe5d2, 'Regular');
+  static const wind = IconData(0xe5d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windmill](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/windmill.svg)
-  static const windmill = PhosphorFlatIconData(0xe9f8, 'Regular');
+  static const windmill = IconData(0xe9f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windows-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/windows-logo.svg)
-  static const windowsLogo = PhosphorFlatIconData(0xe692, 'Regular');
+  static const windowsLogo = IconData(0xe692,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wine](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wine.svg)
-  static const wine = PhosphorFlatIconData(0xe6b2, 'Regular');
+  static const wine = IconData(0xe6b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wrench](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/wrench.svg)
-  static const wrench = PhosphorFlatIconData(0xe5d4, 'Regular');
+  static const wrench = IconData(0xe5d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/x.svg)
-  static const x = PhosphorFlatIconData(0xe4f6, 'Regular');
+  static const x = IconData(0xe4f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-circle](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/x-circle.svg)
-  static const xCircle = PhosphorFlatIconData(0xe4f8, 'Regular');
+  static const xCircle = IconData(0xe4f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/x-logo.svg)
-  static const xLogo = PhosphorFlatIconData(0xe4bc, 'Regular');
+  static const xLogo = IconData(0xe4bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-square](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/x-square.svg)
-  static const xSquare = PhosphorFlatIconData(0xe4fa, 'Regular');
+  static const xSquare = IconData(0xe4fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yarn](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/yarn.svg)
-  static const yarn = PhosphorFlatIconData(0xed9a, 'Regular');
+  static const yarn = IconData(0xed9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yin-yang](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/yin-yang.svg)
-  static const yinYang = PhosphorFlatIconData(0xe92a, 'Regular');
+  static const yinYang = IconData(0xe92a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![youtube-logo](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/regular/youtube-logo.svg)
-  static const youtubeLogo = PhosphorFlatIconData(0xe4fc, 'Regular');
+  static const youtubeLogo = IconData(0xe4fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 }

--- a/lib/src/phosphor_icons_thin.dart
+++ b/lib/src/phosphor_icons_thin.dart
@@ -1,4547 +1,6060 @@
 // Auto generated File
 // DON'T EDIT BY HAND
 
-import 'package:phosphor_flutter/src/phosphor_icon_data.dart';
 import 'package:flutter/widgets.dart';
+
+const String _f = 'PhosphorThin';
+const String _p = 'phosphor_flutter';
 
 @staticIconProvider
 class PhosphorIconsThin {
   const PhosphorIconsThin();
 
   /// ![acorn-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/acorn-thin.svg)
-  static const acorn = PhosphorFlatIconData(0xeb9a, 'Thin');
+  static const acorn = IconData(0xeb9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/address-book-thin.svg)
-  static const addressBook = PhosphorFlatIconData(0xe6f8, 'Thin');
+  static const addressBook = IconData(0xe6f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![address-book-tabs-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/address-book-tabs-thin.svg)
-  static const addressBookTabs = PhosphorFlatIconData(0xee4e, 'Thin');
+  static const addressBookTabs = IconData(0xee4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![air-traffic-control-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/air-traffic-control-thin.svg)
-  static const airTrafficControl = PhosphorFlatIconData(0xecd8, 'Thin');
+  static const airTrafficControl = IconData(0xecd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/airplane-thin.svg)
-  static const airplane = PhosphorFlatIconData(0xe002, 'Thin');
+  static const airplane = IconData(0xe002,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-in-flight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/airplane-in-flight-thin.svg)
-  static const airplaneInFlight = PhosphorFlatIconData(0xe4fe, 'Thin');
+  static const airplaneInFlight = IconData(0xe4fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-landing-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/airplane-landing-thin.svg)
-  static const airplaneLanding = PhosphorFlatIconData(0xe502, 'Thin');
+  static const airplaneLanding = IconData(0xe502,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-takeoff-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/airplane-takeoff-thin.svg)
-  static const airplaneTakeoff = PhosphorFlatIconData(0xe504, 'Thin');
+  static const airplaneTakeoff = IconData(0xe504,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-taxiing-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/airplane-taxiing-thin.svg)
-  static const airplaneTaxiing = PhosphorFlatIconData(0xe500, 'Thin');
+  static const airplaneTaxiing = IconData(0xe500,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplane-tilt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/airplane-tilt-thin.svg)
-  static const airplaneTilt = PhosphorFlatIconData(0xe5d6, 'Thin');
+  static const airplaneTilt = IconData(0xe5d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![airplay-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/airplay-thin.svg)
-  static const airplay = PhosphorFlatIconData(0xe004, 'Thin');
+  static const airplay = IconData(0xe004,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alarm-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/alarm-thin.svg)
-  static const alarm = PhosphorFlatIconData(0xe006, 'Thin');
+  static const alarm = IconData(0xe006,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![alien-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/alien-thin.svg)
-  static const alien = PhosphorFlatIconData(0xe8a6, 'Thin');
+  static const alien = IconData(0xe8a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-bottom-thin.svg)
-  static const alignBottom = PhosphorFlatIconData(0xe506, 'Thin');
+  static const alignBottom = IconData(0xe506,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-bottom-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-bottom-simple-thin.svg)
-  static const alignBottomSimple = PhosphorFlatIconData(0xeb0c, 'Thin');
+  static const alignBottomSimple = IconData(0xeb0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-center-horizontal-thin.svg)
-  static const alignCenterHorizontal = PhosphorFlatIconData(0xe50a, 'Thin');
+  static const alignCenterHorizontal = IconData(0xe50a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-horizontal-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-center-horizontal-simple-thin.svg)
-  static const alignCenterHorizontalSimple =
-      PhosphorFlatIconData(0xeb0e, 'Thin');
+  static const alignCenterHorizontalSimple = IconData(0xeb0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-center-vertical-thin.svg)
-  static const alignCenterVertical = PhosphorFlatIconData(0xe50c, 'Thin');
+  static const alignCenterVertical = IconData(0xe50c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-center-vertical-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-center-vertical-simple-thin.svg)
-  static const alignCenterVerticalSimple = PhosphorFlatIconData(0xeb10, 'Thin');
+  static const alignCenterVerticalSimple = IconData(0xeb10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-left-thin.svg)
-  static const alignLeft = PhosphorFlatIconData(0xe50e, 'Thin');
+  static const alignLeft = IconData(0xe50e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-left-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-left-simple-thin.svg)
-  static const alignLeftSimple = PhosphorFlatIconData(0xeaee, 'Thin');
+  static const alignLeftSimple = IconData(0xeaee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-right-thin.svg)
-  static const alignRight = PhosphorFlatIconData(0xe510, 'Thin');
+  static const alignRight = IconData(0xe510,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-right-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-right-simple-thin.svg)
-  static const alignRightSimple = PhosphorFlatIconData(0xeb12, 'Thin');
+  static const alignRightSimple = IconData(0xeb12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-top-thin.svg)
-  static const alignTop = PhosphorFlatIconData(0xe512, 'Thin');
+  static const alignTop = IconData(0xe512,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![align-top-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/align-top-simple-thin.svg)
-  static const alignTopSimple = PhosphorFlatIconData(0xeb14, 'Thin');
+  static const alignTopSimple = IconData(0xeb14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![amazon-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/amazon-logo-thin.svg)
-  static const amazonLogo = PhosphorFlatIconData(0xe96c, 'Thin');
+  static const amazonLogo = IconData(0xe96c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ambulance-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ambulance-thin.svg)
-  static const ambulance = PhosphorFlatIconData(0xe572, 'Thin');
+  static const ambulance = IconData(0xe572,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/anchor-thin.svg)
-  static const anchor = PhosphorFlatIconData(0xe514, 'Thin');
+  static const anchor = IconData(0xe514,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![anchor-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/anchor-simple-thin.svg)
-  static const anchorSimple = PhosphorFlatIconData(0xe5d8, 'Thin');
+  static const anchorSimple = IconData(0xe5d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![android-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/android-logo-thin.svg)
-  static const androidLogo = PhosphorFlatIconData(0xe008, 'Thin');
+  static const androidLogo = IconData(0xe008,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/angle-thin.svg)
-  static const angle = PhosphorFlatIconData(0xe7bc, 'Thin');
+  static const angle = IconData(0xe7bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![angular-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/angular-logo-thin.svg)
-  static const angularLogo = PhosphorFlatIconData(0xeb80, 'Thin');
+  static const angularLogo = IconData(0xeb80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![aperture-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/aperture-thin.svg)
-  static const aperture = PhosphorFlatIconData(0xe00a, 'Thin');
+  static const aperture = IconData(0xe00a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-store-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/app-store-logo-thin.svg)
-  static const appStoreLogo = PhosphorFlatIconData(0xe974, 'Thin');
+  static const appStoreLogo = IconData(0xe974,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![app-window-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/app-window-thin.svg)
-  static const appWindow = PhosphorFlatIconData(0xe5da, 'Thin');
+  static const appWindow = IconData(0xe5da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/apple-logo-thin.svg)
-  static const appleLogo = PhosphorFlatIconData(0xe516, 'Thin');
+  static const appleLogo = IconData(0xe516,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![apple-podcasts-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/apple-podcasts-logo-thin.svg)
-  static const applePodcastsLogo = PhosphorFlatIconData(0xeb96, 'Thin');
+  static const applePodcastsLogo = IconData(0xeb96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![approximate-equals-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/approximate-equals-thin.svg)
-  static const approximateEquals = PhosphorFlatIconData(0xedaa, 'Thin');
+  static const approximateEquals = IconData(0xedaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![archive-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/archive-thin.svg)
-  static const archive = PhosphorFlatIconData(0xe00c, 'Thin');
+  static const archive = IconData(0xe00c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![armchair-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/armchair-thin.svg)
-  static const armchair = PhosphorFlatIconData(0xe012, 'Thin');
+  static const armchair = IconData(0xe012,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-arc-left-thin.svg)
-  static const arrowArcLeft = PhosphorFlatIconData(0xe014, 'Thin');
+  static const arrowArcLeft = IconData(0xe014,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-arc-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-arc-right-thin.svg)
-  static const arrowArcRight = PhosphorFlatIconData(0xe016, 'Thin');
+  static const arrowArcRight = IconData(0xe016,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-double-up-left-thin.svg)
-  static const arrowBendDoubleUpLeft = PhosphorFlatIconData(0xe03a, 'Thin');
+  static const arrowBendDoubleUpLeft = IconData(0xe03a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-double-up-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-double-up-right-thin.svg)
-  static const arrowBendDoubleUpRight = PhosphorFlatIconData(0xe03c, 'Thin');
+  static const arrowBendDoubleUpRight = IconData(0xe03c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-down-left-thin.svg)
-  static const arrowBendDownLeft = PhosphorFlatIconData(0xe018, 'Thin');
+  static const arrowBendDownLeft = IconData(0xe018,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-down-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-down-right-thin.svg)
-  static const arrowBendDownRight = PhosphorFlatIconData(0xe01a, 'Thin');
+  static const arrowBendDownRight = IconData(0xe01a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-left-down-thin.svg)
-  static const arrowBendLeftDown = PhosphorFlatIconData(0xe01c, 'Thin');
+  static const arrowBendLeftDown = IconData(0xe01c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-left-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-left-up-thin.svg)
-  static const arrowBendLeftUp = PhosphorFlatIconData(0xe01e, 'Thin');
+  static const arrowBendLeftUp = IconData(0xe01e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-right-down-thin.svg)
-  static const arrowBendRightDown = PhosphorFlatIconData(0xe020, 'Thin');
+  static const arrowBendRightDown = IconData(0xe020,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-right-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-right-up-thin.svg)
-  static const arrowBendRightUp = PhosphorFlatIconData(0xe022, 'Thin');
+  static const arrowBendRightUp = IconData(0xe022,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-up-left-thin.svg)
-  static const arrowBendUpLeft = PhosphorFlatIconData(0xe024, 'Thin');
+  static const arrowBendUpLeft = IconData(0xe024,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-bend-up-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-bend-up-right-thin.svg)
-  static const arrowBendUpRight = PhosphorFlatIconData(0xe026, 'Thin');
+  static const arrowBendUpRight = IconData(0xe026,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-circle-down-thin.svg)
-  static const arrowCircleDown = PhosphorFlatIconData(0xe028, 'Thin');
+  static const arrowCircleDown = IconData(0xe028,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-circle-down-left-thin.svg)
-  static const arrowCircleDownLeft = PhosphorFlatIconData(0xe02a, 'Thin');
+  static const arrowCircleDownLeft = IconData(0xe02a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-down-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-circle-down-right-thin.svg)
-  static const arrowCircleDownRight = PhosphorFlatIconData(0xe02c, 'Thin');
+  static const arrowCircleDownRight = IconData(0xe02c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-circle-left-thin.svg)
-  static const arrowCircleLeft = PhosphorFlatIconData(0xe05a, 'Thin');
+  static const arrowCircleLeft = IconData(0xe05a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-circle-right-thin.svg)
-  static const arrowCircleRight = PhosphorFlatIconData(0xe02e, 'Thin');
+  static const arrowCircleRight = IconData(0xe02e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-circle-up-thin.svg)
-  static const arrowCircleUp = PhosphorFlatIconData(0xe030, 'Thin');
+  static const arrowCircleUp = IconData(0xe030,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-circle-up-left-thin.svg)
-  static const arrowCircleUpLeft = PhosphorFlatIconData(0xe032, 'Thin');
+  static const arrowCircleUpLeft = IconData(0xe032,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-circle-up-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-circle-up-right-thin.svg)
-  static const arrowCircleUpRight = PhosphorFlatIconData(0xe034, 'Thin');
+  static const arrowCircleUpRight = IconData(0xe034,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-clockwise-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-clockwise-thin.svg)
-  static const arrowClockwise = PhosphorFlatIconData(0xe036, 'Thin');
+  static const arrowClockwise = IconData(0xe036,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-counter-clockwise-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-counter-clockwise-thin.svg)
-  static const arrowCounterClockwise = PhosphorFlatIconData(0xe038, 'Thin');
+  static const arrowCounterClockwise = IconData(0xe038,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-down-thin.svg)
-  static const arrowDown = PhosphorFlatIconData(0xe03e, 'Thin');
+  static const arrowDown = IconData(0xe03e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-down-left-thin.svg)
-  static const arrowDownLeft = PhosphorFlatIconData(0xe040, 'Thin');
+  static const arrowDownLeft = IconData(0xe040,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-down-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-down-right-thin.svg)
-  static const arrowDownRight = PhosphorFlatIconData(0xe042, 'Thin');
+  static const arrowDownRight = IconData(0xe042,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-down-left-thin.svg)
-  static const arrowElbowDownLeft = PhosphorFlatIconData(0xe044, 'Thin');
+  static const arrowElbowDownLeft = IconData(0xe044,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-down-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-down-right-thin.svg)
-  static const arrowElbowDownRight = PhosphorFlatIconData(0xe046, 'Thin');
+  static const arrowElbowDownRight = IconData(0xe046,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-left-thin.svg)
-  static const arrowElbowLeft = PhosphorFlatIconData(0xe048, 'Thin');
+  static const arrowElbowLeft = IconData(0xe048,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-left-down-thin.svg)
-  static const arrowElbowLeftDown = PhosphorFlatIconData(0xe04a, 'Thin');
+  static const arrowElbowLeftDown = IconData(0xe04a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-left-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-left-up-thin.svg)
-  static const arrowElbowLeftUp = PhosphorFlatIconData(0xe04c, 'Thin');
+  static const arrowElbowLeftUp = IconData(0xe04c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-right-thin.svg)
-  static const arrowElbowRight = PhosphorFlatIconData(0xe04e, 'Thin');
+  static const arrowElbowRight = IconData(0xe04e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-right-down-thin.svg)
-  static const arrowElbowRightDown = PhosphorFlatIconData(0xe050, 'Thin');
+  static const arrowElbowRightDown = IconData(0xe050,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-right-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-right-up-thin.svg)
-  static const arrowElbowRightUp = PhosphorFlatIconData(0xe052, 'Thin');
+  static const arrowElbowRightUp = IconData(0xe052,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-up-left-thin.svg)
-  static const arrowElbowUpLeft = PhosphorFlatIconData(0xe054, 'Thin');
+  static const arrowElbowUpLeft = IconData(0xe054,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-elbow-up-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-elbow-up-right-thin.svg)
-  static const arrowElbowUpRight = PhosphorFlatIconData(0xe056, 'Thin');
+  static const arrowElbowUpRight = IconData(0xe056,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-down-thin.svg)
-  static const arrowFatDown = PhosphorFlatIconData(0xe518, 'Thin');
+  static const arrowFatDown = IconData(0xe518,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-left-thin.svg)
-  static const arrowFatLeft = PhosphorFlatIconData(0xe51a, 'Thin');
+  static const arrowFatLeft = IconData(0xe51a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-line-down-thin.svg)
-  static const arrowFatLineDown = PhosphorFlatIconData(0xe51c, 'Thin');
+  static const arrowFatLineDown = IconData(0xe51c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-line-left-thin.svg)
-  static const arrowFatLineLeft = PhosphorFlatIconData(0xe51e, 'Thin');
+  static const arrowFatLineLeft = IconData(0xe51e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-line-right-thin.svg)
-  static const arrowFatLineRight = PhosphorFlatIconData(0xe520, 'Thin');
+  static const arrowFatLineRight = IconData(0xe520,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-line-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-line-up-thin.svg)
-  static const arrowFatLineUp = PhosphorFlatIconData(0xe522, 'Thin');
+  static const arrowFatLineUp = IconData(0xe522,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-lines-down-thin.svg)
-  static const arrowFatLinesDown = PhosphorFlatIconData(0xe524, 'Thin');
+  static const arrowFatLinesDown = IconData(0xe524,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-lines-left-thin.svg)
-  static const arrowFatLinesLeft = PhosphorFlatIconData(0xe526, 'Thin');
+  static const arrowFatLinesLeft = IconData(0xe526,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-lines-right-thin.svg)
-  static const arrowFatLinesRight = PhosphorFlatIconData(0xe528, 'Thin');
+  static const arrowFatLinesRight = IconData(0xe528,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-lines-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-lines-up-thin.svg)
-  static const arrowFatLinesUp = PhosphorFlatIconData(0xe52a, 'Thin');
+  static const arrowFatLinesUp = IconData(0xe52a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-right-thin.svg)
-  static const arrowFatRight = PhosphorFlatIconData(0xe52c, 'Thin');
+  static const arrowFatRight = IconData(0xe52c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-fat-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-fat-up-thin.svg)
-  static const arrowFatUp = PhosphorFlatIconData(0xe52e, 'Thin');
+  static const arrowFatUp = IconData(0xe52e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-left-thin.svg)
-  static const arrowLeft = PhosphorFlatIconData(0xe058, 'Thin');
+  static const arrowLeft = IconData(0xe058,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-line-down-thin.svg)
-  static const arrowLineDown = PhosphorFlatIconData(0xe05c, 'Thin');
+  static const arrowLineDown = IconData(0xe05c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-line-down-left-thin.svg)
-  static const arrowLineDownLeft = PhosphorFlatIconData(0xe05e, 'Thin');
+  static const arrowLineDownLeft = IconData(0xe05e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-down-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-line-down-right-thin.svg)
-  static const arrowLineDownRight = PhosphorFlatIconData(0xe060, 'Thin');
+  static const arrowLineDownRight = IconData(0xe060,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-line-left-thin.svg)
-  static const arrowLineLeft = PhosphorFlatIconData(0xe062, 'Thin');
+  static const arrowLineLeft = IconData(0xe062,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-line-right-thin.svg)
-  static const arrowLineRight = PhosphorFlatIconData(0xe064, 'Thin');
+  static const arrowLineRight = IconData(0xe064,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-line-up-thin.svg)
-  static const arrowLineUp = PhosphorFlatIconData(0xe066, 'Thin');
+  static const arrowLineUp = IconData(0xe066,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-line-up-left-thin.svg)
-  static const arrowLineUpLeft = PhosphorFlatIconData(0xe068, 'Thin');
+  static const arrowLineUpLeft = IconData(0xe068,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-line-up-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-line-up-right-thin.svg)
-  static const arrowLineUpRight = PhosphorFlatIconData(0xe06a, 'Thin');
+  static const arrowLineUpRight = IconData(0xe06a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-right-thin.svg)
-  static const arrowRight = PhosphorFlatIconData(0xe06c, 'Thin');
+  static const arrowRight = IconData(0xe06c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-down-thin.svg)
-  static const arrowSquareDown = PhosphorFlatIconData(0xe06e, 'Thin');
+  static const arrowSquareDown = IconData(0xe06e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-down-left-thin.svg)
-  static const arrowSquareDownLeft = PhosphorFlatIconData(0xe070, 'Thin');
+  static const arrowSquareDownLeft = IconData(0xe070,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-down-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-down-right-thin.svg)
-  static const arrowSquareDownRight = PhosphorFlatIconData(0xe072, 'Thin');
+  static const arrowSquareDownRight = IconData(0xe072,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-in-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-in-thin.svg)
-  static const arrowSquareIn = PhosphorFlatIconData(0xe5dc, 'Thin');
+  static const arrowSquareIn = IconData(0xe5dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-left-thin.svg)
-  static const arrowSquareLeft = PhosphorFlatIconData(0xe074, 'Thin');
+  static const arrowSquareLeft = IconData(0xe074,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-out-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-out-thin.svg)
-  static const arrowSquareOut = PhosphorFlatIconData(0xe5de, 'Thin');
+  static const arrowSquareOut = IconData(0xe5de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-right-thin.svg)
-  static const arrowSquareRight = PhosphorFlatIconData(0xe076, 'Thin');
+  static const arrowSquareRight = IconData(0xe076,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-up-thin.svg)
-  static const arrowSquareUp = PhosphorFlatIconData(0xe078, 'Thin');
+  static const arrowSquareUp = IconData(0xe078,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-up-left-thin.svg)
-  static const arrowSquareUpLeft = PhosphorFlatIconData(0xe07a, 'Thin');
+  static const arrowSquareUpLeft = IconData(0xe07a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-square-up-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-square-up-right-thin.svg)
-  static const arrowSquareUpRight = PhosphorFlatIconData(0xe07c, 'Thin');
+  static const arrowSquareUpRight = IconData(0xe07c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-u-down-left-thin.svg)
-  static const arrowUDownLeft = PhosphorFlatIconData(0xe07e, 'Thin');
+  static const arrowUDownLeft = IconData(0xe07e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-down-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-u-down-right-thin.svg)
-  static const arrowUDownRight = PhosphorFlatIconData(0xe080, 'Thin');
+  static const arrowUDownRight = IconData(0xe080,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-u-left-down-thin.svg)
-  static const arrowULeftDown = PhosphorFlatIconData(0xe082, 'Thin');
+  static const arrowULeftDown = IconData(0xe082,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-left-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-u-left-up-thin.svg)
-  static const arrowULeftUp = PhosphorFlatIconData(0xe084, 'Thin');
+  static const arrowULeftUp = IconData(0xe084,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-u-right-down-thin.svg)
-  static const arrowURightDown = PhosphorFlatIconData(0xe086, 'Thin');
+  static const arrowURightDown = IconData(0xe086,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-right-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-u-right-up-thin.svg)
-  static const arrowURightUp = PhosphorFlatIconData(0xe088, 'Thin');
+  static const arrowURightUp = IconData(0xe088,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-u-up-left-thin.svg)
-  static const arrowUUpLeft = PhosphorFlatIconData(0xe08a, 'Thin');
+  static const arrowUUpLeft = IconData(0xe08a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-u-up-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-u-up-right-thin.svg)
-  static const arrowUUpRight = PhosphorFlatIconData(0xe08c, 'Thin');
+  static const arrowUUpRight = IconData(0xe08c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-up-thin.svg)
-  static const arrowUp = PhosphorFlatIconData(0xe08e, 'Thin');
+  static const arrowUp = IconData(0xe08e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-up-left-thin.svg)
-  static const arrowUpLeft = PhosphorFlatIconData(0xe090, 'Thin');
+  static const arrowUpLeft = IconData(0xe090,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrow-up-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrow-up-right-thin.svg)
-  static const arrowUpRight = PhosphorFlatIconData(0xe092, 'Thin');
+  static const arrowUpRight = IconData(0xe092,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-clockwise-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-clockwise-thin.svg)
-  static const arrowsClockwise = PhosphorFlatIconData(0xe094, 'Thin');
+  static const arrowsClockwise = IconData(0xe094,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-counter-clockwise-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-counter-clockwise-thin.svg)
-  static const arrowsCounterClockwise = PhosphorFlatIconData(0xe096, 'Thin');
+  static const arrowsCounterClockwise = IconData(0xe096,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-down-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-down-up-thin.svg)
-  static const arrowsDownUp = PhosphorFlatIconData(0xe098, 'Thin');
+  static const arrowsDownUp = IconData(0xe098,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-horizontal-thin.svg)
-  static const arrowsHorizontal = PhosphorFlatIconData(0xeb06, 'Thin');
+  static const arrowsHorizontal = IconData(0xeb06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-in-thin.svg)
-  static const arrowsIn = PhosphorFlatIconData(0xe09a, 'Thin');
+  static const arrowsIn = IconData(0xe09a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-cardinal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-in-cardinal-thin.svg)
-  static const arrowsInCardinal = PhosphorFlatIconData(0xe09c, 'Thin');
+  static const arrowsInCardinal = IconData(0xe09c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-in-line-horizontal-thin.svg)
-  static const arrowsInLineHorizontal = PhosphorFlatIconData(0xe530, 'Thin');
+  static const arrowsInLineHorizontal = IconData(0xe530,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-line-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-in-line-vertical-thin.svg)
-  static const arrowsInLineVertical = PhosphorFlatIconData(0xe532, 'Thin');
+  static const arrowsInLineVertical = IconData(0xe532,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-in-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-in-simple-thin.svg)
-  static const arrowsInSimple = PhosphorFlatIconData(0xe09e, 'Thin');
+  static const arrowsInSimple = IconData(0xe09e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-left-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-left-right-thin.svg)
-  static const arrowsLeftRight = PhosphorFlatIconData(0xe0a0, 'Thin');
+  static const arrowsLeftRight = IconData(0xe0a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-merge-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-merge-thin.svg)
-  static const arrowsMerge = PhosphorFlatIconData(0xed3e, 'Thin');
+  static const arrowsMerge = IconData(0xed3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-out-thin.svg)
-  static const arrowsOut = PhosphorFlatIconData(0xe0a2, 'Thin');
+  static const arrowsOut = IconData(0xe0a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-cardinal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-out-cardinal-thin.svg)
-  static const arrowsOutCardinal = PhosphorFlatIconData(0xe0a4, 'Thin');
+  static const arrowsOutCardinal = IconData(0xe0a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-out-line-horizontal-thin.svg)
-  static const arrowsOutLineHorizontal = PhosphorFlatIconData(0xe534, 'Thin');
+  static const arrowsOutLineHorizontal = IconData(0xe534,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-line-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-out-line-vertical-thin.svg)
-  static const arrowsOutLineVertical = PhosphorFlatIconData(0xe536, 'Thin');
+  static const arrowsOutLineVertical = IconData(0xe536,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-out-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-out-simple-thin.svg)
-  static const arrowsOutSimple = PhosphorFlatIconData(0xe0a6, 'Thin');
+  static const arrowsOutSimple = IconData(0xe0a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-split-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-split-thin.svg)
-  static const arrowsSplit = PhosphorFlatIconData(0xed3c, 'Thin');
+  static const arrowsSplit = IconData(0xed3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![arrows-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/arrows-vertical-thin.svg)
-  static const arrowsVertical = PhosphorFlatIconData(0xeb04, 'Thin');
+  static const arrowsVertical = IconData(0xeb04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/article-thin.svg)
-  static const article = PhosphorFlatIconData(0xe0a8, 'Thin');
+  static const article = IconData(0xe0a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-medium-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/article-medium-thin.svg)
-  static const articleMedium = PhosphorFlatIconData(0xe5e0, 'Thin');
+  static const articleMedium = IconData(0xe5e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![article-ny-times-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/article-ny-times-thin.svg)
-  static const articleNyTimes = PhosphorFlatIconData(0xe5e2, 'Thin');
+  static const articleNyTimes = IconData(0xe5e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asclepius-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/asclepius-thin.svg)
-  static const asclepius = PhosphorFlatIconData(0xee34, 'Thin');
+  static const asclepius = IconData(0xee34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/asterisk-thin.svg)
-  static const asterisk = PhosphorFlatIconData(0xe0aa, 'Thin');
+  static const asterisk = IconData(0xe0aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![asterisk-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/asterisk-simple-thin.svg)
-  static const asteriskSimple = PhosphorFlatIconData(0xe832, 'Thin');
+  static const asteriskSimple = IconData(0xe832,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![at-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/at-thin.svg)
-  static const at = PhosphorFlatIconData(0xe0ac, 'Thin');
+  static const at = IconData(0xe0ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![atom-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/atom-thin.svg)
-  static const atom = PhosphorFlatIconData(0xe5e4, 'Thin');
+  static const atom = IconData(0xe5e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![avocado-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/avocado-thin.svg)
-  static const avocado = PhosphorFlatIconData(0xee04, 'Thin');
+  static const avocado = IconData(0xee04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![axe-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/axe-thin.svg)
-  static const axe = PhosphorFlatIconData(0xe9fc, 'Thin');
+  static const axe = IconData(0xe9fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/baby-thin.svg)
-  static const baby = PhosphorFlatIconData(0xe774, 'Thin');
+  static const baby = IconData(0xe774,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baby-carriage-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/baby-carriage-thin.svg)
-  static const babyCarriage = PhosphorFlatIconData(0xe818, 'Thin');
+  static const babyCarriage = IconData(0xe818,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backpack-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/backpack-thin.svg)
-  static const backpack = PhosphorFlatIconData(0xe922, 'Thin');
+  static const backpack = IconData(0xe922,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![backspace-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/backspace-thin.svg)
-  static const backspace = PhosphorFlatIconData(0xe0ae, 'Thin');
+  static const backspace = IconData(0xe0ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bag-thin.svg)
-  static const bag = PhosphorFlatIconData(0xe0b0, 'Thin');
+  static const bag = IconData(0xe0b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bag-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bag-simple-thin.svg)
-  static const bagSimple = PhosphorFlatIconData(0xe5e6, 'Thin');
+  static const bagSimple = IconData(0xe5e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![balloon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/balloon-thin.svg)
-  static const balloon = PhosphorFlatIconData(0xe76c, 'Thin');
+  static const balloon = IconData(0xe76c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bandaids-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bandaids-thin.svg)
-  static const bandaids = PhosphorFlatIconData(0xe0b2, 'Thin');
+  static const bandaids = IconData(0xe0b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bank-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bank-thin.svg)
-  static const bank = PhosphorFlatIconData(0xe0b4, 'Thin');
+  static const bank = IconData(0xe0b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barbell-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/barbell-thin.svg)
-  static const barbell = PhosphorFlatIconData(0xe0b6, 'Thin');
+  static const barbell = IconData(0xe0b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barcode-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/barcode-thin.svg)
-  static const barcode = PhosphorFlatIconData(0xe0b8, 'Thin');
+  static const barcode = IconData(0xe0b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barn-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/barn-thin.svg)
-  static const barn = PhosphorFlatIconData(0xec72, 'Thin');
+  static const barn = IconData(0xec72,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![barricade-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/barricade-thin.svg)
-  static const barricade = PhosphorFlatIconData(0xe948, 'Thin');
+  static const barricade = IconData(0xe948,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/baseball-thin.svg)
-  static const baseball = PhosphorFlatIconData(0xe71a, 'Thin');
+  static const baseball = IconData(0xe71a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-cap-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/baseball-cap-thin.svg)
-  static const baseballCap = PhosphorFlatIconData(0xea28, 'Thin');
+  static const baseballCap = IconData(0xea28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![baseball-helmet-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/baseball-helmet-thin.svg)
-  static const baseballHelmet = PhosphorFlatIconData(0xee4a, 'Thin');
+  static const baseballHelmet = IconData(0xee4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basket-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/basket-thin.svg)
-  static const basket = PhosphorFlatIconData(0xe964, 'Thin');
+  static const basket = IconData(0xe964,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![basketball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/basketball-thin.svg)
-  static const basketball = PhosphorFlatIconData(0xe724, 'Thin');
+  static const basketball = IconData(0xe724,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bathtub-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bathtub-thin.svg)
-  static const bathtub = PhosphorFlatIconData(0xe81e, 'Thin');
+  static const bathtub = IconData(0xe81e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-charging-thin.svg)
-  static const batteryCharging = PhosphorFlatIconData(0xe0ba, 'Thin');
+  static const batteryCharging = IconData(0xe0ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-charging-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-charging-vertical-thin.svg)
-  static const batteryChargingVertical = PhosphorFlatIconData(0xe0bc, 'Thin');
+  static const batteryChargingVertical = IconData(0xe0bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-empty-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-empty-thin.svg)
-  static const batteryEmpty = PhosphorFlatIconData(0xe0be, 'Thin');
+  static const batteryEmpty = IconData(0xe0be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-full-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-full-thin.svg)
-  static const batteryFull = PhosphorFlatIconData(0xe0c0, 'Thin');
+  static const batteryFull = IconData(0xe0c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-high-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-high-thin.svg)
-  static const batteryHigh = PhosphorFlatIconData(0xe0c2, 'Thin');
+  static const batteryHigh = IconData(0xe0c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-low-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-low-thin.svg)
-  static const batteryLow = PhosphorFlatIconData(0xe0c4, 'Thin');
+  static const batteryLow = IconData(0xe0c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-medium-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-medium-thin.svg)
-  static const batteryMedium = PhosphorFlatIconData(0xe0c6, 'Thin');
+  static const batteryMedium = IconData(0xe0c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-plus-thin.svg)
-  static const batteryPlus = PhosphorFlatIconData(0xe808, 'Thin');
+  static const batteryPlus = IconData(0xe808,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-plus-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-plus-vertical-thin.svg)
-  static const batteryPlusVertical = PhosphorFlatIconData(0xec50, 'Thin');
+  static const batteryPlusVertical = IconData(0xec50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-empty-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-vertical-empty-thin.svg)
-  static const batteryVerticalEmpty = PhosphorFlatIconData(0xe7c6, 'Thin');
+  static const batteryVerticalEmpty = IconData(0xe7c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-full-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-vertical-full-thin.svg)
-  static const batteryVerticalFull = PhosphorFlatIconData(0xe7c4, 'Thin');
+  static const batteryVerticalFull = IconData(0xe7c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-high-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-vertical-high-thin.svg)
-  static const batteryVerticalHigh = PhosphorFlatIconData(0xe7c2, 'Thin');
+  static const batteryVerticalHigh = IconData(0xe7c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-low-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-vertical-low-thin.svg)
-  static const batteryVerticalLow = PhosphorFlatIconData(0xe7be, 'Thin');
+  static const batteryVerticalLow = IconData(0xe7be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-vertical-medium-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-vertical-medium-thin.svg)
-  static const batteryVerticalMedium = PhosphorFlatIconData(0xe7c0, 'Thin');
+  static const batteryVerticalMedium = IconData(0xe7c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-warning-thin.svg)
-  static const batteryWarning = PhosphorFlatIconData(0xe0c8, 'Thin');
+  static const batteryWarning = IconData(0xe0c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![battery-warning-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/battery-warning-vertical-thin.svg)
-  static const batteryWarningVertical = PhosphorFlatIconData(0xe0ca, 'Thin');
+  static const batteryWarningVertical = IconData(0xe0ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beach-ball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/beach-ball-thin.svg)
-  static const beachBall = PhosphorFlatIconData(0xed24, 'Thin');
+  static const beachBall = IconData(0xed24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beanie-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/beanie-thin.svg)
-  static const beanie = PhosphorFlatIconData(0xea2a, 'Thin');
+  static const beanie = IconData(0xea2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bed-thin.svg)
-  static const bed = PhosphorFlatIconData(0xe0cc, 'Thin');
+  static const bed = IconData(0xe0cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-bottle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/beer-bottle-thin.svg)
-  static const beerBottle = PhosphorFlatIconData(0xe7b0, 'Thin');
+  static const beerBottle = IconData(0xe7b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![beer-stein-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/beer-stein-thin.svg)
-  static const beerStein = PhosphorFlatIconData(0xeb62, 'Thin');
+  static const beerStein = IconData(0xeb62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![behance-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/behance-logo-thin.svg)
-  static const behanceLogo = PhosphorFlatIconData(0xe7f4, 'Thin');
+  static const behanceLogo = IconData(0xe7f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bell-thin.svg)
-  static const bell = PhosphorFlatIconData(0xe0ce, 'Thin');
+  static const bell = IconData(0xe0ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-ringing-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bell-ringing-thin.svg)
-  static const bellRinging = PhosphorFlatIconData(0xe5e8, 'Thin');
+  static const bellRinging = IconData(0xe5e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bell-simple-thin.svg)
-  static const bellSimple = PhosphorFlatIconData(0xe0d0, 'Thin');
+  static const bellSimple = IconData(0xe0d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-ringing-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bell-simple-ringing-thin.svg)
-  static const bellSimpleRinging = PhosphorFlatIconData(0xe5ea, 'Thin');
+  static const bellSimpleRinging = IconData(0xe5ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bell-simple-slash-thin.svg)
-  static const bellSimpleSlash = PhosphorFlatIconData(0xe0d2, 'Thin');
+  static const bellSimpleSlash = IconData(0xe0d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-simple-z-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bell-simple-z-thin.svg)
-  static const bellSimpleZ = PhosphorFlatIconData(0xe5ec, 'Thin');
+  static const bellSimpleZ = IconData(0xe5ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bell-slash-thin.svg)
-  static const bellSlash = PhosphorFlatIconData(0xe0d4, 'Thin');
+  static const bellSlash = IconData(0xe0d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bell-z-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bell-z-thin.svg)
-  static const bellZ = PhosphorFlatIconData(0xe5ee, 'Thin');
+  static const bellZ = IconData(0xe5ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![belt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/belt-thin.svg)
-  static const belt = PhosphorFlatIconData(0xea2c, 'Thin');
+  static const belt = IconData(0xea2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bezier-curve-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bezier-curve-thin.svg)
-  static const bezierCurve = PhosphorFlatIconData(0xeb00, 'Thin');
+  static const bezierCurve = IconData(0xeb00,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bicycle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bicycle-thin.svg)
-  static const bicycle = PhosphorFlatIconData(0xe0d6, 'Thin');
+  static const bicycle = IconData(0xe0d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binary-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/binary-thin.svg)
-  static const binary = PhosphorFlatIconData(0xee60, 'Thin');
+  static const binary = IconData(0xee60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![binoculars-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/binoculars-thin.svg)
-  static const binoculars = PhosphorFlatIconData(0xea64, 'Thin');
+  static const binoculars = IconData(0xea64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![biohazard-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/biohazard-thin.svg)
-  static const biohazard = PhosphorFlatIconData(0xe9e0, 'Thin');
+  static const biohazard = IconData(0xe9e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bird-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bird-thin.svg)
-  static const bird = PhosphorFlatIconData(0xe72c, 'Thin');
+  static const bird = IconData(0xe72c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![blueprint-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/blueprint-thin.svg)
-  static const blueprint = PhosphorFlatIconData(0xeda0, 'Thin');
+  static const blueprint = IconData(0xeda0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bluetooth-thin.svg)
-  static const bluetooth = PhosphorFlatIconData(0xe0da, 'Thin');
+  static const bluetooth = IconData(0xe0da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-connected-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bluetooth-connected-thin.svg)
-  static const bluetoothConnected = PhosphorFlatIconData(0xe0dc, 'Thin');
+  static const bluetoothConnected = IconData(0xe0dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bluetooth-slash-thin.svg)
-  static const bluetoothSlash = PhosphorFlatIconData(0xe0de, 'Thin');
+  static const bluetoothSlash = IconData(0xe0de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bluetooth-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bluetooth-x-thin.svg)
-  static const bluetoothX = PhosphorFlatIconData(0xe0e0, 'Thin');
+  static const bluetoothX = IconData(0xe0e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/boat-thin.svg)
-  static const boat = PhosphorFlatIconData(0xe786, 'Thin');
+  static const boat = IconData(0xe786,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bomb-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bomb-thin.svg)
-  static const bomb = PhosphorFlatIconData(0xee0a, 'Thin');
+  static const bomb = IconData(0xee0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bone-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bone-thin.svg)
-  static const bone = PhosphorFlatIconData(0xe7f2, 'Thin');
+  static const bone = IconData(0xe7f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/book-thin.svg)
-  static const book = PhosphorFlatIconData(0xe0e2, 'Thin');
+  static const book = IconData(0xe0e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-bookmark-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/book-bookmark-thin.svg)
-  static const bookBookmark = PhosphorFlatIconData(0xe0e4, 'Thin');
+  static const bookBookmark = IconData(0xe0e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/book-open-thin.svg)
-  static const bookOpen = PhosphorFlatIconData(0xe0e6, 'Thin');
+  static const bookOpen = IconData(0xe0e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-text-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/book-open-text-thin.svg)
-  static const bookOpenText = PhosphorFlatIconData(0xe8f2, 'Thin');
+  static const bookOpenText = IconData(0xe8f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![book-open-user-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/book-open-user-thin.svg)
-  static const bookOpenUser = PhosphorFlatIconData(0xede0, 'Thin');
+  static const bookOpenUser = IconData(0xede0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bookmark-thin.svg)
-  static const bookmark = PhosphorFlatIconData(0xe0e8, 'Thin');
+  static const bookmark = IconData(0xe0e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmark-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bookmark-simple-thin.svg)
-  static const bookmarkSimple = PhosphorFlatIconData(0xe0ea, 'Thin');
+  static const bookmarkSimple = IconData(0xe0ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bookmarks-thin.svg)
-  static const bookmarks = PhosphorFlatIconData(0xe0ec, 'Thin');
+  static const bookmarks = IconData(0xe0ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bookmarks-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bookmarks-simple-thin.svg)
-  static const bookmarksSimple = PhosphorFlatIconData(0xe5f0, 'Thin');
+  static const bookmarksSimple = IconData(0xe5f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![books-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/books-thin.svg)
-  static const books = PhosphorFlatIconData(0xe758, 'Thin');
+  static const books = IconData(0xe758,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boot-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/boot-thin.svg)
-  static const boot = PhosphorFlatIconData(0xecca, 'Thin');
+  static const boot = IconData(0xecca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boules-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/boules-thin.svg)
-  static const boules = PhosphorFlatIconData(0xe722, 'Thin');
+  static const boules = IconData(0xe722,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bounding-box-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bounding-box-thin.svg)
-  static const boundingBox = PhosphorFlatIconData(0xe6ce, 'Thin');
+  static const boundingBox = IconData(0xe6ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-food-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bowl-food-thin.svg)
-  static const bowlFood = PhosphorFlatIconData(0xeaa4, 'Thin');
+  static const bowlFood = IconData(0xeaa4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowl-steam-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bowl-steam-thin.svg)
-  static const bowlSteam = PhosphorFlatIconData(0xe8e4, 'Thin');
+  static const bowlSteam = IconData(0xe8e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bowling-ball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bowling-ball-thin.svg)
-  static const bowlingBall = PhosphorFlatIconData(0xea34, 'Thin');
+  static const bowlingBall = IconData(0xea34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/box-arrow-down-thin.svg)
-  static const boxArrowDown = PhosphorFlatIconData(0xe00e, 'Thin');
+  static const boxArrowDown = IconData(0xe00e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![box-arrow-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/box-arrow-up-thin.svg)
-  static const boxArrowUp = PhosphorFlatIconData(0xee54, 'Thin');
+  static const boxArrowUp = IconData(0xee54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![boxing-glove-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/boxing-glove-thin.svg)
-  static const boxingGlove = PhosphorFlatIconData(0xea36, 'Thin');
+  static const boxingGlove = IconData(0xea36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-angle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/brackets-angle-thin.svg)
-  static const bracketsAngle = PhosphorFlatIconData(0xe862, 'Thin');
+  static const bracketsAngle = IconData(0xe862,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-curly-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/brackets-curly-thin.svg)
-  static const bracketsCurly = PhosphorFlatIconData(0xe860, 'Thin');
+  static const bracketsCurly = IconData(0xe860,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-round-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/brackets-round-thin.svg)
-  static const bracketsRound = PhosphorFlatIconData(0xe864, 'Thin');
+  static const bracketsRound = IconData(0xe864,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brackets-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/brackets-square-thin.svg)
-  static const bracketsSquare = PhosphorFlatIconData(0xe85e, 'Thin');
+  static const bracketsSquare = IconData(0xe85e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brain-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/brain-thin.svg)
-  static const brain = PhosphorFlatIconData(0xe74e, 'Thin');
+  static const brain = IconData(0xe74e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![brandy-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/brandy-thin.svg)
-  static const brandy = PhosphorFlatIconData(0xe6b4, 'Thin');
+  static const brandy = IconData(0xe6b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bread-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bread-thin.svg)
-  static const bread = PhosphorFlatIconData(0xe81c, 'Thin');
+  static const bread = IconData(0xe81c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bridge-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bridge-thin.svg)
-  static const bridge = PhosphorFlatIconData(0xea68, 'Thin');
+  static const bridge = IconData(0xea68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/briefcase-thin.svg)
-  static const briefcase = PhosphorFlatIconData(0xe0ee, 'Thin');
+  static const briefcase = IconData(0xe0ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![briefcase-metal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/briefcase-metal-thin.svg)
-  static const briefcaseMetal = PhosphorFlatIconData(0xe5f2, 'Thin');
+  static const briefcaseMetal = IconData(0xe5f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broadcast-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/broadcast-thin.svg)
-  static const broadcast = PhosphorFlatIconData(0xe0f2, 'Thin');
+  static const broadcast = IconData(0xe0f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![broom-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/broom-thin.svg)
-  static const broom = PhosphorFlatIconData(0xec54, 'Thin');
+  static const broom = IconData(0xec54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browser-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/browser-thin.svg)
-  static const browser = PhosphorFlatIconData(0xe0f4, 'Thin');
+  static const browser = IconData(0xe0f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![browsers-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/browsers-thin.svg)
-  static const browsers = PhosphorFlatIconData(0xe0f6, 'Thin');
+  static const browsers = IconData(0xe0f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bug-thin.svg)
-  static const bug = PhosphorFlatIconData(0xe5f4, 'Thin');
+  static const bug = IconData(0xe5f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-beetle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bug-beetle-thin.svg)
-  static const bugBeetle = PhosphorFlatIconData(0xe5f6, 'Thin');
+  static const bugBeetle = IconData(0xe5f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bug-droid-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bug-droid-thin.svg)
-  static const bugDroid = PhosphorFlatIconData(0xe5f8, 'Thin');
+  static const bugDroid = IconData(0xe5f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/building-thin.svg)
-  static const building = PhosphorFlatIconData(0xe100, 'Thin');
+  static const building = IconData(0xe100,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-apartment-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/building-apartment-thin.svg)
-  static const buildingApartment = PhosphorFlatIconData(0xe0fe, 'Thin');
+  static const buildingApartment = IconData(0xe0fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![building-office-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/building-office-thin.svg)
-  static const buildingOffice = PhosphorFlatIconData(0xe0ff, 'Thin');
+  static const buildingOffice = IconData(0xe0ff,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![buildings-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/buildings-thin.svg)
-  static const buildings = PhosphorFlatIconData(0xe102, 'Thin');
+  static const buildings = IconData(0xe102,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bulldozer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bulldozer-thin.svg)
-  static const bulldozer = PhosphorFlatIconData(0xec6c, 'Thin');
+  static const bulldozer = IconData(0xec6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![bus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/bus-thin.svg)
-  static const bus = PhosphorFlatIconData(0xe106, 'Thin');
+  static const bus = IconData(0xe106,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![butterfly-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/butterfly-thin.svg)
-  static const butterfly = PhosphorFlatIconData(0xea6e, 'Thin');
+  static const butterfly = IconData(0xea6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cable-car-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cable-car-thin.svg)
-  static const cableCar = PhosphorFlatIconData(0xe49c, 'Thin');
+  static const cableCar = IconData(0xe49c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cactus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cactus-thin.svg)
-  static const cactus = PhosphorFlatIconData(0xe918, 'Thin');
+  static const cactus = IconData(0xe918,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cake-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cake-thin.svg)
-  static const cake = PhosphorFlatIconData(0xe780, 'Thin');
+  static const cake = IconData(0xe780,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calculator-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calculator-thin.svg)
-  static const calculator = PhosphorFlatIconData(0xe538, 'Thin');
+  static const calculator = IconData(0xe538,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-thin.svg)
-  static const calendar = PhosphorFlatIconData(0xe108, 'Thin');
+  static const calendar = IconData(0xe108,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-blank-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-blank-thin.svg)
-  static const calendarBlank = PhosphorFlatIconData(0xe10a, 'Thin');
+  static const calendarBlank = IconData(0xe10a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-check-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-check-thin.svg)
-  static const calendarCheck = PhosphorFlatIconData(0xe712, 'Thin');
+  static const calendarCheck = IconData(0xe712,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dot-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-dot-thin.svg)
-  static const calendarDot = PhosphorFlatIconData(0xe7b2, 'Thin');
+  static const calendarDot = IconData(0xe7b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-dots-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-dots-thin.svg)
-  static const calendarDots = PhosphorFlatIconData(0xe7b4, 'Thin');
+  static const calendarDots = IconData(0xe7b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-heart-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-heart-thin.svg)
-  static const calendarHeart = PhosphorFlatIconData(0xe8b0, 'Thin');
+  static const calendarHeart = IconData(0xe8b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-minus-thin.svg)
-  static const calendarMinus = PhosphorFlatIconData(0xea14, 'Thin');
+  static const calendarMinus = IconData(0xea14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-plus-thin.svg)
-  static const calendarPlus = PhosphorFlatIconData(0xe714, 'Thin');
+  static const calendarPlus = IconData(0xe714,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-slash-thin.svg)
-  static const calendarSlash = PhosphorFlatIconData(0xea12, 'Thin');
+  static const calendarSlash = IconData(0xea12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-star-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-star-thin.svg)
-  static const calendarStar = PhosphorFlatIconData(0xe8b2, 'Thin');
+  static const calendarStar = IconData(0xe8b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![calendar-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/calendar-x-thin.svg)
-  static const calendarX = PhosphorFlatIconData(0xe10c, 'Thin');
+  static const calendarX = IconData(0xe10c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![call-bell-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/call-bell-thin.svg)
-  static const callBell = PhosphorFlatIconData(0xe7de, 'Thin');
+  static const callBell = IconData(0xe7de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/camera-thin.svg)
-  static const camera = PhosphorFlatIconData(0xe10e, 'Thin');
+  static const camera = IconData(0xe10e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/camera-plus-thin.svg)
-  static const cameraPlus = PhosphorFlatIconData(0xec58, 'Thin');
+  static const cameraPlus = IconData(0xec58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-rotate-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/camera-rotate-thin.svg)
-  static const cameraRotate = PhosphorFlatIconData(0xe7a4, 'Thin');
+  static const cameraRotate = IconData(0xe7a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![camera-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/camera-slash-thin.svg)
-  static const cameraSlash = PhosphorFlatIconData(0xe110, 'Thin');
+  static const cameraSlash = IconData(0xe110,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![campfire-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/campfire-thin.svg)
-  static const campfire = PhosphorFlatIconData(0xe9d8, 'Thin');
+  static const campfire = IconData(0xe9d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/car-thin.svg)
-  static const car = PhosphorFlatIconData(0xe112, 'Thin');
+  static const car = IconData(0xe112,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-battery-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/car-battery-thin.svg)
-  static const carBattery = PhosphorFlatIconData(0xee30, 'Thin');
+  static const carBattery = IconData(0xee30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-profile-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/car-profile-thin.svg)
-  static const carProfile = PhosphorFlatIconData(0xe8cc, 'Thin');
+  static const carProfile = IconData(0xe8cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![car-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/car-simple-thin.svg)
-  static const carSimple = PhosphorFlatIconData(0xe114, 'Thin');
+  static const carSimple = IconData(0xe114,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cardholder-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cardholder-thin.svg)
-  static const cardholder = PhosphorFlatIconData(0xe5fa, 'Thin');
+  static const cardholder = IconData(0xe5fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cards-thin.svg)
-  static const cards = PhosphorFlatIconData(0xe0f8, 'Thin');
+  static const cards = IconData(0xe0f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cards-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cards-three-thin.svg)
-  static const cardsThree = PhosphorFlatIconData(0xee50, 'Thin');
+  static const cardsThree = IconData(0xee50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-double-down-thin.svg)
-  static const caretCircleDoubleDown = PhosphorFlatIconData(0xe116, 'Thin');
+  static const caretCircleDoubleDown = IconData(0xe116,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-double-left-thin.svg)
-  static const caretCircleDoubleLeft = PhosphorFlatIconData(0xe118, 'Thin');
+  static const caretCircleDoubleLeft = IconData(0xe118,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-double-right-thin.svg)
-  static const caretCircleDoubleRight = PhosphorFlatIconData(0xe11a, 'Thin');
+  static const caretCircleDoubleRight = IconData(0xe11a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-double-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-double-up-thin.svg)
-  static const caretCircleDoubleUp = PhosphorFlatIconData(0xe11c, 'Thin');
+  static const caretCircleDoubleUp = IconData(0xe11c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-down-thin.svg)
-  static const caretCircleDown = PhosphorFlatIconData(0xe11e, 'Thin');
+  static const caretCircleDown = IconData(0xe11e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-left-thin.svg)
-  static const caretCircleLeft = PhosphorFlatIconData(0xe120, 'Thin');
+  static const caretCircleLeft = IconData(0xe120,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-right-thin.svg)
-  static const caretCircleRight = PhosphorFlatIconData(0xe122, 'Thin');
+  static const caretCircleRight = IconData(0xe122,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-up-thin.svg)
-  static const caretCircleUp = PhosphorFlatIconData(0xe124, 'Thin');
+  static const caretCircleUp = IconData(0xe124,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-circle-up-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-circle-up-down-thin.svg)
-  static const caretCircleUpDown = PhosphorFlatIconData(0xe13e, 'Thin');
+  static const caretCircleUpDown = IconData(0xe13e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-double-down-thin.svg)
-  static const caretDoubleDown = PhosphorFlatIconData(0xe126, 'Thin');
+  static const caretDoubleDown = IconData(0xe126,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-double-left-thin.svg)
-  static const caretDoubleLeft = PhosphorFlatIconData(0xe128, 'Thin');
+  static const caretDoubleLeft = IconData(0xe128,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-double-right-thin.svg)
-  static const caretDoubleRight = PhosphorFlatIconData(0xe12a, 'Thin');
+  static const caretDoubleRight = IconData(0xe12a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-double-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-double-up-thin.svg)
-  static const caretDoubleUp = PhosphorFlatIconData(0xe12c, 'Thin');
+  static const caretDoubleUp = IconData(0xe12c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-down-thin.svg)
-  static const caretDown = PhosphorFlatIconData(0xe136, 'Thin');
+  static const caretDown = IconData(0xe136,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-left-thin.svg)
-  static const caretLeft = PhosphorFlatIconData(0xe138, 'Thin');
+  static const caretLeft = IconData(0xe138,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-line-down-thin.svg)
-  static const caretLineDown = PhosphorFlatIconData(0xe134, 'Thin');
+  static const caretLineDown = IconData(0xe134,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-line-left-thin.svg)
-  static const caretLineLeft = PhosphorFlatIconData(0xe132, 'Thin');
+  static const caretLineLeft = IconData(0xe132,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-line-right-thin.svg)
-  static const caretLineRight = PhosphorFlatIconData(0xe130, 'Thin');
+  static const caretLineRight = IconData(0xe130,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-line-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-line-up-thin.svg)
-  static const caretLineUp = PhosphorFlatIconData(0xe12e, 'Thin');
+  static const caretLineUp = IconData(0xe12e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-right-thin.svg)
-  static const caretRight = PhosphorFlatIconData(0xe13a, 'Thin');
+  static const caretRight = IconData(0xe13a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-up-thin.svg)
-  static const caretUp = PhosphorFlatIconData(0xe13c, 'Thin');
+  static const caretUp = IconData(0xe13c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![caret-up-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/caret-up-down-thin.svg)
-  static const caretUpDown = PhosphorFlatIconData(0xe140, 'Thin');
+  static const caretUpDown = IconData(0xe140,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![carrot-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/carrot-thin.svg)
-  static const carrot = PhosphorFlatIconData(0xed38, 'Thin');
+  static const carrot = IconData(0xed38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cash-register-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cash-register-thin.svg)
-  static const cashRegister = PhosphorFlatIconData(0xed80, 'Thin');
+  static const cashRegister = IconData(0xed80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cassette-tape-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cassette-tape-thin.svg)
-  static const cassetteTape = PhosphorFlatIconData(0xed2e, 'Thin');
+  static const cassetteTape = IconData(0xed2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![castle-turret-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/castle-turret-thin.svg)
-  static const castleTurret = PhosphorFlatIconData(0xe9d0, 'Thin');
+  static const castleTurret = IconData(0xe9d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cat-thin.svg)
-  static const cat = PhosphorFlatIconData(0xe748, 'Thin');
+  static const cat = IconData(0xe748,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-full-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cell-signal-full-thin.svg)
-  static const cellSignalFull = PhosphorFlatIconData(0xe142, 'Thin');
+  static const cellSignalFull = IconData(0xe142,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-high-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cell-signal-high-thin.svg)
-  static const cellSignalHigh = PhosphorFlatIconData(0xe144, 'Thin');
+  static const cellSignalHigh = IconData(0xe144,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-low-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cell-signal-low-thin.svg)
-  static const cellSignalLow = PhosphorFlatIconData(0xe146, 'Thin');
+  static const cellSignalLow = IconData(0xe146,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-medium-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cell-signal-medium-thin.svg)
-  static const cellSignalMedium = PhosphorFlatIconData(0xe148, 'Thin');
+  static const cellSignalMedium = IconData(0xe148,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-none-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cell-signal-none-thin.svg)
-  static const cellSignalNone = PhosphorFlatIconData(0xe14a, 'Thin');
+  static const cellSignalNone = IconData(0xe14a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cell-signal-slash-thin.svg)
-  static const cellSignalSlash = PhosphorFlatIconData(0xe14c, 'Thin');
+  static const cellSignalSlash = IconData(0xe14c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-signal-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cell-signal-x-thin.svg)
-  static const cellSignalX = PhosphorFlatIconData(0xe14e, 'Thin');
+  static const cellSignalX = IconData(0xe14e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cell-tower-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cell-tower-thin.svg)
-  static const cellTower = PhosphorFlatIconData(0xebaa, 'Thin');
+  static const cellTower = IconData(0xebaa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![certificate-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/certificate-thin.svg)
-  static const certificate = PhosphorFlatIconData(0xe766, 'Thin');
+  static const certificate = IconData(0xe766,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chair-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chair-thin.svg)
-  static const chair = PhosphorFlatIconData(0xe950, 'Thin');
+  static const chair = IconData(0xe950,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chalkboard-thin.svg)
-  static const chalkboard = PhosphorFlatIconData(0xe5fc, 'Thin');
+  static const chalkboard = IconData(0xe5fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chalkboard-simple-thin.svg)
-  static const chalkboardSimple = PhosphorFlatIconData(0xe5fe, 'Thin');
+  static const chalkboardSimple = IconData(0xe5fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chalkboard-teacher-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chalkboard-teacher-thin.svg)
-  static const chalkboardTeacher = PhosphorFlatIconData(0xe600, 'Thin');
+  static const chalkboardTeacher = IconData(0xe600,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![champagne-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/champagne-thin.svg)
-  static const champagne = PhosphorFlatIconData(0xeaca, 'Thin');
+  static const champagne = IconData(0xeaca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![charging-station-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/charging-station-thin.svg)
-  static const chargingStation = PhosphorFlatIconData(0xe8d0, 'Thin');
+  static const chargingStation = IconData(0xe8d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-bar-thin.svg)
-  static const chartBar = PhosphorFlatIconData(0xe150, 'Thin');
+  static const chartBar = IconData(0xe150,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-bar-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-bar-horizontal-thin.svg)
-  static const chartBarHorizontal = PhosphorFlatIconData(0xe152, 'Thin');
+  static const chartBarHorizontal = IconData(0xe152,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-donut-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-donut-thin.svg)
-  static const chartDonut = PhosphorFlatIconData(0xeaa6, 'Thin');
+  static const chartDonut = IconData(0xeaa6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-line-thin.svg)
-  static const chartLine = PhosphorFlatIconData(0xe154, 'Thin');
+  static const chartLine = IconData(0xe154,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-line-down-thin.svg)
-  static const chartLineDown = PhosphorFlatIconData(0xe8b6, 'Thin');
+  static const chartLineDown = IconData(0xe8b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-line-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-line-up-thin.svg)
-  static const chartLineUp = PhosphorFlatIconData(0xe156, 'Thin');
+  static const chartLineUp = IconData(0xe156,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-pie-thin.svg)
-  static const chartPie = PhosphorFlatIconData(0xe158, 'Thin');
+  static const chartPie = IconData(0xe158,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-pie-slice-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-pie-slice-thin.svg)
-  static const chartPieSlice = PhosphorFlatIconData(0xe15a, 'Thin');
+  static const chartPieSlice = IconData(0xe15a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-polar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-polar-thin.svg)
-  static const chartPolar = PhosphorFlatIconData(0xeaa8, 'Thin');
+  static const chartPolar = IconData(0xeaa8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chart-scatter-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chart-scatter-thin.svg)
-  static const chartScatter = PhosphorFlatIconData(0xeaac, 'Thin');
+  static const chartScatter = IconData(0xeaac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-thin.svg)
-  static const chat = PhosphorFlatIconData(0xe15c, 'Thin');
+  static const chat = IconData(0xe15c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-centered-thin.svg)
-  static const chatCentered = PhosphorFlatIconData(0xe160, 'Thin');
+  static const chatCentered = IconData(0xe160,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-dots-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-centered-dots-thin.svg)
-  static const chatCenteredDots = PhosphorFlatIconData(0xe164, 'Thin');
+  static const chatCenteredDots = IconData(0xe164,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-centered-slash-thin.svg)
-  static const chatCenteredSlash = PhosphorFlatIconData(0xe162, 'Thin');
+  static const chatCenteredSlash = IconData(0xe162,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-centered-text-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-centered-text-thin.svg)
-  static const chatCenteredText = PhosphorFlatIconData(0xe166, 'Thin');
+  static const chatCenteredText = IconData(0xe166,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-circle-thin.svg)
-  static const chatCircle = PhosphorFlatIconData(0xe168, 'Thin');
+  static const chatCircle = IconData(0xe168,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-dots-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-circle-dots-thin.svg)
-  static const chatCircleDots = PhosphorFlatIconData(0xe16c, 'Thin');
+  static const chatCircleDots = IconData(0xe16c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-circle-slash-thin.svg)
-  static const chatCircleSlash = PhosphorFlatIconData(0xe16a, 'Thin');
+  static const chatCircleSlash = IconData(0xe16a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-circle-text-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-circle-text-thin.svg)
-  static const chatCircleText = PhosphorFlatIconData(0xe16e, 'Thin');
+  static const chatCircleText = IconData(0xe16e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-dots-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-dots-thin.svg)
-  static const chatDots = PhosphorFlatIconData(0xe170, 'Thin');
+  static const chatDots = IconData(0xe170,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-slash-thin.svg)
-  static const chatSlash = PhosphorFlatIconData(0xe15e, 'Thin');
+  static const chatSlash = IconData(0xe15e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-teardrop-thin.svg)
-  static const chatTeardrop = PhosphorFlatIconData(0xe172, 'Thin');
+  static const chatTeardrop = IconData(0xe172,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-dots-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-teardrop-dots-thin.svg)
-  static const chatTeardropDots = PhosphorFlatIconData(0xe176, 'Thin');
+  static const chatTeardropDots = IconData(0xe176,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-teardrop-slash-thin.svg)
-  static const chatTeardropSlash = PhosphorFlatIconData(0xe174, 'Thin');
+  static const chatTeardropSlash = IconData(0xe174,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-teardrop-text-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-teardrop-text-thin.svg)
-  static const chatTeardropText = PhosphorFlatIconData(0xe178, 'Thin');
+  static const chatTeardropText = IconData(0xe178,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chat-text-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chat-text-thin.svg)
-  static const chatText = PhosphorFlatIconData(0xe17a, 'Thin');
+  static const chatText = IconData(0xe17a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chats-thin.svg)
-  static const chats = PhosphorFlatIconData(0xe17c, 'Thin');
+  static const chats = IconData(0xe17c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chats-circle-thin.svg)
-  static const chatsCircle = PhosphorFlatIconData(0xe17e, 'Thin');
+  static const chatsCircle = IconData(0xe17e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chats-teardrop-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chats-teardrop-thin.svg)
-  static const chatsTeardrop = PhosphorFlatIconData(0xe180, 'Thin');
+  static const chatsTeardrop = IconData(0xe180,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/check-thin.svg)
-  static const check = PhosphorFlatIconData(0xe182, 'Thin');
+  static const check = IconData(0xe182,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/check-circle-thin.svg)
-  static const checkCircle = PhosphorFlatIconData(0xe184, 'Thin');
+  static const checkCircle = IconData(0xe184,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-fat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/check-fat-thin.svg)
-  static const checkFat = PhosphorFlatIconData(0xeba6, 'Thin');
+  static const checkFat = IconData(0xeba6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/check-square-thin.svg)
-  static const checkSquare = PhosphorFlatIconData(0xe186, 'Thin');
+  static const checkSquare = IconData(0xe186,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![check-square-offset-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/check-square-offset-thin.svg)
-  static const checkSquareOffset = PhosphorFlatIconData(0xe188, 'Thin');
+  static const checkSquareOffset = IconData(0xe188,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checkerboard-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/checkerboard-thin.svg)
-  static const checkerboard = PhosphorFlatIconData(0xe8c4, 'Thin');
+  static const checkerboard = IconData(0xe8c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![checks-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/checks-thin.svg)
-  static const checks = PhosphorFlatIconData(0xe53a, 'Thin');
+  static const checks = IconData(0xe53a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheers-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cheers-thin.svg)
-  static const cheers = PhosphorFlatIconData(0xea4a, 'Thin');
+  static const cheers = IconData(0xea4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cheese-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cheese-thin.svg)
-  static const cheese = PhosphorFlatIconData(0xe9fe, 'Thin');
+  static const cheese = IconData(0xe9fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![chef-hat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/chef-hat-thin.svg)
-  static const chefHat = PhosphorFlatIconData(0xed8e, 'Thin');
+  static const chefHat = IconData(0xed8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cherries-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cherries-thin.svg)
-  static const cherries = PhosphorFlatIconData(0xe830, 'Thin');
+  static const cherries = IconData(0xe830,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![church-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/church-thin.svg)
-  static const church = PhosphorFlatIconData(0xecea, 'Thin');
+  static const church = IconData(0xecea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cigarette-thin.svg)
-  static const cigarette = PhosphorFlatIconData(0xed90, 'Thin');
+  static const cigarette = IconData(0xed90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cigarette-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cigarette-slash-thin.svg)
-  static const cigaretteSlash = PhosphorFlatIconData(0xed92, 'Thin');
+  static const cigaretteSlash = IconData(0xed92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circle-thin.svg)
-  static const circle = PhosphorFlatIconData(0xe18a, 'Thin');
+  static const circle = IconData(0xe18a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-dashed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circle-dashed-thin.svg)
-  static const circleDashed = PhosphorFlatIconData(0xe602, 'Thin');
+  static const circleDashed = IconData(0xe602,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circle-half-thin.svg)
-  static const circleHalf = PhosphorFlatIconData(0xe18c, 'Thin');
+  static const circleHalf = IconData(0xe18c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-half-tilt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circle-half-tilt-thin.svg)
-  static const circleHalfTilt = PhosphorFlatIconData(0xe18e, 'Thin');
+  static const circleHalfTilt = IconData(0xe18e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circle-notch-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circle-notch-thin.svg)
-  static const circleNotch = PhosphorFlatIconData(0xeb44, 'Thin');
+  static const circleNotch = IconData(0xeb44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circles-four-thin.svg)
-  static const circlesFour = PhosphorFlatIconData(0xe190, 'Thin');
+  static const circlesFour = IconData(0xe190,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circles-three-thin.svg)
-  static const circlesThree = PhosphorFlatIconData(0xe192, 'Thin');
+  static const circlesThree = IconData(0xe192,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circles-three-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circles-three-plus-thin.svg)
-  static const circlesThreePlus = PhosphorFlatIconData(0xe194, 'Thin');
+  static const circlesThreePlus = IconData(0xe194,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![circuitry-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/circuitry-thin.svg)
-  static const circuitry = PhosphorFlatIconData(0xe9c2, 'Thin');
+  static const circuitry = IconData(0xe9c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![city-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/city-thin.svg)
-  static const city = PhosphorFlatIconData(0xea6a, 'Thin');
+  static const city = IconData(0xea6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clipboard-thin.svg)
-  static const clipboard = PhosphorFlatIconData(0xe196, 'Thin');
+  static const clipboard = IconData(0xe196,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clipboard-text-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clipboard-text-thin.svg)
-  static const clipboardText = PhosphorFlatIconData(0xe198, 'Thin');
+  static const clipboardText = IconData(0xe198,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clock-thin.svg)
-  static const clock = PhosphorFlatIconData(0xe19a, 'Thin');
+  static const clock = IconData(0xe19a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-afternoon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clock-afternoon-thin.svg)
-  static const clockAfternoon = PhosphorFlatIconData(0xe19c, 'Thin');
+  static const clockAfternoon = IconData(0xe19c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-clockwise-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clock-clockwise-thin.svg)
-  static const clockClockwise = PhosphorFlatIconData(0xe19e, 'Thin');
+  static const clockClockwise = IconData(0xe19e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-countdown-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clock-countdown-thin.svg)
-  static const clockCountdown = PhosphorFlatIconData(0xed2c, 'Thin');
+  static const clockCountdown = IconData(0xed2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-counter-clockwise-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clock-counter-clockwise-thin.svg)
-  static const clockCounterClockwise = PhosphorFlatIconData(0xe1a0, 'Thin');
+  static const clockCounterClockwise = IconData(0xe1a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clock-user-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clock-user-thin.svg)
-  static const clockUser = PhosphorFlatIconData(0xedec, 'Thin');
+  static const clockUser = IconData(0xedec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![closed-captioning-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/closed-captioning-thin.svg)
-  static const closedCaptioning = PhosphorFlatIconData(0xe1a4, 'Thin');
+  static const closedCaptioning = IconData(0xe1a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-thin.svg)
-  static const cloud = PhosphorFlatIconData(0xe1aa, 'Thin');
+  static const cloud = IconData(0xe1aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-arrow-down-thin.svg)
-  static const cloudArrowDown = PhosphorFlatIconData(0xe1ac, 'Thin');
+  static const cloudArrowDown = IconData(0xe1ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-arrow-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-arrow-up-thin.svg)
-  static const cloudArrowUp = PhosphorFlatIconData(0xe1ae, 'Thin');
+  static const cloudArrowUp = IconData(0xe1ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-check-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-check-thin.svg)
-  static const cloudCheck = PhosphorFlatIconData(0xe1b0, 'Thin');
+  static const cloudCheck = IconData(0xe1b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-fog-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-fog-thin.svg)
-  static const cloudFog = PhosphorFlatIconData(0xe53c, 'Thin');
+  static const cloudFog = IconData(0xe53c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-lightning-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-lightning-thin.svg)
-  static const cloudLightning = PhosphorFlatIconData(0xe1b2, 'Thin');
+  static const cloudLightning = IconData(0xe1b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-moon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-moon-thin.svg)
-  static const cloudMoon = PhosphorFlatIconData(0xe53e, 'Thin');
+  static const cloudMoon = IconData(0xe53e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-rain-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-rain-thin.svg)
-  static const cloudRain = PhosphorFlatIconData(0xe1b4, 'Thin');
+  static const cloudRain = IconData(0xe1b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-slash-thin.svg)
-  static const cloudSlash = PhosphorFlatIconData(0xe1b6, 'Thin');
+  static const cloudSlash = IconData(0xe1b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-snow-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-snow-thin.svg)
-  static const cloudSnow = PhosphorFlatIconData(0xe1b8, 'Thin');
+  static const cloudSnow = IconData(0xe1b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-sun-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-sun-thin.svg)
-  static const cloudSun = PhosphorFlatIconData(0xe540, 'Thin');
+  static const cloudSun = IconData(0xe540,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-warning-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-warning-thin.svg)
-  static const cloudWarning = PhosphorFlatIconData(0xea98, 'Thin');
+  static const cloudWarning = IconData(0xea98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cloud-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cloud-x-thin.svg)
-  static const cloudX = PhosphorFlatIconData(0xea96, 'Thin');
+  static const cloudX = IconData(0xea96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![clover-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/clover-thin.svg)
-  static const clover = PhosphorFlatIconData(0xedc8, 'Thin');
+  static const clover = IconData(0xedc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![club-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/club-thin.svg)
-  static const club = PhosphorFlatIconData(0xe1ba, 'Thin');
+  static const club = IconData(0xe1ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coat-hanger-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/coat-hanger-thin.svg)
-  static const coatHanger = PhosphorFlatIconData(0xe7fe, 'Thin');
+  static const coatHanger = IconData(0xe7fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coda-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/coda-logo-thin.svg)
-  static const codaLogo = PhosphorFlatIconData(0xe7ce, 'Thin');
+  static const codaLogo = IconData(0xe7ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/code-thin.svg)
-  static const code = PhosphorFlatIconData(0xe1bc, 'Thin');
+  static const code = IconData(0xe1bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-block-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/code-block-thin.svg)
-  static const codeBlock = PhosphorFlatIconData(0xeafe, 'Thin');
+  static const codeBlock = IconData(0xeafe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![code-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/code-simple-thin.svg)
-  static const codeSimple = PhosphorFlatIconData(0xe1be, 'Thin');
+  static const codeSimple = IconData(0xe1be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codepen-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/codepen-logo-thin.svg)
-  static const codepenLogo = PhosphorFlatIconData(0xe978, 'Thin');
+  static const codepenLogo = IconData(0xe978,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![codesandbox-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/codesandbox-logo-thin.svg)
-  static const codesandboxLogo = PhosphorFlatIconData(0xea06, 'Thin');
+  static const codesandboxLogo = IconData(0xea06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/coffee-thin.svg)
-  static const coffee = PhosphorFlatIconData(0xe1c2, 'Thin');
+  static const coffee = IconData(0xe1c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coffee-bean-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/coffee-bean-thin.svg)
-  static const coffeeBean = PhosphorFlatIconData(0xe1c0, 'Thin');
+  static const coffeeBean = IconData(0xe1c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/coin-thin.svg)
-  static const coin = PhosphorFlatIconData(0xe60e, 'Thin');
+  static const coin = IconData(0xe60e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coin-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/coin-vertical-thin.svg)
-  static const coinVertical = PhosphorFlatIconData(0xeb48, 'Thin');
+  static const coinVertical = IconData(0xeb48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![coins-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/coins-thin.svg)
-  static const coins = PhosphorFlatIconData(0xe78e, 'Thin');
+  static const coins = IconData(0xe78e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/columns-thin.svg)
-  static const columns = PhosphorFlatIconData(0xe546, 'Thin');
+  static const columns = IconData(0xe546,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/columns-plus-left-thin.svg)
-  static const columnsPlusLeft = PhosphorFlatIconData(0xe544, 'Thin');
+  static const columnsPlusLeft = IconData(0xe544,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![columns-plus-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/columns-plus-right-thin.svg)
-  static const columnsPlusRight = PhosphorFlatIconData(0xe542, 'Thin');
+  static const columnsPlusRight = IconData(0xe542,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![command-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/command-thin.svg)
-  static const command = PhosphorFlatIconData(0xe1c4, 'Thin');
+  static const command = IconData(0xe1c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/compass-thin.svg)
-  static const compass = PhosphorFlatIconData(0xe1c8, 'Thin');
+  static const compass = IconData(0xe1c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-rose-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/compass-rose-thin.svg)
-  static const compassRose = PhosphorFlatIconData(0xe1c6, 'Thin');
+  static const compassRose = IconData(0xe1c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![compass-tool-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/compass-tool-thin.svg)
-  static const compassTool = PhosphorFlatIconData(0xea0e, 'Thin');
+  static const compassTool = IconData(0xea0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![computer-tower-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/computer-tower-thin.svg)
-  static const computerTower = PhosphorFlatIconData(0xe548, 'Thin');
+  static const computerTower = IconData(0xe548,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![confetti-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/confetti-thin.svg)
-  static const confetti = PhosphorFlatIconData(0xe81a, 'Thin');
+  static const confetti = IconData(0xe81a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![contactless-payment-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/contactless-payment-thin.svg)
-  static const contactlessPayment = PhosphorFlatIconData(0xed42, 'Thin');
+  static const contactlessPayment = IconData(0xed42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![control-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/control-thin.svg)
-  static const control = PhosphorFlatIconData(0xeca6, 'Thin');
+  static const control = IconData(0xeca6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cookie-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cookie-thin.svg)
-  static const cookie = PhosphorFlatIconData(0xe6ca, 'Thin');
+  static const cookie = IconData(0xe6ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cooking-pot-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cooking-pot-thin.svg)
-  static const cookingPot = PhosphorFlatIconData(0xe764, 'Thin');
+  static const cookingPot = IconData(0xe764,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/copy-thin.svg)
-  static const copy = PhosphorFlatIconData(0xe1ca, 'Thin');
+  static const copy = IconData(0xe1ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copy-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/copy-simple-thin.svg)
-  static const copySimple = PhosphorFlatIconData(0xe1cc, 'Thin');
+  static const copySimple = IconData(0xe1cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyleft-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/copyleft-thin.svg)
-  static const copyleft = PhosphorFlatIconData(0xe86a, 'Thin');
+  static const copyleft = IconData(0xe86a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![copyright-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/copyright-thin.svg)
-  static const copyright = PhosphorFlatIconData(0xe54a, 'Thin');
+  static const copyright = IconData(0xe54a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-in-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/corners-in-thin.svg)
-  static const cornersIn = PhosphorFlatIconData(0xe1ce, 'Thin');
+  static const cornersIn = IconData(0xe1ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![corners-out-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/corners-out-thin.svg)
-  static const cornersOut = PhosphorFlatIconData(0xe1d0, 'Thin');
+  static const cornersOut = IconData(0xe1d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![couch-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/couch-thin.svg)
-  static const couch = PhosphorFlatIconData(0xe7f6, 'Thin');
+  static const couch = IconData(0xe7f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![court-basketball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/court-basketball-thin.svg)
-  static const courtBasketball = PhosphorFlatIconData(0xee36, 'Thin');
+  static const courtBasketball = IconData(0xee36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cow-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cow-thin.svg)
-  static const cow = PhosphorFlatIconData(0xeabe, 'Thin');
+  static const cow = IconData(0xeabe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cowboy-hat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cowboy-hat-thin.svg)
-  static const cowboyHat = PhosphorFlatIconData(0xed12, 'Thin');
+  static const cowboyHat = IconData(0xed12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cpu-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cpu-thin.svg)
-  static const cpu = PhosphorFlatIconData(0xe610, 'Thin');
+  static const cpu = IconData(0xe610,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/crane-thin.svg)
-  static const crane = PhosphorFlatIconData(0xed48, 'Thin');
+  static const crane = IconData(0xed48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crane-tower-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/crane-tower-thin.svg)
-  static const craneTower = PhosphorFlatIconData(0xed49, 'Thin');
+  static const craneTower = IconData(0xed49,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![credit-card-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/credit-card-thin.svg)
-  static const creditCard = PhosphorFlatIconData(0xe1d2, 'Thin');
+  static const creditCard = IconData(0xe1d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cricket-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cricket-thin.svg)
-  static const cricket = PhosphorFlatIconData(0xee12, 'Thin');
+  static const cricket = IconData(0xee12,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crop-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/crop-thin.svg)
-  static const crop = PhosphorFlatIconData(0xe1d4, 'Thin');
+  static const crop = IconData(0xe1d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cross-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cross-thin.svg)
-  static const cross = PhosphorFlatIconData(0xe8a0, 'Thin');
+  static const cross = IconData(0xe8a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/crosshair-thin.svg)
-  static const crosshair = PhosphorFlatIconData(0xe1d6, 'Thin');
+  static const crosshair = IconData(0xe1d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crosshair-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/crosshair-simple-thin.svg)
-  static const crosshairSimple = PhosphorFlatIconData(0xe1d8, 'Thin');
+  static const crosshairSimple = IconData(0xe1d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/crown-thin.svg)
-  static const crown = PhosphorFlatIconData(0xe614, 'Thin');
+  static const crown = IconData(0xe614,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-cross-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/crown-cross-thin.svg)
-  static const crownCross = PhosphorFlatIconData(0xee5e, 'Thin');
+  static const crownCross = IconData(0xee5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![crown-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/crown-simple-thin.svg)
-  static const crownSimple = PhosphorFlatIconData(0xe616, 'Thin');
+  static const crownSimple = IconData(0xe616,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cube-thin.svg)
-  static const cube = PhosphorFlatIconData(0xe1da, 'Thin');
+  static const cube = IconData(0xe1da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-focus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cube-focus-thin.svg)
-  static const cubeFocus = PhosphorFlatIconData(0xed0a, 'Thin');
+  static const cubeFocus = IconData(0xed0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cube-transparent-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cube-transparent-thin.svg)
-  static const cubeTransparent = PhosphorFlatIconData(0xec7c, 'Thin');
+  static const cubeTransparent = IconData(0xec7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-btc-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-btc-thin.svg)
-  static const currencyBtc = PhosphorFlatIconData(0xe618, 'Thin');
+  static const currencyBtc = IconData(0xe618,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-circle-dollar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-circle-dollar-thin.svg)
-  static const currencyCircleDollar = PhosphorFlatIconData(0xe54c, 'Thin');
+  static const currencyCircleDollar = IconData(0xe54c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-cny-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-cny-thin.svg)
-  static const currencyCny = PhosphorFlatIconData(0xe54e, 'Thin');
+  static const currencyCny = IconData(0xe54e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-dollar-thin.svg)
-  static const currencyDollar = PhosphorFlatIconData(0xe550, 'Thin');
+  static const currencyDollar = IconData(0xe550,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-dollar-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-dollar-simple-thin.svg)
-  static const currencyDollarSimple = PhosphorFlatIconData(0xe552, 'Thin');
+  static const currencyDollarSimple = IconData(0xe552,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eth-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-eth-thin.svg)
-  static const currencyEth = PhosphorFlatIconData(0xeada, 'Thin');
+  static const currencyEth = IconData(0xeada,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-eur-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-eur-thin.svg)
-  static const currencyEur = PhosphorFlatIconData(0xe554, 'Thin');
+  static const currencyEur = IconData(0xe554,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-gbp-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-gbp-thin.svg)
-  static const currencyGbp = PhosphorFlatIconData(0xe556, 'Thin');
+  static const currencyGbp = IconData(0xe556,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-inr-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-inr-thin.svg)
-  static const currencyInr = PhosphorFlatIconData(0xe558, 'Thin');
+  static const currencyInr = IconData(0xe558,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-jpy-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-jpy-thin.svg)
-  static const currencyJpy = PhosphorFlatIconData(0xe55a, 'Thin');
+  static const currencyJpy = IconData(0xe55a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-krw-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-krw-thin.svg)
-  static const currencyKrw = PhosphorFlatIconData(0xe55c, 'Thin');
+  static const currencyKrw = IconData(0xe55c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-kzt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-kzt-thin.svg)
-  static const currencyKzt = PhosphorFlatIconData(0xec4c, 'Thin');
+  static const currencyKzt = IconData(0xec4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-ngn-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-ngn-thin.svg)
-  static const currencyNgn = PhosphorFlatIconData(0xeb52, 'Thin');
+  static const currencyNgn = IconData(0xeb52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![currency-rub-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/currency-rub-thin.svg)
-  static const currencyRub = PhosphorFlatIconData(0xe55e, 'Thin');
+  static const currencyRub = IconData(0xe55e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cursor-thin.svg)
-  static const cursor = PhosphorFlatIconData(0xe1dc, 'Thin');
+  static const cursor = IconData(0xe1dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-click-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cursor-click-thin.svg)
-  static const cursorClick = PhosphorFlatIconData(0xe7c8, 'Thin');
+  static const cursorClick = IconData(0xe7c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cursor-text-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cursor-text-thin.svg)
-  static const cursorText = PhosphorFlatIconData(0xe7d8, 'Thin');
+  static const cursorText = IconData(0xe7d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![cylinder-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/cylinder-thin.svg)
-  static const cylinder = PhosphorFlatIconData(0xe8fc, 'Thin');
+  static const cylinder = IconData(0xe8fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![database-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/database-thin.svg)
-  static const database = PhosphorFlatIconData(0xe1de, 'Thin');
+  static const database = IconData(0xe1de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desk-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/desk-thin.svg)
-  static const desk = PhosphorFlatIconData(0xed16, 'Thin');
+  static const desk = IconData(0xed16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/desktop-thin.svg)
-  static const desktop = PhosphorFlatIconData(0xe560, 'Thin');
+  static const desktop = IconData(0xe560,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![desktop-tower-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/desktop-tower-thin.svg)
-  static const desktopTower = PhosphorFlatIconData(0xe562, 'Thin');
+  static const desktopTower = IconData(0xe562,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![detective-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/detective-thin.svg)
-  static const detective = PhosphorFlatIconData(0xe83e, 'Thin');
+  static const detective = IconData(0xe83e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dev-to-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dev-to-logo-thin.svg)
-  static const devToLogo = PhosphorFlatIconData(0xed0e, 'Thin');
+  static const devToLogo = IconData(0xed0e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/device-mobile-thin.svg)
-  static const deviceMobile = PhosphorFlatIconData(0xe1e0, 'Thin');
+  static const deviceMobile = IconData(0xe1e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-camera-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/device-mobile-camera-thin.svg)
-  static const deviceMobileCamera = PhosphorFlatIconData(0xe1e2, 'Thin');
+  static const deviceMobileCamera = IconData(0xe1e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/device-mobile-slash-thin.svg)
-  static const deviceMobileSlash = PhosphorFlatIconData(0xee46, 'Thin');
+  static const deviceMobileSlash = IconData(0xee46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-mobile-speaker-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/device-mobile-speaker-thin.svg)
-  static const deviceMobileSpeaker = PhosphorFlatIconData(0xe1e4, 'Thin');
+  static const deviceMobileSpeaker = IconData(0xe1e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-rotate-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/device-rotate-thin.svg)
-  static const deviceRotate = PhosphorFlatIconData(0xedf2, 'Thin');
+  static const deviceRotate = IconData(0xedf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/device-tablet-thin.svg)
-  static const deviceTablet = PhosphorFlatIconData(0xe1e6, 'Thin');
+  static const deviceTablet = IconData(0xe1e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-camera-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/device-tablet-camera-thin.svg)
-  static const deviceTabletCamera = PhosphorFlatIconData(0xe1e8, 'Thin');
+  static const deviceTabletCamera = IconData(0xe1e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![device-tablet-speaker-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/device-tablet-speaker-thin.svg)
-  static const deviceTabletSpeaker = PhosphorFlatIconData(0xe1ea, 'Thin');
+  static const deviceTabletSpeaker = IconData(0xe1ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![devices-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/devices-thin.svg)
-  static const devices = PhosphorFlatIconData(0xeba4, 'Thin');
+  static const devices = IconData(0xeba4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamond-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/diamond-thin.svg)
-  static const diamond = PhosphorFlatIconData(0xe1ec, 'Thin');
+  static const diamond = IconData(0xe1ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![diamonds-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/diamonds-four-thin.svg)
-  static const diamondsFour = PhosphorFlatIconData(0xe8f4, 'Thin');
+  static const diamondsFour = IconData(0xe8f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-five-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dice-five-thin.svg)
-  static const diceFive = PhosphorFlatIconData(0xe1ee, 'Thin');
+  static const diceFive = IconData(0xe1ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dice-four-thin.svg)
-  static const diceFour = PhosphorFlatIconData(0xe1f0, 'Thin');
+  static const diceFour = IconData(0xe1f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-one-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dice-one-thin.svg)
-  static const diceOne = PhosphorFlatIconData(0xe1f2, 'Thin');
+  static const diceOne = IconData(0xe1f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-six-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dice-six-thin.svg)
-  static const diceSix = PhosphorFlatIconData(0xe1f4, 'Thin');
+  static const diceSix = IconData(0xe1f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dice-three-thin.svg)
-  static const diceThree = PhosphorFlatIconData(0xe1f6, 'Thin');
+  static const diceThree = IconData(0xe1f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dice-two-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dice-two-thin.svg)
-  static const diceTwo = PhosphorFlatIconData(0xe1f8, 'Thin');
+  static const diceTwo = IconData(0xe1f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disc-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/disc-thin.svg)
-  static const disc = PhosphorFlatIconData(0xe564, 'Thin');
+  static const disc = IconData(0xe564,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![disco-ball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/disco-ball-thin.svg)
-  static const discoBall = PhosphorFlatIconData(0xed98, 'Thin');
+  static const discoBall = IconData(0xed98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![discord-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/discord-logo-thin.svg)
-  static const discordLogo = PhosphorFlatIconData(0xe61a, 'Thin');
+  static const discordLogo = IconData(0xe61a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![divide-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/divide-thin.svg)
-  static const divide = PhosphorFlatIconData(0xe1fa, 'Thin');
+  static const divide = IconData(0xe1fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dna-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dna-thin.svg)
-  static const dna = PhosphorFlatIconData(0xe924, 'Thin');
+  static const dna = IconData(0xe924,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dog-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dog-thin.svg)
-  static const dog = PhosphorFlatIconData(0xe74a, 'Thin');
+  static const dog = IconData(0xe74a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/door-thin.svg)
-  static const door = PhosphorFlatIconData(0xe61c, 'Thin');
+  static const door = IconData(0xe61c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![door-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/door-open-thin.svg)
-  static const doorOpen = PhosphorFlatIconData(0xe7e6, 'Thin');
+  static const doorOpen = IconData(0xe7e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dot-thin.svg)
-  static const dot = PhosphorFlatIconData(0xecde, 'Thin');
+  static const dot = IconData(0xecde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dot-outline-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dot-outline-thin.svg)
-  static const dotOutline = PhosphorFlatIconData(0xece0, 'Thin');
+  static const dotOutline = IconData(0xece0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-nine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-nine-thin.svg)
-  static const dotsNine = PhosphorFlatIconData(0xe1fc, 'Thin');
+  static const dotsNine = IconData(0xe1fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-six-thin.svg)
-  static const dotsSix = PhosphorFlatIconData(0xe794, 'Thin');
+  static const dotsSix = IconData(0xe794,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-six-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-six-vertical-thin.svg)
-  static const dotsSixVertical = PhosphorFlatIconData(0xeae2, 'Thin');
+  static const dotsSixVertical = IconData(0xeae2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-three-thin.svg)
-  static const dotsThree = PhosphorFlatIconData(0xe1fe, 'Thin');
+  static const dotsThree = IconData(0xe1fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-three-circle-thin.svg)
-  static const dotsThreeCircle = PhosphorFlatIconData(0xe200, 'Thin');
+  static const dotsThreeCircle = IconData(0xe200,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-circle-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-three-circle-vertical-thin.svg)
-  static const dotsThreeCircleVertical = PhosphorFlatIconData(0xe202, 'Thin');
+  static const dotsThreeCircleVertical = IconData(0xe202,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-three-outline-thin.svg)
-  static const dotsThreeOutline = PhosphorFlatIconData(0xe204, 'Thin');
+  static const dotsThreeOutline = IconData(0xe204,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-outline-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-three-outline-vertical-thin.svg)
-  static const dotsThreeOutlineVertical = PhosphorFlatIconData(0xe206, 'Thin');
+  static const dotsThreeOutlineVertical = IconData(0xe206,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dots-three-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dots-three-vertical-thin.svg)
-  static const dotsThreeVertical = PhosphorFlatIconData(0xe208, 'Thin');
+  static const dotsThreeVertical = IconData(0xe208,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/download-thin.svg)
-  static const download = PhosphorFlatIconData(0xe20a, 'Thin');
+  static const download = IconData(0xe20a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![download-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/download-simple-thin.svg)
-  static const downloadSimple = PhosphorFlatIconData(0xe20c, 'Thin');
+  static const downloadSimple = IconData(0xe20c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dress-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dress-thin.svg)
-  static const dress = PhosphorFlatIconData(0xea7e, 'Thin');
+  static const dress = IconData(0xea7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dresser-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dresser-thin.svg)
-  static const dresser = PhosphorFlatIconData(0xe94e, 'Thin');
+  static const dresser = IconData(0xe94e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dribbble-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dribbble-logo-thin.svg)
-  static const dribbbleLogo = PhosphorFlatIconData(0xe20e, 'Thin');
+  static const dribbbleLogo = IconData(0xe20e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drone-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/drone-thin.svg)
-  static const drone = PhosphorFlatIconData(0xed74, 'Thin');
+  static const drone = IconData(0xed74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/drop-thin.svg)
-  static const drop = PhosphorFlatIconData(0xe210, 'Thin');
+  static const drop = IconData(0xe210,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/drop-half-thin.svg)
-  static const dropHalf = PhosphorFlatIconData(0xe566, 'Thin');
+  static const dropHalf = IconData(0xe566,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-half-bottom-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/drop-half-bottom-thin.svg)
-  static const dropHalfBottom = PhosphorFlatIconData(0xeb40, 'Thin');
+  static const dropHalfBottom = IconData(0xeb40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/drop-simple-thin.svg)
-  static const dropSimple = PhosphorFlatIconData(0xee32, 'Thin');
+  static const dropSimple = IconData(0xee32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![drop-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/drop-slash-thin.svg)
-  static const dropSlash = PhosphorFlatIconData(0xe954, 'Thin');
+  static const dropSlash = IconData(0xe954,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![dropbox-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/dropbox-logo-thin.svg)
-  static const dropboxLogo = PhosphorFlatIconData(0xe7d0, 'Thin');
+  static const dropboxLogo = IconData(0xe7d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ear-thin.svg)
-  static const ear = PhosphorFlatIconData(0xe70c, 'Thin');
+  static const ear = IconData(0xe70c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ear-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ear-slash-thin.svg)
-  static const earSlash = PhosphorFlatIconData(0xe70e, 'Thin');
+  static const earSlash = IconData(0xe70e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/egg-thin.svg)
-  static const egg = PhosphorFlatIconData(0xe812, 'Thin');
+  static const egg = IconData(0xe812,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![egg-crack-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/egg-crack-thin.svg)
-  static const eggCrack = PhosphorFlatIconData(0xeb64, 'Thin');
+  static const eggCrack = IconData(0xeb64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eject-thin.svg)
-  static const eject = PhosphorFlatIconData(0xe212, 'Thin');
+  static const eject = IconData(0xe212,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eject-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eject-simple-thin.svg)
-  static const ejectSimple = PhosphorFlatIconData(0xe6ae, 'Thin');
+  static const ejectSimple = IconData(0xe6ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![elevator-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/elevator-thin.svg)
-  static const elevator = PhosphorFlatIconData(0xecc0, 'Thin');
+  static const elevator = IconData(0xecc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![empty-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/empty-thin.svg)
-  static const empty = PhosphorFlatIconData(0xedbc, 'Thin');
+  static const empty = IconData(0xedbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![engine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/engine-thin.svg)
-  static const engine = PhosphorFlatIconData(0xea80, 'Thin');
+  static const engine = IconData(0xea80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/envelope-thin.svg)
-  static const envelope = PhosphorFlatIconData(0xe214, 'Thin');
+  static const envelope = IconData(0xe214,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/envelope-open-thin.svg)
-  static const envelopeOpen = PhosphorFlatIconData(0xe216, 'Thin');
+  static const envelopeOpen = IconData(0xe216,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/envelope-simple-thin.svg)
-  static const envelopeSimple = PhosphorFlatIconData(0xe218, 'Thin');
+  static const envelopeSimple = IconData(0xe218,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![envelope-simple-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/envelope-simple-open-thin.svg)
-  static const envelopeSimpleOpen = PhosphorFlatIconData(0xe21a, 'Thin');
+  static const envelopeSimpleOpen = IconData(0xe21a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equalizer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/equalizer-thin.svg)
-  static const equalizer = PhosphorFlatIconData(0xebbc, 'Thin');
+  static const equalizer = IconData(0xebbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![equals-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/equals-thin.svg)
-  static const equals = PhosphorFlatIconData(0xe21c, 'Thin');
+  static const equals = IconData(0xe21c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eraser-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eraser-thin.svg)
-  static const eraser = PhosphorFlatIconData(0xe21e, 'Thin');
+  static const eraser = IconData(0xe21e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/escalator-down-thin.svg)
-  static const escalatorDown = PhosphorFlatIconData(0xecba, 'Thin');
+  static const escalatorDown = IconData(0xecba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![escalator-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/escalator-up-thin.svg)
-  static const escalatorUp = PhosphorFlatIconData(0xecbc, 'Thin');
+  static const escalatorUp = IconData(0xecbc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exam-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/exam-thin.svg)
-  static const exam = PhosphorFlatIconData(0xe742, 'Thin');
+  static const exam = IconData(0xe742,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclamation-mark-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/exclamation-mark-thin.svg)
-  static const exclamationMark = PhosphorFlatIconData(0xee44, 'Thin');
+  static const exclamationMark = IconData(0xee44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/exclude-thin.svg)
-  static const exclude = PhosphorFlatIconData(0xe882, 'Thin');
+  static const exclude = IconData(0xe882,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![exclude-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/exclude-square-thin.svg)
-  static const excludeSquare = PhosphorFlatIconData(0xe880, 'Thin');
+  static const excludeSquare = IconData(0xe880,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![export-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/export-thin.svg)
-  static const export = PhosphorFlatIconData(0xeaf0, 'Thin');
+  static const export = IconData(0xeaf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eye-thin.svg)
-  static const eye = PhosphorFlatIconData(0xe220, 'Thin');
+  static const eye = IconData(0xe220,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-closed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eye-closed-thin.svg)
-  static const eyeClosed = PhosphorFlatIconData(0xe222, 'Thin');
+  static const eyeClosed = IconData(0xe222,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eye-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eye-slash-thin.svg)
-  static const eyeSlash = PhosphorFlatIconData(0xe224, 'Thin');
+  static const eyeSlash = IconData(0xe224,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eyedropper-thin.svg)
-  static const eyedropper = PhosphorFlatIconData(0xe568, 'Thin');
+  static const eyedropper = IconData(0xe568,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyedropper-sample-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eyedropper-sample-thin.svg)
-  static const eyedropperSample = PhosphorFlatIconData(0xeac4, 'Thin');
+  static const eyedropperSample = IconData(0xeac4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyeglasses-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eyeglasses-thin.svg)
-  static const eyeglasses = PhosphorFlatIconData(0xe7ba, 'Thin');
+  static const eyeglasses = IconData(0xe7ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![eyes-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/eyes-thin.svg)
-  static const eyes = PhosphorFlatIconData(0xee5c, 'Thin');
+  static const eyes = IconData(0xee5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![face-mask-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/face-mask-thin.svg)
-  static const faceMask = PhosphorFlatIconData(0xe56a, 'Thin');
+  static const faceMask = IconData(0xe56a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![facebook-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/facebook-logo-thin.svg)
-  static const facebookLogo = PhosphorFlatIconData(0xe226, 'Thin');
+  static const facebookLogo = IconData(0xe226,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![factory-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/factory-thin.svg)
-  static const factory = PhosphorFlatIconData(0xe760, 'Thin');
+  static const factory = IconData(0xe760,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/faders-thin.svg)
-  static const faders = PhosphorFlatIconData(0xe228, 'Thin');
+  static const faders = IconData(0xe228,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![faders-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/faders-horizontal-thin.svg)
-  static const fadersHorizontal = PhosphorFlatIconData(0xe22a, 'Thin');
+  static const fadersHorizontal = IconData(0xe22a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fallout-shelter-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fallout-shelter-thin.svg)
-  static const falloutShelter = PhosphorFlatIconData(0xe9de, 'Thin');
+  static const falloutShelter = IconData(0xe9de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fan-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fan-thin.svg)
-  static const fan = PhosphorFlatIconData(0xe9f2, 'Thin');
+  static const fan = IconData(0xe9f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![farm-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/farm-thin.svg)
-  static const farm = PhosphorFlatIconData(0xec70, 'Thin');
+  static const farm = IconData(0xec70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fast-forward-thin.svg)
-  static const fastForward = PhosphorFlatIconData(0xe6a6, 'Thin');
+  static const fastForward = IconData(0xe6a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fast-forward-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fast-forward-circle-thin.svg)
-  static const fastForwardCircle = PhosphorFlatIconData(0xe22c, 'Thin');
+  static const fastForwardCircle = IconData(0xe22c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![feather-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/feather-thin.svg)
-  static const feather = PhosphorFlatIconData(0xe9c0, 'Thin');
+  static const feather = IconData(0xe9c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fediverse-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fediverse-logo-thin.svg)
-  static const fediverseLogo = PhosphorFlatIconData(0xed66, 'Thin');
+  static const fediverseLogo = IconData(0xed66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![figma-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/figma-logo-thin.svg)
-  static const figmaLogo = PhosphorFlatIconData(0xe22e, 'Thin');
+  static const figmaLogo = IconData(0xe22e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-thin.svg)
-  static const file = PhosphorFlatIconData(0xe230, 'Thin');
+  static const file = IconData(0xe230,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-archive-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-archive-thin.svg)
-  static const fileArchive = PhosphorFlatIconData(0xeb2a, 'Thin');
+  static const fileArchive = IconData(0xeb2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-arrow-down-thin.svg)
-  static const fileArrowDown = PhosphorFlatIconData(0xe232, 'Thin');
+  static const fileArrowDown = IconData(0xe232,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-arrow-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-arrow-up-thin.svg)
-  static const fileArrowUp = PhosphorFlatIconData(0xe61e, 'Thin');
+  static const fileArrowUp = IconData(0xe61e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-audio-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-audio-thin.svg)
-  static const fileAudio = PhosphorFlatIconData(0xea20, 'Thin');
+  static const fileAudio = IconData(0xea20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-c-thin.svg)
-  static const fileC = PhosphorFlatIconData(0xeb32, 'Thin');
+  static const fileC = IconData(0xeb32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-c-sharp-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-c-sharp-thin.svg)
-  static const fileCSharp = PhosphorFlatIconData(0xeb30, 'Thin');
+  static const fileCSharp = IconData(0xeb30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cloud-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-cloud-thin.svg)
-  static const fileCloud = PhosphorFlatIconData(0xe95e, 'Thin');
+  static const fileCloud = IconData(0xe95e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-code-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-code-thin.svg)
-  static const fileCode = PhosphorFlatIconData(0xe914, 'Thin');
+  static const fileCode = IconData(0xe914,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-cpp-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-cpp-thin.svg)
-  static const fileCpp = PhosphorFlatIconData(0xeb2e, 'Thin');
+  static const fileCpp = IconData(0xeb2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-css-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-css-thin.svg)
-  static const fileCss = PhosphorFlatIconData(0xeb34, 'Thin');
+  static const fileCss = IconData(0xeb34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-csv-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-csv-thin.svg)
-  static const fileCsv = PhosphorFlatIconData(0xeb1c, 'Thin');
+  static const fileCsv = IconData(0xeb1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-dashed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-dashed-thin.svg)
-  static const fileDashed = PhosphorFlatIconData(0xe704, 'Thin');
+  static const fileDashed = IconData(0xe704,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-doc-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-doc-thin.svg)
-  static const fileDoc = PhosphorFlatIconData(0xeb1e, 'Thin');
+  static const fileDoc = IconData(0xeb1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-html-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-html-thin.svg)
-  static const fileHtml = PhosphorFlatIconData(0xeb38, 'Thin');
+  static const fileHtml = IconData(0xeb38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-image-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-image-thin.svg)
-  static const fileImage = PhosphorFlatIconData(0xea24, 'Thin');
+  static const fileImage = IconData(0xea24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ini-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-ini-thin.svg)
-  static const fileIni = PhosphorFlatIconData(0xeb33, 'Thin');
+  static const fileIni = IconData(0xeb33,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jpg-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-jpg-thin.svg)
-  static const fileJpg = PhosphorFlatIconData(0xeb1a, 'Thin');
+  static const fileJpg = IconData(0xeb1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-js-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-js-thin.svg)
-  static const fileJs = PhosphorFlatIconData(0xeb24, 'Thin');
+  static const fileJs = IconData(0xeb24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-jsx-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-jsx-thin.svg)
-  static const fileJsx = PhosphorFlatIconData(0xeb3a, 'Thin');
+  static const fileJsx = IconData(0xeb3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-lock-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-lock-thin.svg)
-  static const fileLock = PhosphorFlatIconData(0xe95c, 'Thin');
+  static const fileLock = IconData(0xe95c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-magnifying-glass-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-magnifying-glass-thin.svg)
-  static const fileMagnifyingGlass = PhosphorFlatIconData(0xe238, 'Thin');
+  static const fileMagnifyingGlass = IconData(0xe238,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-md-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-md-thin.svg)
-  static const fileMd = PhosphorFlatIconData(0xed50, 'Thin');
+  static const fileMd = IconData(0xed50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-minus-thin.svg)
-  static const fileMinus = PhosphorFlatIconData(0xe234, 'Thin');
+  static const fileMinus = IconData(0xe234,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-pdf-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-pdf-thin.svg)
-  static const filePdf = PhosphorFlatIconData(0xe702, 'Thin');
+  static const filePdf = IconData(0xe702,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-plus-thin.svg)
-  static const filePlus = PhosphorFlatIconData(0xe236, 'Thin');
+  static const filePlus = IconData(0xe236,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-png-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-png-thin.svg)
-  static const filePng = PhosphorFlatIconData(0xeb18, 'Thin');
+  static const filePng = IconData(0xeb18,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ppt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-ppt-thin.svg)
-  static const filePpt = PhosphorFlatIconData(0xeb20, 'Thin');
+  static const filePpt = IconData(0xeb20,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-py-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-py-thin.svg)
-  static const filePy = PhosphorFlatIconData(0xeb2c, 'Thin');
+  static const filePy = IconData(0xeb2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-rs-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-rs-thin.svg)
-  static const fileRs = PhosphorFlatIconData(0xeb28, 'Thin');
+  static const fileRs = IconData(0xeb28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-sql-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-sql-thin.svg)
-  static const fileSql = PhosphorFlatIconData(0xed4e, 'Thin');
+  static const fileSql = IconData(0xed4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-svg-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-svg-thin.svg)
-  static const fileSvg = PhosphorFlatIconData(0xed08, 'Thin');
+  static const fileSvg = IconData(0xed08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-text-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-text-thin.svg)
-  static const fileText = PhosphorFlatIconData(0xe23a, 'Thin');
+  static const fileText = IconData(0xe23a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-ts-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-ts-thin.svg)
-  static const fileTs = PhosphorFlatIconData(0xeb26, 'Thin');
+  static const fileTs = IconData(0xeb26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-tsx-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-tsx-thin.svg)
-  static const fileTsx = PhosphorFlatIconData(0xeb3c, 'Thin');
+  static const fileTsx = IconData(0xeb3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-txt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-txt-thin.svg)
-  static const fileTxt = PhosphorFlatIconData(0xeb35, 'Thin');
+  static const fileTxt = IconData(0xeb35,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-video-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-video-thin.svg)
-  static const fileVideo = PhosphorFlatIconData(0xea22, 'Thin');
+  static const fileVideo = IconData(0xea22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-vue-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-vue-thin.svg)
-  static const fileVue = PhosphorFlatIconData(0xeb3e, 'Thin');
+  static const fileVue = IconData(0xeb3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-x-thin.svg)
-  static const fileX = PhosphorFlatIconData(0xe23c, 'Thin');
+  static const fileX = IconData(0xe23c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-xls-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-xls-thin.svg)
-  static const fileXls = PhosphorFlatIconData(0xeb22, 'Thin');
+  static const fileXls = IconData(0xeb22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![file-zip-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/file-zip-thin.svg)
-  static const fileZip = PhosphorFlatIconData(0xe958, 'Thin');
+  static const fileZip = IconData(0xe958,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![files-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/files-thin.svg)
-  static const files = PhosphorFlatIconData(0xe710, 'Thin');
+  static const files = IconData(0xe710,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-reel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/film-reel-thin.svg)
-  static const filmReel = PhosphorFlatIconData(0xe8c0, 'Thin');
+  static const filmReel = IconData(0xe8c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-script-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/film-script-thin.svg)
-  static const filmScript = PhosphorFlatIconData(0xeb50, 'Thin');
+  static const filmScript = IconData(0xeb50,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-slate-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/film-slate-thin.svg)
-  static const filmSlate = PhosphorFlatIconData(0xe8c2, 'Thin');
+  static const filmSlate = IconData(0xe8c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![film-strip-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/film-strip-thin.svg)
-  static const filmStrip = PhosphorFlatIconData(0xe792, 'Thin');
+  static const filmStrip = IconData(0xe792,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fingerprint-thin.svg)
-  static const fingerprint = PhosphorFlatIconData(0xe23e, 'Thin');
+  static const fingerprint = IconData(0xe23e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fingerprint-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fingerprint-simple-thin.svg)
-  static const fingerprintSimple = PhosphorFlatIconData(0xe240, 'Thin');
+  static const fingerprintSimple = IconData(0xe240,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![finn-the-human-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/finn-the-human-thin.svg)
-  static const finnTheHuman = PhosphorFlatIconData(0xe56c, 'Thin');
+  static const finnTheHuman = IconData(0xe56c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fire-thin.svg)
-  static const fire = PhosphorFlatIconData(0xe242, 'Thin');
+  static const fire = IconData(0xe242,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-extinguisher-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fire-extinguisher-thin.svg)
-  static const fireExtinguisher = PhosphorFlatIconData(0xe9e8, 'Thin');
+  static const fireExtinguisher = IconData(0xe9e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fire-simple-thin.svg)
-  static const fireSimple = PhosphorFlatIconData(0xe620, 'Thin');
+  static const fireSimple = IconData(0xe620,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fire-truck-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fire-truck-thin.svg)
-  static const fireTruck = PhosphorFlatIconData(0xe574, 'Thin');
+  static const fireTruck = IconData(0xe574,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/first-aid-thin.svg)
-  static const firstAid = PhosphorFlatIconData(0xe56e, 'Thin');
+  static const firstAid = IconData(0xe56e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![first-aid-kit-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/first-aid-kit-thin.svg)
-  static const firstAidKit = PhosphorFlatIconData(0xe570, 'Thin');
+  static const firstAidKit = IconData(0xe570,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fish-thin.svg)
-  static const fish = PhosphorFlatIconData(0xe728, 'Thin');
+  static const fish = IconData(0xe728,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fish-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fish-simple-thin.svg)
-  static const fishSimple = PhosphorFlatIconData(0xe72a, 'Thin');
+  static const fishSimple = IconData(0xe72a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flag-thin.svg)
-  static const flag = PhosphorFlatIconData(0xe244, 'Thin');
+  static const flag = IconData(0xe244,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flag-banner-thin.svg)
-  static const flagBanner = PhosphorFlatIconData(0xe622, 'Thin');
+  static const flagBanner = IconData(0xe622,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-banner-fold-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flag-banner-fold-thin.svg)
-  static const flagBannerFold = PhosphorFlatIconData(0xecf2, 'Thin');
+  static const flagBannerFold = IconData(0xecf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-checkered-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flag-checkered-thin.svg)
-  static const flagCheckered = PhosphorFlatIconData(0xea38, 'Thin');
+  static const flagCheckered = IconData(0xea38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flag-pennant-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flag-pennant-thin.svg)
-  static const flagPennant = PhosphorFlatIconData(0xecf0, 'Thin');
+  static const flagPennant = IconData(0xecf0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flame-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flame-thin.svg)
-  static const flame = PhosphorFlatIconData(0xe624, 'Thin');
+  static const flame = IconData(0xe624,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flashlight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flashlight-thin.svg)
-  static const flashlight = PhosphorFlatIconData(0xe246, 'Thin');
+  static const flashlight = IconData(0xe246,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flask-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flask-thin.svg)
-  static const flask = PhosphorFlatIconData(0xe79e, 'Thin');
+  static const flask = IconData(0xe79e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flip-horizontal-thin.svg)
-  static const flipHorizontal = PhosphorFlatIconData(0xed6a, 'Thin');
+  static const flipHorizontal = IconData(0xed6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flip-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flip-vertical-thin.svg)
-  static const flipVertical = PhosphorFlatIconData(0xed6c, 'Thin');
+  static const flipVertical = IconData(0xed6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/floppy-disk-thin.svg)
-  static const floppyDisk = PhosphorFlatIconData(0xe248, 'Thin');
+  static const floppyDisk = IconData(0xe248,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![floppy-disk-back-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/floppy-disk-back-thin.svg)
-  static const floppyDiskBack = PhosphorFlatIconData(0xeaf4, 'Thin');
+  static const floppyDiskBack = IconData(0xeaf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flow-arrow-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flow-arrow-thin.svg)
-  static const flowArrow = PhosphorFlatIconData(0xe6ec, 'Thin');
+  static const flowArrow = IconData(0xe6ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flower-thin.svg)
-  static const flower = PhosphorFlatIconData(0xe75e, 'Thin');
+  static const flower = IconData(0xe75e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-lotus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flower-lotus-thin.svg)
-  static const flowerLotus = PhosphorFlatIconData(0xe6cc, 'Thin');
+  static const flowerLotus = IconData(0xe6cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flower-tulip-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flower-tulip-thin.svg)
-  static const flowerTulip = PhosphorFlatIconData(0xeacc, 'Thin');
+  static const flowerTulip = IconData(0xeacc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![flying-saucer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/flying-saucer-thin.svg)
-  static const flyingSaucer = PhosphorFlatIconData(0xeb4a, 'Thin');
+  static const flyingSaucer = IconData(0xeb4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-thin.svg)
-  static const folder = PhosphorFlatIconData(0xe24a, 'Thin');
+  static const folder = IconData(0xe24a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-dashed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-dashed-thin.svg)
-  static const folderDashed = PhosphorFlatIconData(0xe8f8, 'Thin');
+  static const folderDashed = IconData(0xe8f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-lock-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-lock-thin.svg)
-  static const folderLock = PhosphorFlatIconData(0xea3c, 'Thin');
+  static const folderLock = IconData(0xea3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-minus-thin.svg)
-  static const folderMinus = PhosphorFlatIconData(0xe254, 'Thin');
+  static const folderMinus = IconData(0xe254,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-open-thin.svg)
-  static const folderOpen = PhosphorFlatIconData(0xe256, 'Thin');
+  static const folderOpen = IconData(0xe256,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-plus-thin.svg)
-  static const folderPlus = PhosphorFlatIconData(0xe258, 'Thin');
+  static const folderPlus = IconData(0xe258,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-simple-thin.svg)
-  static const folderSimple = PhosphorFlatIconData(0xe25a, 'Thin');
+  static const folderSimple = IconData(0xe25a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-dashed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-simple-dashed-thin.svg)
-  static const folderSimpleDashed = PhosphorFlatIconData(0xec2a, 'Thin');
+  static const folderSimpleDashed = IconData(0xec2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-lock-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-simple-lock-thin.svg)
-  static const folderSimpleLock = PhosphorFlatIconData(0xeb5e, 'Thin');
+  static const folderSimpleLock = IconData(0xeb5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-simple-minus-thin.svg)
-  static const folderSimpleMinus = PhosphorFlatIconData(0xe25c, 'Thin');
+  static const folderSimpleMinus = IconData(0xe25c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-simple-plus-thin.svg)
-  static const folderSimplePlus = PhosphorFlatIconData(0xe25e, 'Thin');
+  static const folderSimplePlus = IconData(0xe25e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-star-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-simple-star-thin.svg)
-  static const folderSimpleStar = PhosphorFlatIconData(0xec2e, 'Thin');
+  static const folderSimpleStar = IconData(0xec2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-simple-user-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-simple-user-thin.svg)
-  static const folderSimpleUser = PhosphorFlatIconData(0xeb60, 'Thin');
+  static const folderSimpleUser = IconData(0xeb60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-star-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-star-thin.svg)
-  static const folderStar = PhosphorFlatIconData(0xea86, 'Thin');
+  static const folderStar = IconData(0xea86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folder-user-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folder-user-thin.svg)
-  static const folderUser = PhosphorFlatIconData(0xeb46, 'Thin');
+  static const folderUser = IconData(0xeb46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![folders-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/folders-thin.svg)
-  static const folders = PhosphorFlatIconData(0xe260, 'Thin');
+  static const folders = IconData(0xe260,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/football-thin.svg)
-  static const football = PhosphorFlatIconData(0xe718, 'Thin');
+  static const football = IconData(0xe718,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![football-helmet-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/football-helmet-thin.svg)
-  static const footballHelmet = PhosphorFlatIconData(0xee4c, 'Thin');
+  static const footballHelmet = IconData(0xee4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![footprints-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/footprints-thin.svg)
-  static const footprints = PhosphorFlatIconData(0xea88, 'Thin');
+  static const footprints = IconData(0xea88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![fork-knife-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/fork-knife-thin.svg)
-  static const forkKnife = PhosphorFlatIconData(0xe262, 'Thin');
+  static const forkKnife = IconData(0xe262,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![four-k-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/four-k-thin.svg)
-  static const fourK = PhosphorFlatIconData(0xea5c, 'Thin');
+  static const fourK = IconData(0xea5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![frame-corners-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/frame-corners-thin.svg)
-  static const frameCorners = PhosphorFlatIconData(0xe626, 'Thin');
+  static const frameCorners = IconData(0xe626,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![framer-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/framer-logo-thin.svg)
-  static const framerLogo = PhosphorFlatIconData(0xe264, 'Thin');
+  static const framerLogo = IconData(0xe264,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![function-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/function-thin.svg)
-  static const function = PhosphorFlatIconData(0xebe4, 'Thin');
+  static const function = IconData(0xebe4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/funnel-thin.svg)
-  static const funnel = PhosphorFlatIconData(0xe266, 'Thin');
+  static const funnel = IconData(0xe266,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/funnel-simple-thin.svg)
-  static const funnelSimple = PhosphorFlatIconData(0xe268, 'Thin');
+  static const funnelSimple = IconData(0xe268,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-simple-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/funnel-simple-x-thin.svg)
-  static const funnelSimpleX = PhosphorFlatIconData(0xe26a, 'Thin');
+  static const funnelSimpleX = IconData(0xe26a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![funnel-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/funnel-x-thin.svg)
-  static const funnelX = PhosphorFlatIconData(0xe26c, 'Thin');
+  static const funnelX = IconData(0xe26c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![game-controller-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/game-controller-thin.svg)
-  static const gameController = PhosphorFlatIconData(0xe26e, 'Thin');
+  static const gameController = IconData(0xe26e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![garage-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/garage-thin.svg)
-  static const garage = PhosphorFlatIconData(0xecd6, 'Thin');
+  static const garage = IconData(0xecd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-can-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gas-can-thin.svg)
-  static const gasCan = PhosphorFlatIconData(0xe8ce, 'Thin');
+  static const gasCan = IconData(0xe8ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gas-pump-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gas-pump-thin.svg)
-  static const gasPump = PhosphorFlatIconData(0xe768, 'Thin');
+  static const gasPump = IconData(0xe768,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gauge-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gauge-thin.svg)
-  static const gauge = PhosphorFlatIconData(0xe628, 'Thin');
+  static const gauge = IconData(0xe628,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gavel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gavel-thin.svg)
-  static const gavel = PhosphorFlatIconData(0xea32, 'Thin');
+  static const gavel = IconData(0xea32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gear-thin.svg)
-  static const gear = PhosphorFlatIconData(0xe270, 'Thin');
+  static const gear = IconData(0xe270,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-fine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gear-fine-thin.svg)
-  static const gearFine = PhosphorFlatIconData(0xe87c, 'Thin');
+  static const gearFine = IconData(0xe87c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gear-six-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gear-six-thin.svg)
-  static const gearSix = PhosphorFlatIconData(0xe272, 'Thin');
+  static const gearSix = IconData(0xe272,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-female-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gender-female-thin.svg)
-  static const genderFemale = PhosphorFlatIconData(0xe6e0, 'Thin');
+  static const genderFemale = IconData(0xe6e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-intersex-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gender-intersex-thin.svg)
-  static const genderIntersex = PhosphorFlatIconData(0xe6e6, 'Thin');
+  static const genderIntersex = IconData(0xe6e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-male-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gender-male-thin.svg)
-  static const genderMale = PhosphorFlatIconData(0xe6e2, 'Thin');
+  static const genderMale = IconData(0xe6e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-neuter-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gender-neuter-thin.svg)
-  static const genderNeuter = PhosphorFlatIconData(0xe6ea, 'Thin');
+  static const genderNeuter = IconData(0xe6ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-nonbinary-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gender-nonbinary-thin.svg)
-  static const genderNonbinary = PhosphorFlatIconData(0xe6e4, 'Thin');
+  static const genderNonbinary = IconData(0xe6e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gender-transgender-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gender-transgender-thin.svg)
-  static const genderTransgender = PhosphorFlatIconData(0xe6e8, 'Thin');
+  static const genderTransgender = IconData(0xe6e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ghost-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ghost-thin.svg)
-  static const ghost = PhosphorFlatIconData(0xe62a, 'Thin');
+  static const ghost = IconData(0xe62a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gif-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gif-thin.svg)
-  static const gif = PhosphorFlatIconData(0xe274, 'Thin');
+  static const gif = IconData(0xe274,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gift-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gift-thin.svg)
-  static const gift = PhosphorFlatIconData(0xe276, 'Thin');
+  static const gift = IconData(0xe276,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-branch-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/git-branch-thin.svg)
-  static const gitBranch = PhosphorFlatIconData(0xe278, 'Thin');
+  static const gitBranch = IconData(0xe278,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-commit-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/git-commit-thin.svg)
-  static const gitCommit = PhosphorFlatIconData(0xe27a, 'Thin');
+  static const gitCommit = IconData(0xe27a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-diff-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/git-diff-thin.svg)
-  static const gitDiff = PhosphorFlatIconData(0xe27c, 'Thin');
+  static const gitDiff = IconData(0xe27c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-fork-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/git-fork-thin.svg)
-  static const gitFork = PhosphorFlatIconData(0xe27e, 'Thin');
+  static const gitFork = IconData(0xe27e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-merge-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/git-merge-thin.svg)
-  static const gitMerge = PhosphorFlatIconData(0xe280, 'Thin');
+  static const gitMerge = IconData(0xe280,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![git-pull-request-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/git-pull-request-thin.svg)
-  static const gitPullRequest = PhosphorFlatIconData(0xe282, 'Thin');
+  static const gitPullRequest = IconData(0xe282,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![github-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/github-logo-thin.svg)
-  static const githubLogo = PhosphorFlatIconData(0xe576, 'Thin');
+  static const githubLogo = IconData(0xe576,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gitlab-logo-thin.svg)
-  static const gitlabLogo = PhosphorFlatIconData(0xe694, 'Thin');
+  static const gitlabLogo = IconData(0xe694,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gitlab-logo-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gitlab-logo-simple-thin.svg)
-  static const gitlabLogoSimple = PhosphorFlatIconData(0xe696, 'Thin');
+  static const gitlabLogoSimple = IconData(0xe696,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/globe-thin.svg)
-  static const globe = PhosphorFlatIconData(0xe288, 'Thin');
+  static const globe = IconData(0xe288,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-east-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/globe-hemisphere-east-thin.svg)
-  static const globeHemisphereEast = PhosphorFlatIconData(0xe28a, 'Thin');
+  static const globeHemisphereEast = IconData(0xe28a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-hemisphere-west-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/globe-hemisphere-west-thin.svg)
-  static const globeHemisphereWest = PhosphorFlatIconData(0xe28c, 'Thin');
+  static const globeHemisphereWest = IconData(0xe28c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/globe-simple-thin.svg)
-  static const globeSimple = PhosphorFlatIconData(0xe28e, 'Thin');
+  static const globeSimple = IconData(0xe28e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-simple-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/globe-simple-x-thin.svg)
-  static const globeSimpleX = PhosphorFlatIconData(0xe284, 'Thin');
+  static const globeSimpleX = IconData(0xe284,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-stand-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/globe-stand-thin.svg)
-  static const globeStand = PhosphorFlatIconData(0xe290, 'Thin');
+  static const globeStand = IconData(0xe290,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![globe-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/globe-x-thin.svg)
-  static const globeX = PhosphorFlatIconData(0xe286, 'Thin');
+  static const globeX = IconData(0xe286,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goggles-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/goggles-thin.svg)
-  static const goggles = PhosphorFlatIconData(0xecb4, 'Thin');
+  static const goggles = IconData(0xecb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![golf-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/golf-thin.svg)
-  static const golf = PhosphorFlatIconData(0xea3e, 'Thin');
+  static const golf = IconData(0xea3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![goodreads-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/goodreads-logo-thin.svg)
-  static const goodreadsLogo = PhosphorFlatIconData(0xed10, 'Thin');
+  static const goodreadsLogo = IconData(0xed10,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-cardboard-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/google-cardboard-logo-thin.svg)
-  static const googleCardboardLogo = PhosphorFlatIconData(0xe7b6, 'Thin');
+  static const googleCardboardLogo = IconData(0xe7b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-chrome-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/google-chrome-logo-thin.svg)
-  static const googleChromeLogo = PhosphorFlatIconData(0xe976, 'Thin');
+  static const googleChromeLogo = IconData(0xe976,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-drive-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/google-drive-logo-thin.svg)
-  static const googleDriveLogo = PhosphorFlatIconData(0xe8f6, 'Thin');
+  static const googleDriveLogo = IconData(0xe8f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/google-logo-thin.svg)
-  static const googleLogo = PhosphorFlatIconData(0xe292, 'Thin');
+  static const googleLogo = IconData(0xe292,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-photos-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/google-photos-logo-thin.svg)
-  static const googlePhotosLogo = PhosphorFlatIconData(0xeb92, 'Thin');
+  static const googlePhotosLogo = IconData(0xeb92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-play-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/google-play-logo-thin.svg)
-  static const googlePlayLogo = PhosphorFlatIconData(0xe294, 'Thin');
+  static const googlePlayLogo = IconData(0xe294,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![google-podcasts-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/google-podcasts-logo-thin.svg)
-  static const googlePodcastsLogo = PhosphorFlatIconData(0xeb94, 'Thin');
+  static const googlePodcastsLogo = IconData(0xeb94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gps-thin.svg)
-  static const gps = PhosphorFlatIconData(0xedd8, 'Thin');
+  static const gps = IconData(0xedd8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-fix-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gps-fix-thin.svg)
-  static const gpsFix = PhosphorFlatIconData(0xedd6, 'Thin');
+  static const gpsFix = IconData(0xedd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gps-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gps-slash-thin.svg)
-  static const gpsSlash = PhosphorFlatIconData(0xedd4, 'Thin');
+  static const gpsSlash = IconData(0xedd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![gradient-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/gradient-thin.svg)
-  static const gradient = PhosphorFlatIconData(0xeb42, 'Thin');
+  static const gradient = IconData(0xeb42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graduation-cap-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/graduation-cap-thin.svg)
-  static const graduationCap = PhosphorFlatIconData(0xe62c, 'Thin');
+  static const graduationCap = IconData(0xe62c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/grains-thin.svg)
-  static const grains = PhosphorFlatIconData(0xec68, 'Thin');
+  static const grains = IconData(0xec68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grains-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/grains-slash-thin.svg)
-  static const grainsSlash = PhosphorFlatIconData(0xec6a, 'Thin');
+  static const grainsSlash = IconData(0xec6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graph-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/graph-thin.svg)
-  static const graph = PhosphorFlatIconData(0xeb58, 'Thin');
+  static const graph = IconData(0xeb58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![graphics-card-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/graphics-card-thin.svg)
-  static const graphicsCard = PhosphorFlatIconData(0xe612, 'Thin');
+  static const graphicsCard = IconData(0xe612,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/greater-than-thin.svg)
-  static const greaterThan = PhosphorFlatIconData(0xedc4, 'Thin');
+  static const greaterThan = IconData(0xedc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![greater-than-or-equal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/greater-than-or-equal-thin.svg)
-  static const greaterThanOrEqual = PhosphorFlatIconData(0xeda2, 'Thin');
+  static const greaterThanOrEqual = IconData(0xeda2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/grid-four-thin.svg)
-  static const gridFour = PhosphorFlatIconData(0xe296, 'Thin');
+  static const gridFour = IconData(0xe296,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![grid-nine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/grid-nine-thin.svg)
-  static const gridNine = PhosphorFlatIconData(0xec8c, 'Thin');
+  static const gridNine = IconData(0xec8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![guitar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/guitar-thin.svg)
-  static const guitar = PhosphorFlatIconData(0xea8a, 'Thin');
+  static const guitar = IconData(0xea8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hair-dryer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hair-dryer-thin.svg)
-  static const hairDryer = PhosphorFlatIconData(0xea66, 'Thin');
+  static const hairDryer = IconData(0xea66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hamburger-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hamburger-thin.svg)
-  static const hamburger = PhosphorFlatIconData(0xe790, 'Thin');
+  static const hamburger = IconData(0xe790,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hammer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hammer-thin.svg)
-  static const hammer = PhosphorFlatIconData(0xe80e, 'Thin');
+  static const hammer = IconData(0xe80e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-thin.svg)
-  static const hand = PhosphorFlatIconData(0xe298, 'Thin');
+  static const hand = IconData(0xe298,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-arrow-down-thin.svg)
-  static const handArrowDown = PhosphorFlatIconData(0xea4e, 'Thin');
+  static const handArrowDown = IconData(0xea4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-arrow-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-arrow-up-thin.svg)
-  static const handArrowUp = PhosphorFlatIconData(0xee5a, 'Thin');
+  static const handArrowUp = IconData(0xee5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-coins-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-coins-thin.svg)
-  static const handCoins = PhosphorFlatIconData(0xea8c, 'Thin');
+  static const handCoins = IconData(0xea8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-deposit-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-deposit-thin.svg)
-  static const handDeposit = PhosphorFlatIconData(0xee82, 'Thin');
+  static const handDeposit = IconData(0xee82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-eye-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-eye-thin.svg)
-  static const handEye = PhosphorFlatIconData(0xea4c, 'Thin');
+  static const handEye = IconData(0xea4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-fist-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-fist-thin.svg)
-  static const handFist = PhosphorFlatIconData(0xe57a, 'Thin');
+  static const handFist = IconData(0xe57a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-grabbing-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-grabbing-thin.svg)
-  static const handGrabbing = PhosphorFlatIconData(0xe57c, 'Thin');
+  static const handGrabbing = IconData(0xe57c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-heart-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-heart-thin.svg)
-  static const handHeart = PhosphorFlatIconData(0xe810, 'Thin');
+  static const handHeart = IconData(0xe810,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-palm-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-palm-thin.svg)
-  static const handPalm = PhosphorFlatIconData(0xe57e, 'Thin');
+  static const handPalm = IconData(0xe57e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-peace-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-peace-thin.svg)
-  static const handPeace = PhosphorFlatIconData(0xe7cc, 'Thin');
+  static const handPeace = IconData(0xe7cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-pointing-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-pointing-thin.svg)
-  static const handPointing = PhosphorFlatIconData(0xe29a, 'Thin');
+  static const handPointing = IconData(0xe29a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-soap-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-soap-thin.svg)
-  static const handSoap = PhosphorFlatIconData(0xe630, 'Thin');
+  static const handSoap = IconData(0xe630,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-swipe-left-thin.svg)
-  static const handSwipeLeft = PhosphorFlatIconData(0xec94, 'Thin');
+  static const handSwipeLeft = IconData(0xec94,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-swipe-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-swipe-right-thin.svg)
-  static const handSwipeRight = PhosphorFlatIconData(0xec92, 'Thin');
+  static const handSwipeRight = IconData(0xec92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-tap-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-tap-thin.svg)
-  static const handTap = PhosphorFlatIconData(0xec90, 'Thin');
+  static const handTap = IconData(0xec90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-waving-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-waving-thin.svg)
-  static const handWaving = PhosphorFlatIconData(0xe580, 'Thin');
+  static const handWaving = IconData(0xe580,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hand-withdraw-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hand-withdraw-thin.svg)
-  static const handWithdraw = PhosphorFlatIconData(0xee80, 'Thin');
+  static const handWithdraw = IconData(0xee80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/handbag-thin.svg)
-  static const handbag = PhosphorFlatIconData(0xe29c, 'Thin');
+  static const handbag = IconData(0xe29c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handbag-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/handbag-simple-thin.svg)
-  static const handbagSimple = PhosphorFlatIconData(0xe62e, 'Thin');
+  static const handbagSimple = IconData(0xe62e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-clapping-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hands-clapping-thin.svg)
-  static const handsClapping = PhosphorFlatIconData(0xe6a0, 'Thin');
+  static const handsClapping = IconData(0xe6a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hands-praying-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hands-praying-thin.svg)
-  static const handsPraying = PhosphorFlatIconData(0xecc8, 'Thin');
+  static const handsPraying = IconData(0xecc8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![handshake-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/handshake-thin.svg)
-  static const handshake = PhosphorFlatIconData(0xe582, 'Thin');
+  static const handshake = IconData(0xe582,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drive-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hard-drive-thin.svg)
-  static const hardDrive = PhosphorFlatIconData(0xe29e, 'Thin');
+  static const hardDrive = IconData(0xe29e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-drives-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hard-drives-thin.svg)
-  static const hardDrives = PhosphorFlatIconData(0xe2a0, 'Thin');
+  static const hardDrives = IconData(0xe2a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hard-hat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hard-hat-thin.svg)
-  static const hardHat = PhosphorFlatIconData(0xed46, 'Thin');
+  static const hardHat = IconData(0xed46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hash-thin.svg)
-  static const hash = PhosphorFlatIconData(0xe2a2, 'Thin');
+  static const hash = IconData(0xe2a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hash-straight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hash-straight-thin.svg)
-  static const hashStraight = PhosphorFlatIconData(0xe2a4, 'Thin');
+  static const hashStraight = IconData(0xe2a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![head-circuit-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/head-circuit-thin.svg)
-  static const headCircuit = PhosphorFlatIconData(0xe7d4, 'Thin');
+  static const headCircuit = IconData(0xe7d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headlights-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/headlights-thin.svg)
-  static const headlights = PhosphorFlatIconData(0xe6fe, 'Thin');
+  static const headlights = IconData(0xe6fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headphones-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/headphones-thin.svg)
-  static const headphones = PhosphorFlatIconData(0xe2a6, 'Thin');
+  static const headphones = IconData(0xe2a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![headset-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/headset-thin.svg)
-  static const headset = PhosphorFlatIconData(0xe584, 'Thin');
+  static const headset = IconData(0xe584,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/heart-thin.svg)
-  static const heart = PhosphorFlatIconData(0xe2a8, 'Thin');
+  static const heart = IconData(0xe2a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-break-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/heart-break-thin.svg)
-  static const heartBreak = PhosphorFlatIconData(0xebe8, 'Thin');
+  static const heartBreak = IconData(0xebe8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-half-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/heart-half-thin.svg)
-  static const heartHalf = PhosphorFlatIconData(0xec48, 'Thin');
+  static const heartHalf = IconData(0xec48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/heart-straight-thin.svg)
-  static const heartStraight = PhosphorFlatIconData(0xe2aa, 'Thin');
+  static const heartStraight = IconData(0xe2aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heart-straight-break-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/heart-straight-break-thin.svg)
-  static const heartStraightBreak = PhosphorFlatIconData(0xeb98, 'Thin');
+  static const heartStraightBreak = IconData(0xeb98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![heartbeat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/heartbeat-thin.svg)
-  static const heartbeat = PhosphorFlatIconData(0xe2ac, 'Thin');
+  static const heartbeat = IconData(0xe2ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hexagon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hexagon-thin.svg)
-  static const hexagon = PhosphorFlatIconData(0xe2ae, 'Thin');
+  static const hexagon = IconData(0xe2ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-definition-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/high-definition-thin.svg)
-  static const highDefinition = PhosphorFlatIconData(0xea8e, 'Thin');
+  static const highDefinition = IconData(0xea8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![high-heel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/high-heel-thin.svg)
-  static const highHeel = PhosphorFlatIconData(0xe8e8, 'Thin');
+  static const highHeel = IconData(0xe8e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/highlighter-thin.svg)
-  static const highlighter = PhosphorFlatIconData(0xec76, 'Thin');
+  static const highlighter = IconData(0xec76,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![highlighter-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/highlighter-circle-thin.svg)
-  static const highlighterCircle = PhosphorFlatIconData(0xe632, 'Thin');
+  static const highlighterCircle = IconData(0xe632,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hockey-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hockey-thin.svg)
-  static const hockey = PhosphorFlatIconData(0xec86, 'Thin');
+  static const hockey = IconData(0xec86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hoodie-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hoodie-thin.svg)
-  static const hoodie = PhosphorFlatIconData(0xecd0, 'Thin');
+  static const hoodie = IconData(0xecd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![horse-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/horse-thin.svg)
-  static const horse = PhosphorFlatIconData(0xe2b0, 'Thin');
+  static const horse = IconData(0xe2b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hospital-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hospital-thin.svg)
-  static const hospital = PhosphorFlatIconData(0xe844, 'Thin');
+  static const hospital = IconData(0xe844,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hourglass-thin.svg)
-  static const hourglass = PhosphorFlatIconData(0xe2b2, 'Thin');
+  static const hourglass = IconData(0xe2b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-high-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hourglass-high-thin.svg)
-  static const hourglassHigh = PhosphorFlatIconData(0xe2b4, 'Thin');
+  static const hourglassHigh = IconData(0xe2b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-low-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hourglass-low-thin.svg)
-  static const hourglassLow = PhosphorFlatIconData(0xe2b6, 'Thin');
+  static const hourglassLow = IconData(0xe2b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-medium-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hourglass-medium-thin.svg)
-  static const hourglassMedium = PhosphorFlatIconData(0xe2b8, 'Thin');
+  static const hourglassMedium = IconData(0xe2b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hourglass-simple-thin.svg)
-  static const hourglassSimple = PhosphorFlatIconData(0xe2ba, 'Thin');
+  static const hourglassSimple = IconData(0xe2ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-high-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hourglass-simple-high-thin.svg)
-  static const hourglassSimpleHigh = PhosphorFlatIconData(0xe2bc, 'Thin');
+  static const hourglassSimpleHigh = IconData(0xe2bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-low-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hourglass-simple-low-thin.svg)
-  static const hourglassSimpleLow = PhosphorFlatIconData(0xe2be, 'Thin');
+  static const hourglassSimpleLow = IconData(0xe2be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hourglass-simple-medium-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hourglass-simple-medium-thin.svg)
-  static const hourglassSimpleMedium = PhosphorFlatIconData(0xe2c0, 'Thin');
+  static const hourglassSimpleMedium = IconData(0xe2c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/house-thin.svg)
-  static const house = PhosphorFlatIconData(0xe2c2, 'Thin');
+  static const house = IconData(0xe2c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-line-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/house-line-thin.svg)
-  static const houseLine = PhosphorFlatIconData(0xe2c4, 'Thin');
+  static const houseLine = IconData(0xe2c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![house-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/house-simple-thin.svg)
-  static const houseSimple = PhosphorFlatIconData(0xe2c6, 'Thin');
+  static const houseSimple = IconData(0xe2c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![hurricane-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/hurricane-thin.svg)
-  static const hurricane = PhosphorFlatIconData(0xe88e, 'Thin');
+  static const hurricane = IconData(0xe88e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ice-cream-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ice-cream-thin.svg)
-  static const iceCream = PhosphorFlatIconData(0xe804, 'Thin');
+  static const iceCream = IconData(0xe804,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-badge-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/identification-badge-thin.svg)
-  static const identificationBadge = PhosphorFlatIconData(0xe6f6, 'Thin');
+  static const identificationBadge = IconData(0xe6f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![identification-card-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/identification-card-thin.svg)
-  static const identificationCard = PhosphorFlatIconData(0xe2c8, 'Thin');
+  static const identificationCard = IconData(0xe2c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/image-thin.svg)
-  static const image = PhosphorFlatIconData(0xe2ca, 'Thin');
+  static const image = IconData(0xe2ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-broken-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/image-broken-thin.svg)
-  static const imageBroken = PhosphorFlatIconData(0xe7a8, 'Thin');
+  static const imageBroken = IconData(0xe7a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![image-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/image-square-thin.svg)
-  static const imageSquare = PhosphorFlatIconData(0xe2cc, 'Thin');
+  static const imageSquare = IconData(0xe2cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/images-thin.svg)
-  static const images = PhosphorFlatIconData(0xe836, 'Thin');
+  static const images = IconData(0xe836,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![images-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/images-square-thin.svg)
-  static const imagesSquare = PhosphorFlatIconData(0xe834, 'Thin');
+  static const imagesSquare = IconData(0xe834,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![infinity-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/infinity-thin.svg)
-  static const infinity = PhosphorFlatIconData(0xe634, 'Thin');
+  static const infinity = IconData(0xe634,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![info-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/info-thin.svg)
-  static const info = PhosphorFlatIconData(0xe2ce, 'Thin');
+  static const info = IconData(0xe2ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![instagram-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/instagram-logo-thin.svg)
-  static const instagramLogo = PhosphorFlatIconData(0xe2d0, 'Thin');
+  static const instagramLogo = IconData(0xe2d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/intersect-thin.svg)
-  static const intersect = PhosphorFlatIconData(0xe2d2, 'Thin');
+  static const intersect = IconData(0xe2d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/intersect-square-thin.svg)
-  static const intersectSquare = PhosphorFlatIconData(0xe87a, 'Thin');
+  static const intersectSquare = IconData(0xe87a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersect-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/intersect-three-thin.svg)
-  static const intersectThree = PhosphorFlatIconData(0xecc4, 'Thin');
+  static const intersectThree = IconData(0xecc4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![intersection-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/intersection-thin.svg)
-  static const intersection = PhosphorFlatIconData(0xedba, 'Thin');
+  static const intersection = IconData(0xedba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![invoice-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/invoice-thin.svg)
-  static const invoice = PhosphorFlatIconData(0xee42, 'Thin');
+  static const invoice = IconData(0xee42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![island-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/island-thin.svg)
-  static const island = PhosphorFlatIconData(0xee06, 'Thin');
+  static const island = IconData(0xee06,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/jar-thin.svg)
-  static const jar = PhosphorFlatIconData(0xe7e0, 'Thin');
+  static const jar = IconData(0xe7e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jar-label-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/jar-label-thin.svg)
-  static const jarLabel = PhosphorFlatIconData(0xe7e1, 'Thin');
+  static const jarLabel = IconData(0xe7e1,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![jeep-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/jeep-thin.svg)
-  static const jeep = PhosphorFlatIconData(0xe2d4, 'Thin');
+  static const jeep = IconData(0xe2d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![joystick-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/joystick-thin.svg)
-  static const joystick = PhosphorFlatIconData(0xea5e, 'Thin');
+  static const joystick = IconData(0xea5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![kanban-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/kanban-thin.svg)
-  static const kanban = PhosphorFlatIconData(0xeb54, 'Thin');
+  static const kanban = IconData(0xeb54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/key-thin.svg)
-  static const key = PhosphorFlatIconData(0xe2d6, 'Thin');
+  static const key = IconData(0xe2d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![key-return-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/key-return-thin.svg)
-  static const keyReturn = PhosphorFlatIconData(0xe782, 'Thin');
+  static const keyReturn = IconData(0xe782,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyboard-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/keyboard-thin.svg)
-  static const keyboard = PhosphorFlatIconData(0xe2d8, 'Thin');
+  static const keyboard = IconData(0xe2d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![keyhole-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/keyhole-thin.svg)
-  static const keyhole = PhosphorFlatIconData(0xea78, 'Thin');
+  static const keyhole = IconData(0xea78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![knife-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/knife-thin.svg)
-  static const knife = PhosphorFlatIconData(0xe636, 'Thin');
+  static const knife = IconData(0xe636,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ladder-thin.svg)
-  static const ladder = PhosphorFlatIconData(0xe9e4, 'Thin');
+  static const ladder = IconData(0xe9e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ladder-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ladder-simple-thin.svg)
-  static const ladderSimple = PhosphorFlatIconData(0xec26, 'Thin');
+  static const ladderSimple = IconData(0xec26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lamp-thin.svg)
-  static const lamp = PhosphorFlatIconData(0xe638, 'Thin');
+  static const lamp = IconData(0xe638,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lamp-pendant-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lamp-pendant-thin.svg)
-  static const lampPendant = PhosphorFlatIconData(0xee2e, 'Thin');
+  static const lampPendant = IconData(0xee2e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![laptop-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/laptop-thin.svg)
-  static const laptop = PhosphorFlatIconData(0xe586, 'Thin');
+  static const laptop = IconData(0xe586,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lasso-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lasso-thin.svg)
-  static const lasso = PhosphorFlatIconData(0xedc6, 'Thin');
+  static const lasso = IconData(0xedc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lastfm-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lastfm-logo-thin.svg)
-  static const lastfmLogo = PhosphorFlatIconData(0xe842, 'Thin');
+  static const lastfmLogo = IconData(0xe842,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![layout-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/layout-thin.svg)
-  static const layout = PhosphorFlatIconData(0xe6d6, 'Thin');
+  static const layout = IconData(0xe6d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![leaf-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/leaf-thin.svg)
-  static const leaf = PhosphorFlatIconData(0xe2da, 'Thin');
+  static const leaf = IconData(0xe2da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lectern-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lectern-thin.svg)
-  static const lectern = PhosphorFlatIconData(0xe95a, 'Thin');
+  static const lectern = IconData(0xe95a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lego-thin.svg)
-  static const lego = PhosphorFlatIconData(0xe8c6, 'Thin');
+  static const lego = IconData(0xe8c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lego-smiley-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lego-smiley-thin.svg)
-  static const legoSmiley = PhosphorFlatIconData(0xe8c7, 'Thin');
+  static const legoSmiley = IconData(0xe8c7,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/less-than-thin.svg)
-  static const lessThan = PhosphorFlatIconData(0xedac, 'Thin');
+  static const lessThan = IconData(0xedac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![less-than-or-equal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/less-than-or-equal-thin.svg)
-  static const lessThanOrEqual = PhosphorFlatIconData(0xeda4, 'Thin');
+  static const lessThanOrEqual = IconData(0xeda4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-h-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/letter-circle-h-thin.svg)
-  static const letterCircleH = PhosphorFlatIconData(0xebf8, 'Thin');
+  static const letterCircleH = IconData(0xebf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-p-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/letter-circle-p-thin.svg)
-  static const letterCircleP = PhosphorFlatIconData(0xec08, 'Thin');
+  static const letterCircleP = IconData(0xec08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![letter-circle-v-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/letter-circle-v-thin.svg)
-  static const letterCircleV = PhosphorFlatIconData(0xec14, 'Thin');
+  static const letterCircleV = IconData(0xec14,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lifebuoy-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lifebuoy-thin.svg)
-  static const lifebuoy = PhosphorFlatIconData(0xe63a, 'Thin');
+  static const lifebuoy = IconData(0xe63a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lightbulb-thin.svg)
-  static const lightbulb = PhosphorFlatIconData(0xe2dc, 'Thin');
+  static const lightbulb = IconData(0xe2dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightbulb-filament-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lightbulb-filament-thin.svg)
-  static const lightbulbFilament = PhosphorFlatIconData(0xe63c, 'Thin');
+  static const lightbulbFilament = IconData(0xe63c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lighthouse-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lighthouse-thin.svg)
-  static const lighthouse = PhosphorFlatIconData(0xe9f6, 'Thin');
+  static const lighthouse = IconData(0xe9f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lightning-thin.svg)
-  static const lightning = PhosphorFlatIconData(0xe2de, 'Thin');
+  static const lightning = IconData(0xe2de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-a-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lightning-a-thin.svg)
-  static const lightningA = PhosphorFlatIconData(0xea84, 'Thin');
+  static const lightningA = IconData(0xea84,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lightning-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lightning-slash-thin.svg)
-  static const lightningSlash = PhosphorFlatIconData(0xe2e0, 'Thin');
+  static const lightningSlash = IconData(0xe2e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segment-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/line-segment-thin.svg)
-  static const lineSegment = PhosphorFlatIconData(0xe6d2, 'Thin');
+  static const lineSegment = IconData(0xe6d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-segments-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/line-segments-thin.svg)
-  static const lineSegments = PhosphorFlatIconData(0xe6d4, 'Thin');
+  static const lineSegments = IconData(0xe6d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![line-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/line-vertical-thin.svg)
-  static const lineVertical = PhosphorFlatIconData(0xed70, 'Thin');
+  static const lineVertical = IconData(0xed70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/link-thin.svg)
-  static const link = PhosphorFlatIconData(0xe2e2, 'Thin');
+  static const link = IconData(0xe2e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-break-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/link-break-thin.svg)
-  static const linkBreak = PhosphorFlatIconData(0xe2e4, 'Thin');
+  static const linkBreak = IconData(0xe2e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/link-simple-thin.svg)
-  static const linkSimple = PhosphorFlatIconData(0xe2e6, 'Thin');
+  static const linkSimple = IconData(0xe2e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-break-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/link-simple-break-thin.svg)
-  static const linkSimpleBreak = PhosphorFlatIconData(0xe2e8, 'Thin');
+  static const linkSimpleBreak = IconData(0xe2e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/link-simple-horizontal-thin.svg)
-  static const linkSimpleHorizontal = PhosphorFlatIconData(0xe2ea, 'Thin');
+  static const linkSimpleHorizontal = IconData(0xe2ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![link-simple-horizontal-break-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/link-simple-horizontal-break-thin.svg)
-  static const linkSimpleHorizontalBreak = PhosphorFlatIconData(0xe2ec, 'Thin');
+  static const linkSimpleHorizontalBreak = IconData(0xe2ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linkedin-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/linkedin-logo-thin.svg)
-  static const linkedinLogo = PhosphorFlatIconData(0xe2ee, 'Thin');
+  static const linkedinLogo = IconData(0xe2ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linktree-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/linktree-logo-thin.svg)
-  static const linktreeLogo = PhosphorFlatIconData(0xedee, 'Thin');
+  static const linktreeLogo = IconData(0xedee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![linux-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/linux-logo-thin.svg)
-  static const linuxLogo = PhosphorFlatIconData(0xeb02, 'Thin');
+  static const linuxLogo = IconData(0xeb02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-thin.svg)
-  static const list = PhosphorFlatIconData(0xe2f0, 'Thin');
+  static const list = IconData(0xe2f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-bullets-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-bullets-thin.svg)
-  static const listBullets = PhosphorFlatIconData(0xe2f2, 'Thin');
+  static const listBullets = IconData(0xe2f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-checks-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-checks-thin.svg)
-  static const listChecks = PhosphorFlatIconData(0xeadc, 'Thin');
+  static const listChecks = IconData(0xeadc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-dashes-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-dashes-thin.svg)
-  static const listDashes = PhosphorFlatIconData(0xe2f4, 'Thin');
+  static const listDashes = IconData(0xe2f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-heart-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-heart-thin.svg)
-  static const listHeart = PhosphorFlatIconData(0xebde, 'Thin');
+  static const listHeart = IconData(0xebde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-magnifying-glass-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-magnifying-glass-thin.svg)
-  static const listMagnifyingGlass = PhosphorFlatIconData(0xebe0, 'Thin');
+  static const listMagnifyingGlass = IconData(0xebe0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-numbers-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-numbers-thin.svg)
-  static const listNumbers = PhosphorFlatIconData(0xe2f6, 'Thin');
+  static const listNumbers = IconData(0xe2f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-plus-thin.svg)
-  static const listPlus = PhosphorFlatIconData(0xe2f8, 'Thin');
+  static const listPlus = IconData(0xe2f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![list-star-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/list-star-thin.svg)
-  static const listStar = PhosphorFlatIconData(0xebdc, 'Thin');
+  static const listStar = IconData(0xebdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lock-thin.svg)
-  static const lock = PhosphorFlatIconData(0xe2fa, 'Thin');
+  static const lock = IconData(0xe2fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lock-key-thin.svg)
-  static const lockKey = PhosphorFlatIconData(0xe2fe, 'Thin');
+  static const lockKey = IconData(0xe2fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-key-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lock-key-open-thin.svg)
-  static const lockKeyOpen = PhosphorFlatIconData(0xe300, 'Thin');
+  static const lockKeyOpen = IconData(0xe300,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lock-laminated-thin.svg)
-  static const lockLaminated = PhosphorFlatIconData(0xe302, 'Thin');
+  static const lockLaminated = IconData(0xe302,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-laminated-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lock-laminated-open-thin.svg)
-  static const lockLaminatedOpen = PhosphorFlatIconData(0xe304, 'Thin');
+  static const lockLaminatedOpen = IconData(0xe304,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lock-open-thin.svg)
-  static const lockOpen = PhosphorFlatIconData(0xe306, 'Thin');
+  static const lockOpen = IconData(0xe306,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lock-simple-thin.svg)
-  static const lockSimple = PhosphorFlatIconData(0xe308, 'Thin');
+  static const lockSimple = IconData(0xe308,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lock-simple-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lock-simple-open-thin.svg)
-  static const lockSimpleOpen = PhosphorFlatIconData(0xe30a, 'Thin');
+  static const lockSimpleOpen = IconData(0xe30a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![lockers-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/lockers-thin.svg)
-  static const lockers = PhosphorFlatIconData(0xecb8, 'Thin');
+  static const lockers = IconData(0xecb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![log-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/log-thin.svg)
-  static const log = PhosphorFlatIconData(0xed82, 'Thin');
+  static const log = IconData(0xed82,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magic-wand-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/magic-wand-thin.svg)
-  static const magicWand = PhosphorFlatIconData(0xe6b6, 'Thin');
+  static const magicWand = IconData(0xe6b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/magnet-thin.svg)
-  static const magnet = PhosphorFlatIconData(0xe680, 'Thin');
+  static const magnet = IconData(0xe680,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnet-straight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/magnet-straight-thin.svg)
-  static const magnetStraight = PhosphorFlatIconData(0xe682, 'Thin');
+  static const magnetStraight = IconData(0xe682,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/magnifying-glass-thin.svg)
-  static const magnifyingGlass = PhosphorFlatIconData(0xe30c, 'Thin');
+  static const magnifyingGlass = IconData(0xe30c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/magnifying-glass-minus-thin.svg)
-  static const magnifyingGlassMinus = PhosphorFlatIconData(0xe30e, 'Thin');
+  static const magnifyingGlassMinus = IconData(0xe30e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![magnifying-glass-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/magnifying-glass-plus-thin.svg)
-  static const magnifyingGlassPlus = PhosphorFlatIconData(0xe310, 'Thin');
+  static const magnifyingGlassPlus = IconData(0xe310,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mailbox-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mailbox-thin.svg)
-  static const mailbox = PhosphorFlatIconData(0xec1e, 'Thin');
+  static const mailbox = IconData(0xec1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/map-pin-thin.svg)
-  static const mapPin = PhosphorFlatIconData(0xe316, 'Thin');
+  static const mapPin = IconData(0xe316,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-area-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/map-pin-area-thin.svg)
-  static const mapPinArea = PhosphorFlatIconData(0xee3a, 'Thin');
+  static const mapPinArea = IconData(0xee3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-line-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/map-pin-line-thin.svg)
-  static const mapPinLine = PhosphorFlatIconData(0xe318, 'Thin');
+  static const mapPinLine = IconData(0xe318,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/map-pin-plus-thin.svg)
-  static const mapPinPlus = PhosphorFlatIconData(0xe314, 'Thin');
+  static const mapPinPlus = IconData(0xe314,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/map-pin-simple-thin.svg)
-  static const mapPinSimple = PhosphorFlatIconData(0xee3e, 'Thin');
+  static const mapPinSimple = IconData(0xee3e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-area-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/map-pin-simple-area-thin.svg)
-  static const mapPinSimpleArea = PhosphorFlatIconData(0xee3c, 'Thin');
+  static const mapPinSimpleArea = IconData(0xee3c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-pin-simple-line-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/map-pin-simple-line-thin.svg)
-  static const mapPinSimpleLine = PhosphorFlatIconData(0xee38, 'Thin');
+  static const mapPinSimpleLine = IconData(0xee38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![map-trifold-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/map-trifold-thin.svg)
-  static const mapTrifold = PhosphorFlatIconData(0xe31a, 'Thin');
+  static const mapTrifold = IconData(0xe31a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![markdown-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/markdown-logo-thin.svg)
-  static const markdownLogo = PhosphorFlatIconData(0xe508, 'Thin');
+  static const markdownLogo = IconData(0xe508,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![marker-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/marker-circle-thin.svg)
-  static const markerCircle = PhosphorFlatIconData(0xe640, 'Thin');
+  static const markerCircle = IconData(0xe640,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![martini-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/martini-thin.svg)
-  static const martini = PhosphorFlatIconData(0xe31c, 'Thin');
+  static const martini = IconData(0xe31c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-happy-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mask-happy-thin.svg)
-  static const maskHappy = PhosphorFlatIconData(0xe9f4, 'Thin');
+  static const maskHappy = IconData(0xe9f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mask-sad-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mask-sad-thin.svg)
-  static const maskSad = PhosphorFlatIconData(0xeb9e, 'Thin');
+  static const maskSad = IconData(0xeb9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mastodon-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mastodon-logo-thin.svg)
-  static const mastodonLogo = PhosphorFlatIconData(0xed68, 'Thin');
+  static const mastodonLogo = IconData(0xed68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![math-operations-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/math-operations-thin.svg)
-  static const mathOperations = PhosphorFlatIconData(0xe31e, 'Thin');
+  static const mathOperations = IconData(0xe31e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![matrix-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/matrix-logo-thin.svg)
-  static const matrixLogo = PhosphorFlatIconData(0xed64, 'Thin');
+  static const matrixLogo = IconData(0xed64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/medal-thin.svg)
-  static const medal = PhosphorFlatIconData(0xe320, 'Thin');
+  static const medal = IconData(0xe320,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medal-military-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/medal-military-thin.svg)
-  static const medalMilitary = PhosphorFlatIconData(0xecfc, 'Thin');
+  static const medalMilitary = IconData(0xecfc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![medium-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/medium-logo-thin.svg)
-  static const mediumLogo = PhosphorFlatIconData(0xe322, 'Thin');
+  static const mediumLogo = IconData(0xe322,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/megaphone-thin.svg)
-  static const megaphone = PhosphorFlatIconData(0xe324, 'Thin');
+  static const megaphone = IconData(0xe324,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![megaphone-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/megaphone-simple-thin.svg)
-  static const megaphoneSimple = PhosphorFlatIconData(0xe642, 'Thin');
+  static const megaphoneSimple = IconData(0xe642,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![member-of-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/member-of-thin.svg)
-  static const memberOf = PhosphorFlatIconData(0xedc2, 'Thin');
+  static const memberOf = IconData(0xedc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![memory-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/memory-thin.svg)
-  static const memory = PhosphorFlatIconData(0xe9c4, 'Thin');
+  static const memory = IconData(0xe9c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![messenger-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/messenger-logo-thin.svg)
-  static const messengerLogo = PhosphorFlatIconData(0xe6d8, 'Thin');
+  static const messengerLogo = IconData(0xe6d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meta-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/meta-logo-thin.svg)
-  static const metaLogo = PhosphorFlatIconData(0xed02, 'Thin');
+  static const metaLogo = IconData(0xed02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![meteor-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/meteor-thin.svg)
-  static const meteor = PhosphorFlatIconData(0xe9ba, 'Thin');
+  static const meteor = IconData(0xe9ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![metronome-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/metronome-thin.svg)
-  static const metronome = PhosphorFlatIconData(0xec8e, 'Thin');
+  static const metronome = IconData(0xec8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microphone-thin.svg)
-  static const microphone = PhosphorFlatIconData(0xe326, 'Thin');
+  static const microphone = IconData(0xe326,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microphone-slash-thin.svg)
-  static const microphoneSlash = PhosphorFlatIconData(0xe328, 'Thin');
+  static const microphoneSlash = IconData(0xe328,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microphone-stage-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microphone-stage-thin.svg)
-  static const microphoneStage = PhosphorFlatIconData(0xe75c, 'Thin');
+  static const microphoneStage = IconData(0xe75c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microscope-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microscope-thin.svg)
-  static const microscope = PhosphorFlatIconData(0xec7a, 'Thin');
+  static const microscope = IconData(0xec7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-excel-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microsoft-excel-logo-thin.svg)
-  static const microsoftExcelLogo = PhosphorFlatIconData(0xeb6c, 'Thin');
+  static const microsoftExcelLogo = IconData(0xeb6c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-outlook-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microsoft-outlook-logo-thin.svg)
-  static const microsoftOutlookLogo = PhosphorFlatIconData(0xeb70, 'Thin');
+  static const microsoftOutlookLogo = IconData(0xeb70,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-powerpoint-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microsoft-powerpoint-logo-thin.svg)
-  static const microsoftPowerpointLogo = PhosphorFlatIconData(0xeace, 'Thin');
+  static const microsoftPowerpointLogo = IconData(0xeace,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-teams-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microsoft-teams-logo-thin.svg)
-  static const microsoftTeamsLogo = PhosphorFlatIconData(0xeb66, 'Thin');
+  static const microsoftTeamsLogo = IconData(0xeb66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![microsoft-word-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/microsoft-word-logo-thin.svg)
-  static const microsoftWordLogo = PhosphorFlatIconData(0xeb6a, 'Thin');
+  static const microsoftWordLogo = IconData(0xeb6a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/minus-thin.svg)
-  static const minus = PhosphorFlatIconData(0xe32a, 'Thin');
+  static const minus = IconData(0xe32a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/minus-circle-thin.svg)
-  static const minusCircle = PhosphorFlatIconData(0xe32c, 'Thin');
+  static const minusCircle = IconData(0xe32c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![minus-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/minus-square-thin.svg)
-  static const minusSquare = PhosphorFlatIconData(0xed4c, 'Thin');
+  static const minusSquare = IconData(0xed4c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/money-thin.svg)
-  static const money = PhosphorFlatIconData(0xe588, 'Thin');
+  static const money = IconData(0xe588,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![money-wavy-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/money-wavy-thin.svg)
-  static const moneyWavy = PhosphorFlatIconData(0xee68, 'Thin');
+  static const moneyWavy = IconData(0xee68,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/monitor-thin.svg)
-  static const monitor = PhosphorFlatIconData(0xe32e, 'Thin');
+  static const monitor = IconData(0xe32e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-arrow-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/monitor-arrow-up-thin.svg)
-  static const monitorArrowUp = PhosphorFlatIconData(0xe58a, 'Thin');
+  static const monitorArrowUp = IconData(0xe58a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![monitor-play-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/monitor-play-thin.svg)
-  static const monitorPlay = PhosphorFlatIconData(0xe58c, 'Thin');
+  static const monitorPlay = IconData(0xe58c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/moon-thin.svg)
-  static const moon = PhosphorFlatIconData(0xe330, 'Thin');
+  static const moon = IconData(0xe330,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moon-stars-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/moon-stars-thin.svg)
-  static const moonStars = PhosphorFlatIconData(0xe58e, 'Thin');
+  static const moonStars = IconData(0xe58e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/moped-thin.svg)
-  static const moped = PhosphorFlatIconData(0xe824, 'Thin');
+  static const moped = IconData(0xe824,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![moped-front-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/moped-front-thin.svg)
-  static const mopedFront = PhosphorFlatIconData(0xe822, 'Thin');
+  static const mopedFront = IconData(0xe822,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mosque-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mosque-thin.svg)
-  static const mosque = PhosphorFlatIconData(0xecee, 'Thin');
+  static const mosque = IconData(0xecee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![motorcycle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/motorcycle-thin.svg)
-  static const motorcycle = PhosphorFlatIconData(0xe80a, 'Thin');
+  static const motorcycle = IconData(0xe80a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mountains-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mountains-thin.svg)
-  static const mountains = PhosphorFlatIconData(0xe7ae, 'Thin');
+  static const mountains = IconData(0xe7ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mouse-thin.svg)
-  static const mouse = PhosphorFlatIconData(0xe33a, 'Thin');
+  static const mouse = IconData(0xe33a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-left-click-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mouse-left-click-thin.svg)
-  static const mouseLeftClick = PhosphorFlatIconData(0xe334, 'Thin');
+  static const mouseLeftClick = IconData(0xe334,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-middle-click-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mouse-middle-click-thin.svg)
-  static const mouseMiddleClick = PhosphorFlatIconData(0xe338, 'Thin');
+  static const mouseMiddleClick = IconData(0xe338,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-right-click-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mouse-right-click-thin.svg)
-  static const mouseRightClick = PhosphorFlatIconData(0xe336, 'Thin');
+  static const mouseRightClick = IconData(0xe336,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-scroll-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mouse-scroll-thin.svg)
-  static const mouseScroll = PhosphorFlatIconData(0xe332, 'Thin');
+  static const mouseScroll = IconData(0xe332,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![mouse-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/mouse-simple-thin.svg)
-  static const mouseSimple = PhosphorFlatIconData(0xe644, 'Thin');
+  static const mouseSimple = IconData(0xe644,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/music-note-thin.svg)
-  static const musicNote = PhosphorFlatIconData(0xe33c, 'Thin');
+  static const musicNote = IconData(0xe33c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-note-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/music-note-simple-thin.svg)
-  static const musicNoteSimple = PhosphorFlatIconData(0xe33e, 'Thin');
+  static const musicNoteSimple = IconData(0xe33e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/music-notes-thin.svg)
-  static const musicNotes = PhosphorFlatIconData(0xe340, 'Thin');
+  static const musicNotes = IconData(0xe340,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/music-notes-minus-thin.svg)
-  static const musicNotesMinus = PhosphorFlatIconData(0xee0c, 'Thin');
+  static const musicNotesMinus = IconData(0xee0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/music-notes-plus-thin.svg)
-  static const musicNotesPlus = PhosphorFlatIconData(0xeb7c, 'Thin');
+  static const musicNotesPlus = IconData(0xeb7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![music-notes-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/music-notes-simple-thin.svg)
-  static const musicNotesSimple = PhosphorFlatIconData(0xe342, 'Thin');
+  static const musicNotesSimple = IconData(0xe342,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![navigation-arrow-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/navigation-arrow-thin.svg)
-  static const navigationArrow = PhosphorFlatIconData(0xeade, 'Thin');
+  static const navigationArrow = IconData(0xeade,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![needle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/needle-thin.svg)
-  static const needle = PhosphorFlatIconData(0xe82e, 'Thin');
+  static const needle = IconData(0xe82e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/network-thin.svg)
-  static const network = PhosphorFlatIconData(0xedde, 'Thin');
+  static const network = IconData(0xedde,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/network-slash-thin.svg)
-  static const networkSlash = PhosphorFlatIconData(0xeddc, 'Thin');
+  static const networkSlash = IconData(0xeddc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![network-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/network-x-thin.svg)
-  static const networkX = PhosphorFlatIconData(0xedda, 'Thin');
+  static const networkX = IconData(0xedda,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/newspaper-thin.svg)
-  static const newspaper = PhosphorFlatIconData(0xe344, 'Thin');
+  static const newspaper = IconData(0xe344,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![newspaper-clipping-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/newspaper-clipping-thin.svg)
-  static const newspaperClipping = PhosphorFlatIconData(0xe346, 'Thin');
+  static const newspaperClipping = IconData(0xe346,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-equals-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/not-equals-thin.svg)
-  static const notEquals = PhosphorFlatIconData(0xeda6, 'Thin');
+  static const notEquals = IconData(0xeda6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-member-of-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/not-member-of-thin.svg)
-  static const notMemberOf = PhosphorFlatIconData(0xedae, 'Thin');
+  static const notMemberOf = IconData(0xedae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-subset-of-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/not-subset-of-thin.svg)
-  static const notSubsetOf = PhosphorFlatIconData(0xedb0, 'Thin');
+  static const notSubsetOf = IconData(0xedb0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![not-superset-of-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/not-superset-of-thin.svg)
-  static const notSupersetOf = PhosphorFlatIconData(0xedb2, 'Thin');
+  static const notSupersetOf = IconData(0xedb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notches-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/notches-thin.svg)
-  static const notches = PhosphorFlatIconData(0xed3a, 'Thin');
+  static const notches = IconData(0xed3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/note-thin.svg)
-  static const note = PhosphorFlatIconData(0xe348, 'Thin');
+  static const note = IconData(0xe348,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-blank-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/note-blank-thin.svg)
-  static const noteBlank = PhosphorFlatIconData(0xe34a, 'Thin');
+  static const noteBlank = IconData(0xe34a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![note-pencil-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/note-pencil-thin.svg)
-  static const notePencil = PhosphorFlatIconData(0xe34c, 'Thin');
+  static const notePencil = IconData(0xe34c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notebook-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/notebook-thin.svg)
-  static const notebook = PhosphorFlatIconData(0xe34e, 'Thin');
+  static const notebook = IconData(0xe34e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notepad-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/notepad-thin.svg)
-  static const notepad = PhosphorFlatIconData(0xe63e, 'Thin');
+  static const notepad = IconData(0xe63e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notification-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/notification-thin.svg)
-  static const notification = PhosphorFlatIconData(0xe6fa, 'Thin');
+  static const notification = IconData(0xe6fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![notion-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/notion-logo-thin.svg)
-  static const notionLogo = PhosphorFlatIconData(0xe9a0, 'Thin');
+  static const notionLogo = IconData(0xe9a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nuclear-plant-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/nuclear-plant-thin.svg)
-  static const nuclearPlant = PhosphorFlatIconData(0xed7c, 'Thin');
+  static const nuclearPlant = IconData(0xed7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-eight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-eight-thin.svg)
-  static const numberCircleEight = PhosphorFlatIconData(0xe352, 'Thin');
+  static const numberCircleEight = IconData(0xe352,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-five-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-five-thin.svg)
-  static const numberCircleFive = PhosphorFlatIconData(0xe358, 'Thin');
+  static const numberCircleFive = IconData(0xe358,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-four-thin.svg)
-  static const numberCircleFour = PhosphorFlatIconData(0xe35e, 'Thin');
+  static const numberCircleFour = IconData(0xe35e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-nine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-nine-thin.svg)
-  static const numberCircleNine = PhosphorFlatIconData(0xe364, 'Thin');
+  static const numberCircleNine = IconData(0xe364,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-one-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-one-thin.svg)
-  static const numberCircleOne = PhosphorFlatIconData(0xe36a, 'Thin');
+  static const numberCircleOne = IconData(0xe36a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-seven-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-seven-thin.svg)
-  static const numberCircleSeven = PhosphorFlatIconData(0xe370, 'Thin');
+  static const numberCircleSeven = IconData(0xe370,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-six-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-six-thin.svg)
-  static const numberCircleSix = PhosphorFlatIconData(0xe376, 'Thin');
+  static const numberCircleSix = IconData(0xe376,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-three-thin.svg)
-  static const numberCircleThree = PhosphorFlatIconData(0xe37c, 'Thin');
+  static const numberCircleThree = IconData(0xe37c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-two-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-two-thin.svg)
-  static const numberCircleTwo = PhosphorFlatIconData(0xe382, 'Thin');
+  static const numberCircleTwo = IconData(0xe382,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-circle-zero-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-circle-zero-thin.svg)
-  static const numberCircleZero = PhosphorFlatIconData(0xe388, 'Thin');
+  static const numberCircleZero = IconData(0xe388,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-eight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-eight-thin.svg)
-  static const numberEight = PhosphorFlatIconData(0xe350, 'Thin');
+  static const numberEight = IconData(0xe350,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-five-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-five-thin.svg)
-  static const numberFive = PhosphorFlatIconData(0xe356, 'Thin');
+  static const numberFive = IconData(0xe356,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-four-thin.svg)
-  static const numberFour = PhosphorFlatIconData(0xe35c, 'Thin');
+  static const numberFour = IconData(0xe35c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-nine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-nine-thin.svg)
-  static const numberNine = PhosphorFlatIconData(0xe362, 'Thin');
+  static const numberNine = IconData(0xe362,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-one-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-one-thin.svg)
-  static const numberOne = PhosphorFlatIconData(0xe368, 'Thin');
+  static const numberOne = IconData(0xe368,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-seven-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-seven-thin.svg)
-  static const numberSeven = PhosphorFlatIconData(0xe36e, 'Thin');
+  static const numberSeven = IconData(0xe36e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-six-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-six-thin.svg)
-  static const numberSix = PhosphorFlatIconData(0xe374, 'Thin');
+  static const numberSix = IconData(0xe374,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-eight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-eight-thin.svg)
-  static const numberSquareEight = PhosphorFlatIconData(0xe354, 'Thin');
+  static const numberSquareEight = IconData(0xe354,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-five-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-five-thin.svg)
-  static const numberSquareFive = PhosphorFlatIconData(0xe35a, 'Thin');
+  static const numberSquareFive = IconData(0xe35a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-four-thin.svg)
-  static const numberSquareFour = PhosphorFlatIconData(0xe360, 'Thin');
+  static const numberSquareFour = IconData(0xe360,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-nine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-nine-thin.svg)
-  static const numberSquareNine = PhosphorFlatIconData(0xe366, 'Thin');
+  static const numberSquareNine = IconData(0xe366,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-one-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-one-thin.svg)
-  static const numberSquareOne = PhosphorFlatIconData(0xe36c, 'Thin');
+  static const numberSquareOne = IconData(0xe36c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-seven-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-seven-thin.svg)
-  static const numberSquareSeven = PhosphorFlatIconData(0xe372, 'Thin');
+  static const numberSquareSeven = IconData(0xe372,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-six-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-six-thin.svg)
-  static const numberSquareSix = PhosphorFlatIconData(0xe378, 'Thin');
+  static const numberSquareSix = IconData(0xe378,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-three-thin.svg)
-  static const numberSquareThree = PhosphorFlatIconData(0xe37e, 'Thin');
+  static const numberSquareThree = IconData(0xe37e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-two-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-two-thin.svg)
-  static const numberSquareTwo = PhosphorFlatIconData(0xe384, 'Thin');
+  static const numberSquareTwo = IconData(0xe384,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-square-zero-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-square-zero-thin.svg)
-  static const numberSquareZero = PhosphorFlatIconData(0xe38a, 'Thin');
+  static const numberSquareZero = IconData(0xe38a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-three-thin.svg)
-  static const numberThree = PhosphorFlatIconData(0xe37a, 'Thin');
+  static const numberThree = IconData(0xe37a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-two-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-two-thin.svg)
-  static const numberTwo = PhosphorFlatIconData(0xe380, 'Thin');
+  static const numberTwo = IconData(0xe380,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![number-zero-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/number-zero-thin.svg)
-  static const numberZero = PhosphorFlatIconData(0xe386, 'Thin');
+  static const numberZero = IconData(0xe386,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![numpad-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/numpad-thin.svg)
-  static const numpad = PhosphorFlatIconData(0xe3c8, 'Thin');
+  static const numpad = IconData(0xe3c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![nut-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/nut-thin.svg)
-  static const nut = PhosphorFlatIconData(0xe38c, 'Thin');
+  static const nut = IconData(0xe38c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ny-times-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ny-times-logo-thin.svg)
-  static const nyTimesLogo = PhosphorFlatIconData(0xe646, 'Thin');
+  static const nyTimesLogo = IconData(0xe646,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![octagon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/octagon-thin.svg)
-  static const octagon = PhosphorFlatIconData(0xe38e, 'Thin');
+  static const octagon = IconData(0xe38e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![office-chair-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/office-chair-thin.svg)
-  static const officeChair = PhosphorFlatIconData(0xea46, 'Thin');
+  static const officeChair = IconData(0xea46,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![onigiri-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/onigiri-thin.svg)
-  static const onigiri = PhosphorFlatIconData(0xee2c, 'Thin');
+  static const onigiri = IconData(0xee2c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![open-ai-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/open-ai-logo-thin.svg)
-  static const openAiLogo = PhosphorFlatIconData(0xe7d2, 'Thin');
+  static const openAiLogo = IconData(0xe7d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![option-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/option-thin.svg)
-  static const option = PhosphorFlatIconData(0xe8a8, 'Thin');
+  static const option = IconData(0xe8a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/orange-thin.svg)
-  static const orange = PhosphorFlatIconData(0xee40, 'Thin');
+  static const orange = IconData(0xee40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![orange-slice-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/orange-slice-thin.svg)
-  static const orangeSlice = PhosphorFlatIconData(0xed36, 'Thin');
+  static const orangeSlice = IconData(0xed36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![oven-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/oven-thin.svg)
-  static const oven = PhosphorFlatIconData(0xed8c, 'Thin');
+  static const oven = IconData(0xed8c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![package-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/package-thin.svg)
-  static const package = PhosphorFlatIconData(0xe390, 'Thin');
+  static const package = IconData(0xe390,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paint-brush-thin.svg)
-  static const paintBrush = PhosphorFlatIconData(0xe6f0, 'Thin');
+  static const paintBrush = IconData(0xe6f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-broad-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paint-brush-broad-thin.svg)
-  static const paintBrushBroad = PhosphorFlatIconData(0xe590, 'Thin');
+  static const paintBrushBroad = IconData(0xe590,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-brush-household-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paint-brush-household-thin.svg)
-  static const paintBrushHousehold = PhosphorFlatIconData(0xe6f2, 'Thin');
+  static const paintBrushHousehold = IconData(0xe6f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-bucket-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paint-bucket-thin.svg)
-  static const paintBucket = PhosphorFlatIconData(0xe392, 'Thin');
+  static const paintBucket = IconData(0xe392,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paint-roller-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paint-roller-thin.svg)
-  static const paintRoller = PhosphorFlatIconData(0xe6f4, 'Thin');
+  static const paintRoller = IconData(0xe6f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![palette-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/palette-thin.svg)
-  static const palette = PhosphorFlatIconData(0xe6c8, 'Thin');
+  static const palette = IconData(0xe6c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![panorama-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/panorama-thin.svg)
-  static const panorama = PhosphorFlatIconData(0xeaa2, 'Thin');
+  static const panorama = IconData(0xeaa2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pants-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pants-thin.svg)
-  static const pants = PhosphorFlatIconData(0xec88, 'Thin');
+  static const pants = IconData(0xec88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paper-plane-thin.svg)
-  static const paperPlane = PhosphorFlatIconData(0xe394, 'Thin');
+  static const paperPlane = IconData(0xe394,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paper-plane-right-thin.svg)
-  static const paperPlaneRight = PhosphorFlatIconData(0xe396, 'Thin');
+  static const paperPlaneRight = IconData(0xe396,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paper-plane-tilt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paper-plane-tilt-thin.svg)
-  static const paperPlaneTilt = PhosphorFlatIconData(0xe398, 'Thin');
+  static const paperPlaneTilt = IconData(0xe398,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paperclip-thin.svg)
-  static const paperclip = PhosphorFlatIconData(0xe39a, 'Thin');
+  static const paperclip = IconData(0xe39a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paperclip-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paperclip-horizontal-thin.svg)
-  static const paperclipHorizontal = PhosphorFlatIconData(0xe592, 'Thin');
+  static const paperclipHorizontal = IconData(0xe592,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parachute-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/parachute-thin.svg)
-  static const parachute = PhosphorFlatIconData(0xea7c, 'Thin');
+  static const parachute = IconData(0xea7c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paragraph-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paragraph-thin.svg)
-  static const paragraph = PhosphorFlatIconData(0xe960, 'Thin');
+  static const paragraph = IconData(0xe960,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![parallelogram-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/parallelogram-thin.svg)
-  static const parallelogram = PhosphorFlatIconData(0xecc6, 'Thin');
+  static const parallelogram = IconData(0xecc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![park-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/park-thin.svg)
-  static const park = PhosphorFlatIconData(0xecb2, 'Thin');
+  static const park = IconData(0xecb2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![password-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/password-thin.svg)
-  static const password = PhosphorFlatIconData(0xe752, 'Thin');
+  static const password = IconData(0xe752,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![path-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/path-thin.svg)
-  static const path = PhosphorFlatIconData(0xe39c, 'Thin');
+  static const path = IconData(0xe39c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![patreon-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/patreon-logo-thin.svg)
-  static const patreonLogo = PhosphorFlatIconData(0xe98a, 'Thin');
+  static const patreonLogo = IconData(0xe98a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pause-thin.svg)
-  static const pause = PhosphorFlatIconData(0xe39e, 'Thin');
+  static const pause = IconData(0xe39e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pause-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pause-circle-thin.svg)
-  static const pauseCircle = PhosphorFlatIconData(0xe3a0, 'Thin');
+  static const pauseCircle = IconData(0xe3a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paw-print-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paw-print-thin.svg)
-  static const pawPrint = PhosphorFlatIconData(0xe648, 'Thin');
+  static const pawPrint = IconData(0xe648,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![paypal-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/paypal-logo-thin.svg)
-  static const paypalLogo = PhosphorFlatIconData(0xe98c, 'Thin');
+  static const paypalLogo = IconData(0xe98c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![peace-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/peace-thin.svg)
-  static const peace = PhosphorFlatIconData(0xe3a2, 'Thin');
+  static const peace = IconData(0xe3a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pen-thin.svg)
-  static const pen = PhosphorFlatIconData(0xe3aa, 'Thin');
+  static const pen = IconData(0xe3aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pen-nib-thin.svg)
-  static const penNib = PhosphorFlatIconData(0xe3ac, 'Thin');
+  static const penNib = IconData(0xe3ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pen-nib-straight-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pen-nib-straight-thin.svg)
-  static const penNibStraight = PhosphorFlatIconData(0xe64a, 'Thin');
+  static const penNibStraight = IconData(0xe64a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pencil-thin.svg)
-  static const pencil = PhosphorFlatIconData(0xe3ae, 'Thin');
+  static const pencil = IconData(0xe3ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pencil-circle-thin.svg)
-  static const pencilCircle = PhosphorFlatIconData(0xe3b0, 'Thin');
+  static const pencilCircle = IconData(0xe3b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-line-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pencil-line-thin.svg)
-  static const pencilLine = PhosphorFlatIconData(0xe3b2, 'Thin');
+  static const pencilLine = IconData(0xe3b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-ruler-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pencil-ruler-thin.svg)
-  static const pencilRuler = PhosphorFlatIconData(0xe906, 'Thin');
+  static const pencilRuler = IconData(0xe906,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pencil-simple-thin.svg)
-  static const pencilSimple = PhosphorFlatIconData(0xe3b4, 'Thin');
+  static const pencilSimple = IconData(0xe3b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-line-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pencil-simple-line-thin.svg)
-  static const pencilSimpleLine = PhosphorFlatIconData(0xebc6, 'Thin');
+  static const pencilSimpleLine = IconData(0xebc6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-simple-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pencil-simple-slash-thin.svg)
-  static const pencilSimpleSlash = PhosphorFlatIconData(0xecf6, 'Thin');
+  static const pencilSimpleSlash = IconData(0xecf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pencil-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pencil-slash-thin.svg)
-  static const pencilSlash = PhosphorFlatIconData(0xecf8, 'Thin');
+  static const pencilSlash = IconData(0xecf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pentagon-thin.svg)
-  static const pentagon = PhosphorFlatIconData(0xec7e, 'Thin');
+  static const pentagon = IconData(0xec7e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pentagram-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pentagram-thin.svg)
-  static const pentagram = PhosphorFlatIconData(0xec5c, 'Thin');
+  static const pentagram = IconData(0xec5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pepper-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pepper-thin.svg)
-  static const pepper = PhosphorFlatIconData(0xe94a, 'Thin');
+  static const pepper = IconData(0xe94a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![percent-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/percent-thin.svg)
-  static const percent = PhosphorFlatIconData(0xe3b6, 'Thin');
+  static const percent = IconData(0xe3b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-thin.svg)
-  static const person = PhosphorFlatIconData(0xe3a8, 'Thin');
+  static const person = IconData(0xe3a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-arms-spread-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-arms-spread-thin.svg)
-  static const personArmsSpread = PhosphorFlatIconData(0xecfe, 'Thin');
+  static const personArmsSpread = IconData(0xecfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-thin.svg)
-  static const personSimple = PhosphorFlatIconData(0xe72e, 'Thin');
+  static const personSimple = IconData(0xe72e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-bike-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-bike-thin.svg)
-  static const personSimpleBike = PhosphorFlatIconData(0xe734, 'Thin');
+  static const personSimpleBike = IconData(0xe734,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-circle-thin.svg)
-  static const personSimpleCircle = PhosphorFlatIconData(0xee58, 'Thin');
+  static const personSimpleCircle = IconData(0xee58,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-hike-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-hike-thin.svg)
-  static const personSimpleHike = PhosphorFlatIconData(0xed54, 'Thin');
+  static const personSimpleHike = IconData(0xed54,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-run-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-run-thin.svg)
-  static const personSimpleRun = PhosphorFlatIconData(0xe730, 'Thin');
+  static const personSimpleRun = IconData(0xe730,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-ski-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-ski-thin.svg)
-  static const personSimpleSki = PhosphorFlatIconData(0xe71c, 'Thin');
+  static const personSimpleSki = IconData(0xe71c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-snowboard-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-snowboard-thin.svg)
-  static const personSimpleSnowboard = PhosphorFlatIconData(0xe71e, 'Thin');
+  static const personSimpleSnowboard = IconData(0xe71e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-swim-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-swim-thin.svg)
-  static const personSimpleSwim = PhosphorFlatIconData(0xe736, 'Thin');
+  static const personSimpleSwim = IconData(0xe736,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-tai-chi-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-tai-chi-thin.svg)
-  static const personSimpleTaiChi = PhosphorFlatIconData(0xed5c, 'Thin');
+  static const personSimpleTaiChi = IconData(0xed5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-throw-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-throw-thin.svg)
-  static const personSimpleThrow = PhosphorFlatIconData(0xe732, 'Thin');
+  static const personSimpleThrow = IconData(0xe732,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![person-simple-walk-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/person-simple-walk-thin.svg)
-  static const personSimpleWalk = PhosphorFlatIconData(0xe73a, 'Thin');
+  static const personSimpleWalk = IconData(0xe73a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![perspective-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/perspective-thin.svg)
-  static const perspective = PhosphorFlatIconData(0xebe6, 'Thin');
+  static const perspective = IconData(0xebe6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-thin.svg)
-  static const phone = PhosphorFlatIconData(0xe3b8, 'Thin');
+  static const phone = IconData(0xe3b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-call-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-call-thin.svg)
-  static const phoneCall = PhosphorFlatIconData(0xe3ba, 'Thin');
+  static const phoneCall = IconData(0xe3ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-disconnect-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-disconnect-thin.svg)
-  static const phoneDisconnect = PhosphorFlatIconData(0xe3bc, 'Thin');
+  static const phoneDisconnect = IconData(0xe3bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-incoming-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-incoming-thin.svg)
-  static const phoneIncoming = PhosphorFlatIconData(0xe3be, 'Thin');
+  static const phoneIncoming = IconData(0xe3be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-list-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-list-thin.svg)
-  static const phoneList = PhosphorFlatIconData(0xe3cc, 'Thin');
+  static const phoneList = IconData(0xe3cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-outgoing-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-outgoing-thin.svg)
-  static const phoneOutgoing = PhosphorFlatIconData(0xe3c0, 'Thin');
+  static const phoneOutgoing = IconData(0xe3c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-pause-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-pause-thin.svg)
-  static const phonePause = PhosphorFlatIconData(0xe3ca, 'Thin');
+  static const phonePause = IconData(0xe3ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-plus-thin.svg)
-  static const phonePlus = PhosphorFlatIconData(0xec56, 'Thin');
+  static const phonePlus = IconData(0xec56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-slash-thin.svg)
-  static const phoneSlash = PhosphorFlatIconData(0xe3c2, 'Thin');
+  static const phoneSlash = IconData(0xe3c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-transfer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-transfer-thin.svg)
-  static const phoneTransfer = PhosphorFlatIconData(0xe3c6, 'Thin');
+  static const phoneTransfer = IconData(0xe3c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phone-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phone-x-thin.svg)
-  static const phoneX = PhosphorFlatIconData(0xe3c4, 'Thin');
+  static const phoneX = IconData(0xe3c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![phosphor-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/phosphor-logo-thin.svg)
-  static const phosphorLogo = PhosphorFlatIconData(0xe3ce, 'Thin');
+  static const phosphorLogo = IconData(0xe3ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pi-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pi-thin.svg)
-  static const pi = PhosphorFlatIconData(0xec80, 'Thin');
+  static const pi = IconData(0xec80,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piano-keys-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/piano-keys-thin.svg)
-  static const pianoKeys = PhosphorFlatIconData(0xe9c8, 'Thin');
+  static const pianoKeys = IconData(0xe9c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picnic-table-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/picnic-table-thin.svg)
-  static const picnicTable = PhosphorFlatIconData(0xee26, 'Thin');
+  static const picnicTable = IconData(0xee26,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![picture-in-picture-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/picture-in-picture-thin.svg)
-  static const pictureInpicture = PhosphorFlatIconData(0xe64c, 'Thin');
+  static const pictureInpicture = IconData(0xe64c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![piggy-bank-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/piggy-bank-thin.svg)
-  static const piggyBank = PhosphorFlatIconData(0xea04, 'Thin');
+  static const piggyBank = IconData(0xea04,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pill-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pill-thin.svg)
-  static const pill = PhosphorFlatIconData(0xe700, 'Thin');
+  static const pill = IconData(0xe700,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ping-pong-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ping-pong-thin.svg)
-  static const pingPong = PhosphorFlatIconData(0xea42, 'Thin');
+  static const pingPong = IconData(0xea42,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pint-glass-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pint-glass-thin.svg)
-  static const pintGlass = PhosphorFlatIconData(0xedd0, 'Thin');
+  static const pintGlass = IconData(0xedd0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinterest-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pinterest-logo-thin.svg)
-  static const pinterestLogo = PhosphorFlatIconData(0xe64e, 'Thin');
+  static const pinterestLogo = IconData(0xe64e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pinwheel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pinwheel-thin.svg)
-  static const pinwheel = PhosphorFlatIconData(0xeb9c, 'Thin');
+  static const pinwheel = IconData(0xeb9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pipe-thin.svg)
-  static const pipe = PhosphorFlatIconData(0xed86, 'Thin');
+  static const pipe = IconData(0xed86,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pipe-wrench-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pipe-wrench-thin.svg)
-  static const pipeWrench = PhosphorFlatIconData(0xed88, 'Thin');
+  static const pipeWrench = IconData(0xed88,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pix-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pix-logo-thin.svg)
-  static const pixLogo = PhosphorFlatIconData(0xecc2, 'Thin');
+  static const pixLogo = IconData(0xecc2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pizza-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pizza-thin.svg)
-  static const pizza = PhosphorFlatIconData(0xe796, 'Thin');
+  static const pizza = IconData(0xe796,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![placeholder-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/placeholder-thin.svg)
-  static const placeholder = PhosphorFlatIconData(0xe650, 'Thin');
+  static const placeholder = IconData(0xe650,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![planet-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/planet-thin.svg)
-  static const planet = PhosphorFlatIconData(0xe652, 'Thin');
+  static const planet = IconData(0xe652,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plant-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plant-thin.svg)
-  static const plant = PhosphorFlatIconData(0xebae, 'Thin');
+  static const plant = IconData(0xebae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/play-thin.svg)
-  static const play = PhosphorFlatIconData(0xe3d0, 'Thin');
+  static const play = IconData(0xe3d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/play-circle-thin.svg)
-  static const playCircle = PhosphorFlatIconData(0xe3d2, 'Thin');
+  static const playCircle = IconData(0xe3d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![play-pause-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/play-pause-thin.svg)
-  static const playPause = PhosphorFlatIconData(0xe8be, 'Thin');
+  static const playPause = IconData(0xe8be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![playlist-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/playlist-thin.svg)
-  static const playlist = PhosphorFlatIconData(0xe6aa, 'Thin');
+  static const playlist = IconData(0xe6aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plug-thin.svg)
-  static const plug = PhosphorFlatIconData(0xe946, 'Thin');
+  static const plug = IconData(0xe946,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plug-charging-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plug-charging-thin.svg)
-  static const plugCharging = PhosphorFlatIconData(0xeb5c, 'Thin');
+  static const plugCharging = IconData(0xeb5c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plugs-thin.svg)
-  static const plugs = PhosphorFlatIconData(0xeb56, 'Thin');
+  static const plugs = IconData(0xeb56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plugs-connected-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plugs-connected-thin.svg)
-  static const plugsConnected = PhosphorFlatIconData(0xeb5a, 'Thin');
+  static const plugsConnected = IconData(0xeb5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plus-thin.svg)
-  static const plus = PhosphorFlatIconData(0xe3d4, 'Thin');
+  static const plus = IconData(0xe3d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plus-circle-thin.svg)
-  static const plusCircle = PhosphorFlatIconData(0xe3d6, 'Thin');
+  static const plusCircle = IconData(0xe3d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plus-minus-thin.svg)
-  static const plusMinus = PhosphorFlatIconData(0xe3d8, 'Thin');
+  static const plusMinus = IconData(0xe3d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![plus-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/plus-square-thin.svg)
-  static const plusSquare = PhosphorFlatIconData(0xed4a, 'Thin');
+  static const plusSquare = IconData(0xed4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![poker-chip-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/poker-chip-thin.svg)
-  static const pokerChip = PhosphorFlatIconData(0xe594, 'Thin');
+  static const pokerChip = IconData(0xe594,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![police-car-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/police-car-thin.svg)
-  static const policeCar = PhosphorFlatIconData(0xec4a, 'Thin');
+  static const policeCar = IconData(0xec4a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![polygon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/polygon-thin.svg)
-  static const polygon = PhosphorFlatIconData(0xe6d0, 'Thin');
+  static const polygon = IconData(0xe6d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popcorn-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/popcorn-thin.svg)
-  static const popcorn = PhosphorFlatIconData(0xeb4e, 'Thin');
+  static const popcorn = IconData(0xeb4e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![popsicle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/popsicle-thin.svg)
-  static const popsicle = PhosphorFlatIconData(0xebbe, 'Thin');
+  static const popsicle = IconData(0xebbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![potted-plant-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/potted-plant-thin.svg)
-  static const pottedPlant = PhosphorFlatIconData(0xec22, 'Thin');
+  static const pottedPlant = IconData(0xec22,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![power-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/power-thin.svg)
-  static const power = PhosphorFlatIconData(0xe3da, 'Thin');
+  static const power = IconData(0xe3da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prescription-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/prescription-thin.svg)
-  static const prescription = PhosphorFlatIconData(0xe7a2, 'Thin');
+  static const prescription = IconData(0xe7a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/presentation-thin.svg)
-  static const presentation = PhosphorFlatIconData(0xe654, 'Thin');
+  static const presentation = IconData(0xe654,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![presentation-chart-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/presentation-chart-thin.svg)
-  static const presentationChart = PhosphorFlatIconData(0xe656, 'Thin');
+  static const presentationChart = IconData(0xe656,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![printer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/printer-thin.svg)
-  static const printer = PhosphorFlatIconData(0xe3dc, 'Thin');
+  static const printer = IconData(0xe3dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/prohibit-thin.svg)
-  static const prohibit = PhosphorFlatIconData(0xe3de, 'Thin');
+  static const prohibit = IconData(0xe3de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![prohibit-inset-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/prohibit-inset-thin.svg)
-  static const prohibitInset = PhosphorFlatIconData(0xe3e0, 'Thin');
+  static const prohibitInset = IconData(0xe3e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/projector-screen-thin.svg)
-  static const projectorScreen = PhosphorFlatIconData(0xe658, 'Thin');
+  static const projectorScreen = IconData(0xe658,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![projector-screen-chart-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/projector-screen-chart-thin.svg)
-  static const projectorScreenChart = PhosphorFlatIconData(0xe65a, 'Thin');
+  static const projectorScreenChart = IconData(0xe65a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![pulse-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/pulse-thin.svg)
-  static const pulse = PhosphorFlatIconData(0xe000, 'Thin');
+  static const pulse = IconData(0xe000,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/push-pin-thin.svg)
-  static const pushPin = PhosphorFlatIconData(0xe3e2, 'Thin');
+  static const pushPin = IconData(0xe3e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/push-pin-simple-thin.svg)
-  static const pushPinSimple = PhosphorFlatIconData(0xe65c, 'Thin');
+  static const pushPinSimple = IconData(0xe65c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-simple-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/push-pin-simple-slash-thin.svg)
-  static const pushPinSimpleSlash = PhosphorFlatIconData(0xe65e, 'Thin');
+  static const pushPinSimpleSlash = IconData(0xe65e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![push-pin-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/push-pin-slash-thin.svg)
-  static const pushPinSlash = PhosphorFlatIconData(0xe3e4, 'Thin');
+  static const pushPinSlash = IconData(0xe3e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![puzzle-piece-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/puzzle-piece-thin.svg)
-  static const puzzlePiece = PhosphorFlatIconData(0xe596, 'Thin');
+  static const puzzlePiece = IconData(0xe596,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![qr-code-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/qr-code-thin.svg)
-  static const qrCode = PhosphorFlatIconData(0xe3e6, 'Thin');
+  static const qrCode = IconData(0xe3e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/question-thin.svg)
-  static const question = PhosphorFlatIconData(0xe3e8, 'Thin');
+  static const question = IconData(0xe3e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![question-mark-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/question-mark-thin.svg)
-  static const questionMark = PhosphorFlatIconData(0xe3e9, 'Thin');
+  static const questionMark = IconData(0xe3e9,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![queue-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/queue-thin.svg)
-  static const queue = PhosphorFlatIconData(0xe6ac, 'Thin');
+  static const queue = IconData(0xe6ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![quotes-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/quotes-thin.svg)
-  static const quotes = PhosphorFlatIconData(0xe660, 'Thin');
+  static const quotes = IconData(0xe660,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rabbit-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rabbit-thin.svg)
-  static const rabbit = PhosphorFlatIconData(0xeac2, 'Thin');
+  static const rabbit = IconData(0xeac2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![racquet-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/racquet-thin.svg)
-  static const racquet = PhosphorFlatIconData(0xee02, 'Thin');
+  static const racquet = IconData(0xee02,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/radical-thin.svg)
-  static const radical = PhosphorFlatIconData(0xe3ea, 'Thin');
+  static const radical = IconData(0xe3ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/radio-thin.svg)
-  static const radio = PhosphorFlatIconData(0xe77e, 'Thin');
+  static const radio = IconData(0xe77e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radio-button-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/radio-button-thin.svg)
-  static const radioButton = PhosphorFlatIconData(0xeb08, 'Thin');
+  static const radioButton = IconData(0xeb08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![radioactive-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/radioactive-thin.svg)
-  static const radioactive = PhosphorFlatIconData(0xe9dc, 'Thin');
+  static const radioactive = IconData(0xe9dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rainbow-thin.svg)
-  static const rainbow = PhosphorFlatIconData(0xe598, 'Thin');
+  static const rainbow = IconData(0xe598,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rainbow-cloud-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rainbow-cloud-thin.svg)
-  static const rainbowCloud = PhosphorFlatIconData(0xe59a, 'Thin');
+  static const rainbowCloud = IconData(0xe59a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ranking-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ranking-thin.svg)
-  static const ranking = PhosphorFlatIconData(0xed62, 'Thin');
+  static const ranking = IconData(0xed62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![read-cv-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/read-cv-logo-thin.svg)
-  static const readCvLogo = PhosphorFlatIconData(0xed0c, 'Thin');
+  static const readCvLogo = IconData(0xed0c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/receipt-thin.svg)
-  static const receipt = PhosphorFlatIconData(0xe3ec, 'Thin');
+  static const receipt = IconData(0xe3ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![receipt-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/receipt-x-thin.svg)
-  static const receiptX = PhosphorFlatIconData(0xed40, 'Thin');
+  static const receiptX = IconData(0xed40,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![record-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/record-thin.svg)
-  static const record = PhosphorFlatIconData(0xe3ee, 'Thin');
+  static const record = IconData(0xe3ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rectangle-thin.svg)
-  static const rectangle = PhosphorFlatIconData(0xe3f0, 'Thin');
+  static const rectangle = IconData(0xe3f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rectangle-dashed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rectangle-dashed-thin.svg)
-  static const rectangleDashed = PhosphorFlatIconData(0xe3f2, 'Thin');
+  static const rectangleDashed = IconData(0xe3f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![recycle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/recycle-thin.svg)
-  static const recycle = PhosphorFlatIconData(0xe75a, 'Thin');
+  static const recycle = IconData(0xe75a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![reddit-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/reddit-logo-thin.svg)
-  static const redditLogo = PhosphorFlatIconData(0xe59c, 'Thin');
+  static const redditLogo = IconData(0xe59c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/repeat-thin.svg)
-  static const repeat = PhosphorFlatIconData(0xe3f6, 'Thin');
+  static const repeat = IconData(0xe3f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![repeat-once-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/repeat-once-thin.svg)
-  static const repeatOnce = PhosphorFlatIconData(0xe3f8, 'Thin');
+  static const repeatOnce = IconData(0xe3f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![replit-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/replit-logo-thin.svg)
-  static const replitLogo = PhosphorFlatIconData(0xeb8a, 'Thin');
+  static const replitLogo = IconData(0xeb8a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![resize-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/resize-thin.svg)
-  static const resize = PhosphorFlatIconData(0xed6e, 'Thin');
+  static const resize = IconData(0xed6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rewind-thin.svg)
-  static const rewind = PhosphorFlatIconData(0xe6a8, 'Thin');
+  static const rewind = IconData(0xe6a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rewind-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rewind-circle-thin.svg)
-  static const rewindCircle = PhosphorFlatIconData(0xe3fa, 'Thin');
+  static const rewindCircle = IconData(0xe3fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![road-horizon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/road-horizon-thin.svg)
-  static const roadHorizon = PhosphorFlatIconData(0xe838, 'Thin');
+  static const roadHorizon = IconData(0xe838,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![robot-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/robot-thin.svg)
-  static const robot = PhosphorFlatIconData(0xe762, 'Thin');
+  static const robot = IconData(0xe762,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rocket-thin.svg)
-  static const rocket = PhosphorFlatIconData(0xe3fc, 'Thin');
+  static const rocket = IconData(0xe3fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rocket-launch-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rocket-launch-thin.svg)
-  static const rocketLaunch = PhosphorFlatIconData(0xe3fe, 'Thin');
+  static const rocketLaunch = IconData(0xe3fe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rows-thin.svg)
-  static const rows = PhosphorFlatIconData(0xe5a2, 'Thin');
+  static const rows = IconData(0xe5a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-bottom-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rows-plus-bottom-thin.svg)
-  static const rowsPlusBottom = PhosphorFlatIconData(0xe59e, 'Thin');
+  static const rowsPlusBottom = IconData(0xe59e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rows-plus-top-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rows-plus-top-thin.svg)
-  static const rowsPlusTop = PhosphorFlatIconData(0xe5a0, 'Thin');
+  static const rowsPlusTop = IconData(0xe5a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rss-thin.svg)
-  static const rss = PhosphorFlatIconData(0xe400, 'Thin');
+  static const rss = IconData(0xe400,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rss-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rss-simple-thin.svg)
-  static const rssSimple = PhosphorFlatIconData(0xe402, 'Thin');
+  static const rssSimple = IconData(0xe402,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![rug-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/rug-thin.svg)
-  static const rug = PhosphorFlatIconData(0xea1a, 'Thin');
+  static const rug = IconData(0xea1a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ruler-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ruler-thin.svg)
-  static const ruler = PhosphorFlatIconData(0xe6b8, 'Thin');
+  static const ruler = IconData(0xe6b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sailboat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sailboat-thin.svg)
-  static const sailboat = PhosphorFlatIconData(0xe78a, 'Thin');
+  static const sailboat = IconData(0xe78a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scales-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/scales-thin.svg)
-  static const scales = PhosphorFlatIconData(0xe750, 'Thin');
+  static const scales = IconData(0xe750,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/scan-thin.svg)
-  static const scan = PhosphorFlatIconData(0xebb6, 'Thin');
+  static const scan = IconData(0xebb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scan-smiley-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/scan-smiley-thin.svg)
-  static const scanSmiley = PhosphorFlatIconData(0xebb4, 'Thin');
+  static const scanSmiley = IconData(0xebb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scissors-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/scissors-thin.svg)
-  static const scissors = PhosphorFlatIconData(0xeae0, 'Thin');
+  static const scissors = IconData(0xeae0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scooter-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/scooter-thin.svg)
-  static const scooter = PhosphorFlatIconData(0xe820, 'Thin');
+  static const scooter = IconData(0xe820,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screencast-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/screencast-thin.svg)
-  static const screencast = PhosphorFlatIconData(0xe404, 'Thin');
+  static const screencast = IconData(0xe404,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![screwdriver-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/screwdriver-thin.svg)
-  static const screwdriver = PhosphorFlatIconData(0xe86e, 'Thin');
+  static const screwdriver = IconData(0xe86e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/scribble-thin.svg)
-  static const scribble = PhosphorFlatIconData(0xe806, 'Thin');
+  static const scribble = IconData(0xe806,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scribble-loop-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/scribble-loop-thin.svg)
-  static const scribbleLoop = PhosphorFlatIconData(0xe662, 'Thin');
+  static const scribbleLoop = IconData(0xe662,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![scroll-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/scroll-thin.svg)
-  static const scroll = PhosphorFlatIconData(0xeb7a, 'Thin');
+  static const scroll = IconData(0xeb7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/seal-thin.svg)
-  static const seal = PhosphorFlatIconData(0xe604, 'Thin');
+  static const seal = IconData(0xe604,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-check-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/seal-check-thin.svg)
-  static const sealCheck = PhosphorFlatIconData(0xe606, 'Thin');
+  static const sealCheck = IconData(0xe606,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-percent-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/seal-percent-thin.svg)
-  static const sealPercent = PhosphorFlatIconData(0xe60a, 'Thin');
+  static const sealPercent = IconData(0xe60a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-question-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/seal-question-thin.svg)
-  static const sealQuestion = PhosphorFlatIconData(0xe608, 'Thin');
+  static const sealQuestion = IconData(0xe608,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seal-warning-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/seal-warning-thin.svg)
-  static const sealWarning = PhosphorFlatIconData(0xe60c, 'Thin');
+  static const sealWarning = IconData(0xe60c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/seat-thin.svg)
-  static const seat = PhosphorFlatIconData(0xeb8e, 'Thin');
+  static const seat = IconData(0xeb8e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![seatbelt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/seatbelt-thin.svg)
-  static const seatbelt = PhosphorFlatIconData(0xedfe, 'Thin');
+  static const seatbelt = IconData(0xedfe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![security-camera-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/security-camera-thin.svg)
-  static const securityCamera = PhosphorFlatIconData(0xeca4, 'Thin');
+  static const securityCamera = IconData(0xeca4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/selection-thin.svg)
-  static const selection = PhosphorFlatIconData(0xe69a, 'Thin');
+  static const selection = IconData(0xe69a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-all-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/selection-all-thin.svg)
-  static const selectionAll = PhosphorFlatIconData(0xe746, 'Thin');
+  static const selectionAll = IconData(0xe746,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-background-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/selection-background-thin.svg)
-  static const selectionBackground = PhosphorFlatIconData(0xeaf8, 'Thin');
+  static const selectionBackground = IconData(0xeaf8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-foreground-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/selection-foreground-thin.svg)
-  static const selectionForeground = PhosphorFlatIconData(0xeaf6, 'Thin');
+  static const selectionForeground = IconData(0xeaf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-inverse-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/selection-inverse-thin.svg)
-  static const selectionInverse = PhosphorFlatIconData(0xe744, 'Thin');
+  static const selectionInverse = IconData(0xe744,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/selection-plus-thin.svg)
-  static const selectionPlus = PhosphorFlatIconData(0xe69c, 'Thin');
+  static const selectionPlus = IconData(0xe69c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![selection-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/selection-slash-thin.svg)
-  static const selectionSlash = PhosphorFlatIconData(0xe69e, 'Thin');
+  static const selectionSlash = IconData(0xe69e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shapes-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shapes-thin.svg)
-  static const shapes = PhosphorFlatIconData(0xec5e, 'Thin');
+  static const shapes = IconData(0xec5e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/share-thin.svg)
-  static const share = PhosphorFlatIconData(0xe406, 'Thin');
+  static const share = IconData(0xe406,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-fat-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/share-fat-thin.svg)
-  static const shareFat = PhosphorFlatIconData(0xed52, 'Thin');
+  static const shareFat = IconData(0xed52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![share-network-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/share-network-thin.svg)
-  static const shareNetwork = PhosphorFlatIconData(0xe408, 'Thin');
+  static const shareNetwork = IconData(0xe408,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shield-thin.svg)
-  static const shield = PhosphorFlatIconData(0xe40a, 'Thin');
+  static const shield = IconData(0xe40a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-check-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shield-check-thin.svg)
-  static const shieldCheck = PhosphorFlatIconData(0xe40c, 'Thin');
+  static const shieldCheck = IconData(0xe40c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-checkered-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shield-checkered-thin.svg)
-  static const shieldCheckered = PhosphorFlatIconData(0xe708, 'Thin');
+  static const shieldCheckered = IconData(0xe708,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-chevron-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shield-chevron-thin.svg)
-  static const shieldChevron = PhosphorFlatIconData(0xe40e, 'Thin');
+  static const shieldChevron = IconData(0xe40e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shield-plus-thin.svg)
-  static const shieldPlus = PhosphorFlatIconData(0xe706, 'Thin');
+  static const shieldPlus = IconData(0xe706,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shield-slash-thin.svg)
-  static const shieldSlash = PhosphorFlatIconData(0xe410, 'Thin');
+  static const shieldSlash = IconData(0xe410,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-star-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shield-star-thin.svg)
-  static const shieldStar = PhosphorFlatIconData(0xec34, 'Thin');
+  static const shieldStar = IconData(0xec34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shield-warning-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shield-warning-thin.svg)
-  static const shieldWarning = PhosphorFlatIconData(0xe412, 'Thin');
+  static const shieldWarning = IconData(0xe412,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shipping-container-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shipping-container-thin.svg)
-  static const shippingContainer = PhosphorFlatIconData(0xe78c, 'Thin');
+  static const shippingContainer = IconData(0xe78c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shirt-folded-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shirt-folded-thin.svg)
-  static const shirtFolded = PhosphorFlatIconData(0xea92, 'Thin');
+  static const shirtFolded = IconData(0xea92,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shooting-star-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shooting-star-thin.svg)
-  static const shootingStar = PhosphorFlatIconData(0xecfa, 'Thin');
+  static const shootingStar = IconData(0xecfa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shopping-bag-thin.svg)
-  static const shoppingBag = PhosphorFlatIconData(0xe416, 'Thin');
+  static const shoppingBag = IconData(0xe416,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-bag-open-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shopping-bag-open-thin.svg)
-  static const shoppingBagOpen = PhosphorFlatIconData(0xe418, 'Thin');
+  static const shoppingBagOpen = IconData(0xe418,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shopping-cart-thin.svg)
-  static const shoppingCart = PhosphorFlatIconData(0xe41e, 'Thin');
+  static const shoppingCart = IconData(0xe41e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shopping-cart-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shopping-cart-simple-thin.svg)
-  static const shoppingCartSimple = PhosphorFlatIconData(0xe420, 'Thin');
+  static const shoppingCartSimple = IconData(0xe420,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shovel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shovel-thin.svg)
-  static const shovel = PhosphorFlatIconData(0xe9e6, 'Thin');
+  static const shovel = IconData(0xe9e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shower-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shower-thin.svg)
-  static const shower = PhosphorFlatIconData(0xe776, 'Thin');
+  static const shower = IconData(0xe776,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shrimp-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shrimp-thin.svg)
-  static const shrimp = PhosphorFlatIconData(0xeab4, 'Thin');
+  static const shrimp = IconData(0xeab4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shuffle-thin.svg)
-  static const shuffle = PhosphorFlatIconData(0xe422, 'Thin');
+  static const shuffle = IconData(0xe422,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-angular-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shuffle-angular-thin.svg)
-  static const shuffleAngular = PhosphorFlatIconData(0xe424, 'Thin');
+  static const shuffleAngular = IconData(0xe424,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![shuffle-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/shuffle-simple-thin.svg)
-  static const shuffleSimple = PhosphorFlatIconData(0xe426, 'Thin');
+  static const shuffleSimple = IconData(0xe426,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sidebar-thin.svg)
-  static const sidebar = PhosphorFlatIconData(0xeab6, 'Thin');
+  static const sidebar = IconData(0xeab6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sidebar-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sidebar-simple-thin.svg)
-  static const sidebarSimple = PhosphorFlatIconData(0xec24, 'Thin');
+  static const sidebarSimple = IconData(0xec24,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sigma-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sigma-thin.svg)
-  static const sigma = PhosphorFlatIconData(0xeab8, 'Thin');
+  static const sigma = IconData(0xeab8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-in-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sign-in-thin.svg)
-  static const signIn = PhosphorFlatIconData(0xe428, 'Thin');
+  static const signIn = IconData(0xe428,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sign-out-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sign-out-thin.svg)
-  static const signOut = PhosphorFlatIconData(0xe42a, 'Thin');
+  static const signOut = IconData(0xe42a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signature-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/signature-thin.svg)
-  static const signature = PhosphorFlatIconData(0xebac, 'Thin');
+  static const signature = IconData(0xebac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![signpost-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/signpost-thin.svg)
-  static const signpost = PhosphorFlatIconData(0xe89c, 'Thin');
+  static const signpost = IconData(0xe89c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sim-card-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sim-card-thin.svg)
-  static const simCard = PhosphorFlatIconData(0xe664, 'Thin');
+  static const simCard = IconData(0xe664,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![siren-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/siren-thin.svg)
-  static const siren = PhosphorFlatIconData(0xe9b8, 'Thin');
+  static const siren = IconData(0xe9b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sketch-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sketch-logo-thin.svg)
-  static const sketchLogo = PhosphorFlatIconData(0xe42c, 'Thin');
+  static const sketchLogo = IconData(0xe42c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/skip-back-thin.svg)
-  static const skipBack = PhosphorFlatIconData(0xe5a4, 'Thin');
+  static const skipBack = IconData(0xe5a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-back-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/skip-back-circle-thin.svg)
-  static const skipBackCircle = PhosphorFlatIconData(0xe42e, 'Thin');
+  static const skipBackCircle = IconData(0xe42e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/skip-forward-thin.svg)
-  static const skipForward = PhosphorFlatIconData(0xe5a6, 'Thin');
+  static const skipForward = IconData(0xe5a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skip-forward-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/skip-forward-circle-thin.svg)
-  static const skipForwardCircle = PhosphorFlatIconData(0xe430, 'Thin');
+  static const skipForwardCircle = IconData(0xe430,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skull-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/skull-thin.svg)
-  static const skull = PhosphorFlatIconData(0xe916, 'Thin');
+  static const skull = IconData(0xe916,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![skype-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/skype-logo-thin.svg)
-  static const skypeLogo = PhosphorFlatIconData(0xe8dc, 'Thin');
+  static const skypeLogo = IconData(0xe8dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slack-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/slack-logo-thin.svg)
-  static const slackLogo = PhosphorFlatIconData(0xe5a8, 'Thin');
+  static const slackLogo = IconData(0xe5a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sliders-thin.svg)
-  static const sliders = PhosphorFlatIconData(0xe432, 'Thin');
+  static const sliders = IconData(0xe432,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sliders-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sliders-horizontal-thin.svg)
-  static const slidersHorizontal = PhosphorFlatIconData(0xe434, 'Thin');
+  static const slidersHorizontal = IconData(0xe434,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![slideshow-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/slideshow-thin.svg)
-  static const slideshow = PhosphorFlatIconData(0xed32, 'Thin');
+  static const slideshow = IconData(0xed32,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-thin.svg)
-  static const smiley = PhosphorFlatIconData(0xe436, 'Thin');
+  static const smiley = IconData(0xe436,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-angry-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-angry-thin.svg)
-  static const smileyAngry = PhosphorFlatIconData(0xec62, 'Thin');
+  static const smileyAngry = IconData(0xec62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-blank-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-blank-thin.svg)
-  static const smileyBlank = PhosphorFlatIconData(0xe438, 'Thin');
+  static const smileyBlank = IconData(0xe438,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-meh-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-meh-thin.svg)
-  static const smileyMeh = PhosphorFlatIconData(0xe43a, 'Thin');
+  static const smileyMeh = IconData(0xe43a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-melting-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-melting-thin.svg)
-  static const smileyMelting = PhosphorFlatIconData(0xee56, 'Thin');
+  static const smileyMelting = IconData(0xee56,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-nervous-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-nervous-thin.svg)
-  static const smileyNervous = PhosphorFlatIconData(0xe43c, 'Thin');
+  static const smileyNervous = IconData(0xe43c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sad-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-sad-thin.svg)
-  static const smileySad = PhosphorFlatIconData(0xe43e, 'Thin');
+  static const smileySad = IconData(0xe43e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-sticker-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-sticker-thin.svg)
-  static const smileySticker = PhosphorFlatIconData(0xe440, 'Thin');
+  static const smileySticker = IconData(0xe440,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-wink-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-wink-thin.svg)
-  static const smileyWink = PhosphorFlatIconData(0xe666, 'Thin');
+  static const smileyWink = IconData(0xe666,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![smiley-x-eyes-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/smiley-x-eyes-thin.svg)
-  static const smileyXEyes = PhosphorFlatIconData(0xe442, 'Thin');
+  static const smileyXEyes = IconData(0xe442,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snapchat-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/snapchat-logo-thin.svg)
-  static const snapchatLogo = PhosphorFlatIconData(0xe668, 'Thin');
+  static const snapchatLogo = IconData(0xe668,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sneaker-thin.svg)
-  static const sneaker = PhosphorFlatIconData(0xe80c, 'Thin');
+  static const sneaker = IconData(0xe80c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sneaker-move-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sneaker-move-thin.svg)
-  static const sneakerMove = PhosphorFlatIconData(0xed60, 'Thin');
+  static const sneakerMove = IconData(0xed60,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![snowflake-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/snowflake-thin.svg)
-  static const snowflake = PhosphorFlatIconData(0xe5aa, 'Thin');
+  static const snowflake = IconData(0xe5aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soccer-ball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/soccer-ball-thin.svg)
-  static const soccerBall = PhosphorFlatIconData(0xe716, 'Thin');
+  static const soccerBall = IconData(0xe716,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sock-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sock-thin.svg)
-  static const sock = PhosphorFlatIconData(0xecce, 'Thin');
+  static const sock = IconData(0xecce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-panel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/solar-panel-thin.svg)
-  static const solarPanel = PhosphorFlatIconData(0xed7a, 'Thin');
+  static const solarPanel = IconData(0xed7a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![solar-roof-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/solar-roof-thin.svg)
-  static const solarRoof = PhosphorFlatIconData(0xed7b, 'Thin');
+  static const solarRoof = IconData(0xed7b,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-ascending-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sort-ascending-thin.svg)
-  static const sortAscending = PhosphorFlatIconData(0xe444, 'Thin');
+  static const sortAscending = IconData(0xe444,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sort-descending-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sort-descending-thin.svg)
-  static const sortDescending = PhosphorFlatIconData(0xe446, 'Thin');
+  static const sortDescending = IconData(0xe446,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![soundcloud-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/soundcloud-logo-thin.svg)
-  static const soundcloudLogo = PhosphorFlatIconData(0xe8de, 'Thin');
+  static const soundcloudLogo = IconData(0xe8de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spade-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/spade-thin.svg)
-  static const spade = PhosphorFlatIconData(0xe448, 'Thin');
+  static const spade = IconData(0xe448,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sparkle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sparkle-thin.svg)
-  static const sparkle = PhosphorFlatIconData(0xe6a2, 'Thin');
+  static const sparkle = IconData(0xe6a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-hifi-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-hifi-thin.svg)
-  static const speakerHifi = PhosphorFlatIconData(0xea08, 'Thin');
+  static const speakerHifi = IconData(0xea08,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-high-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-high-thin.svg)
-  static const speakerHigh = PhosphorFlatIconData(0xe44a, 'Thin');
+  static const speakerHigh = IconData(0xe44a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-low-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-low-thin.svg)
-  static const speakerLow = PhosphorFlatIconData(0xe44c, 'Thin');
+  static const speakerLow = IconData(0xe44c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-none-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-none-thin.svg)
-  static const speakerNone = PhosphorFlatIconData(0xe44e, 'Thin');
+  static const speakerNone = IconData(0xe44e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-high-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-simple-high-thin.svg)
-  static const speakerSimpleHigh = PhosphorFlatIconData(0xe450, 'Thin');
+  static const speakerSimpleHigh = IconData(0xe450,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-low-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-simple-low-thin.svg)
-  static const speakerSimpleLow = PhosphorFlatIconData(0xe452, 'Thin');
+  static const speakerSimpleLow = IconData(0xe452,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-none-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-simple-none-thin.svg)
-  static const speakerSimpleNone = PhosphorFlatIconData(0xe454, 'Thin');
+  static const speakerSimpleNone = IconData(0xe454,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-simple-slash-thin.svg)
-  static const speakerSimpleSlash = PhosphorFlatIconData(0xe456, 'Thin');
+  static const speakerSimpleSlash = IconData(0xe456,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-simple-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-simple-x-thin.svg)
-  static const speakerSimpleX = PhosphorFlatIconData(0xe458, 'Thin');
+  static const speakerSimpleX = IconData(0xe458,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-slash-thin.svg)
-  static const speakerSlash = PhosphorFlatIconData(0xe45a, 'Thin');
+  static const speakerSlash = IconData(0xe45a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speaker-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speaker-x-thin.svg)
-  static const speakerX = PhosphorFlatIconData(0xe45c, 'Thin');
+  static const speakerX = IconData(0xe45c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![speedometer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/speedometer-thin.svg)
-  static const speedometer = PhosphorFlatIconData(0xee74, 'Thin');
+  static const speedometer = IconData(0xee74,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sphere-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sphere-thin.svg)
-  static const sphere = PhosphorFlatIconData(0xee66, 'Thin');
+  static const sphere = IconData(0xee66,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/spinner-thin.svg)
-  static const spinner = PhosphorFlatIconData(0xe66a, 'Thin');
+  static const spinner = IconData(0xe66a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-ball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/spinner-ball-thin.svg)
-  static const spinnerBall = PhosphorFlatIconData(0xee28, 'Thin');
+  static const spinnerBall = IconData(0xee28,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spinner-gap-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/spinner-gap-thin.svg)
-  static const spinnerGap = PhosphorFlatIconData(0xe66c, 'Thin');
+  static const spinnerGap = IconData(0xe66c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spiral-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/spiral-thin.svg)
-  static const spiral = PhosphorFlatIconData(0xe9fa, 'Thin');
+  static const spiral = IconData(0xe9fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/split-horizontal-thin.svg)
-  static const splitHorizontal = PhosphorFlatIconData(0xe872, 'Thin');
+  static const splitHorizontal = IconData(0xe872,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![split-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/split-vertical-thin.svg)
-  static const splitVertical = PhosphorFlatIconData(0xe876, 'Thin');
+  static const splitVertical = IconData(0xe876,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spotify-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/spotify-logo-thin.svg)
-  static const spotifyLogo = PhosphorFlatIconData(0xe66e, 'Thin');
+  static const spotifyLogo = IconData(0xe66e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![spray-bottle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/spray-bottle-thin.svg)
-  static const sprayBottle = PhosphorFlatIconData(0xe7e4, 'Thin');
+  static const sprayBottle = IconData(0xe7e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/square-thin.svg)
-  static const square = PhosphorFlatIconData(0xe45e, 'Thin');
+  static const square = IconData(0xe45e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/square-half-thin.svg)
-  static const squareHalf = PhosphorFlatIconData(0xe462, 'Thin');
+  static const squareHalf = IconData(0xe462,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-half-bottom-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/square-half-bottom-thin.svg)
-  static const squareHalfBottom = PhosphorFlatIconData(0xeb16, 'Thin');
+  static const squareHalfBottom = IconData(0xeb16,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/square-logo-thin.svg)
-  static const squareLogo = PhosphorFlatIconData(0xe690, 'Thin');
+  static const squareLogo = IconData(0xe690,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-horizontal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/square-split-horizontal-thin.svg)
-  static const squareSplitHorizontal = PhosphorFlatIconData(0xe870, 'Thin');
+  static const squareSplitHorizontal = IconData(0xe870,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![square-split-vertical-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/square-split-vertical-thin.svg)
-  static const squareSplitVertical = PhosphorFlatIconData(0xe874, 'Thin');
+  static const squareSplitVertical = IconData(0xe874,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![squares-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/squares-four-thin.svg)
-  static const squaresFour = PhosphorFlatIconData(0xe464, 'Thin');
+  static const squaresFour = IconData(0xe464,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stack-thin.svg)
-  static const stack = PhosphorFlatIconData(0xe466, 'Thin');
+  static const stack = IconData(0xe466,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stack-minus-thin.svg)
-  static const stackMinus = PhosphorFlatIconData(0xedf4, 'Thin');
+  static const stackMinus = IconData(0xedf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-overflow-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stack-overflow-logo-thin.svg)
-  static const stackOverflowLogo = PhosphorFlatIconData(0xeb78, 'Thin');
+  static const stackOverflowLogo = IconData(0xeb78,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stack-plus-thin.svg)
-  static const stackPlus = PhosphorFlatIconData(0xedf6, 'Thin');
+  static const stackPlus = IconData(0xedf6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stack-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stack-simple-thin.svg)
-  static const stackSimple = PhosphorFlatIconData(0xe468, 'Thin');
+  static const stackSimple = IconData(0xe468,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stairs-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stairs-thin.svg)
-  static const stairs = PhosphorFlatIconData(0xe8ec, 'Thin');
+  static const stairs = IconData(0xe8ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stamp-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stamp-thin.svg)
-  static const stamp = PhosphorFlatIconData(0xea48, 'Thin');
+  static const stamp = IconData(0xea48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![standard-definition-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/standard-definition-thin.svg)
-  static const standardDefinition = PhosphorFlatIconData(0xea90, 'Thin');
+  static const standardDefinition = IconData(0xea90,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/star-thin.svg)
-  static const star = PhosphorFlatIconData(0xe46a, 'Thin');
+  static const star = IconData(0xe46a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-and-crescent-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/star-and-crescent-thin.svg)
-  static const starAndCrescent = PhosphorFlatIconData(0xecf4, 'Thin');
+  static const starAndCrescent = IconData(0xecf4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/star-four-thin.svg)
-  static const starFour = PhosphorFlatIconData(0xe6a4, 'Thin');
+  static const starFour = IconData(0xe6a4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-half-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/star-half-thin.svg)
-  static const starHalf = PhosphorFlatIconData(0xe70a, 'Thin');
+  static const starHalf = IconData(0xe70a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![star-of-david-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/star-of-david-thin.svg)
-  static const starOfDavid = PhosphorFlatIconData(0xe89e, 'Thin');
+  static const starOfDavid = IconData(0xe89e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steam-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/steam-logo-thin.svg)
-  static const steamLogo = PhosphorFlatIconData(0xead4, 'Thin');
+  static const steamLogo = IconData(0xead4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steering-wheel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/steering-wheel-thin.svg)
-  static const steeringWheel = PhosphorFlatIconData(0xe9ac, 'Thin');
+  static const steeringWheel = IconData(0xe9ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![steps-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/steps-thin.svg)
-  static const steps = PhosphorFlatIconData(0xecbe, 'Thin');
+  static const steps = IconData(0xecbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stethoscope-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stethoscope-thin.svg)
-  static const stethoscope = PhosphorFlatIconData(0xe7ea, 'Thin');
+  static const stethoscope = IconData(0xe7ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sticker-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sticker-thin.svg)
-  static const sticker = PhosphorFlatIconData(0xe5ac, 'Thin');
+  static const sticker = IconData(0xe5ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stool-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stool-thin.svg)
-  static const stool = PhosphorFlatIconData(0xea44, 'Thin');
+  static const stool = IconData(0xea44,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stop-thin.svg)
-  static const stop = PhosphorFlatIconData(0xe46c, 'Thin');
+  static const stop = IconData(0xe46c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stop-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stop-circle-thin.svg)
-  static const stopCircle = PhosphorFlatIconData(0xe46e, 'Thin');
+  static const stopCircle = IconData(0xe46e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![storefront-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/storefront-thin.svg)
-  static const storefront = PhosphorFlatIconData(0xe470, 'Thin');
+  static const storefront = IconData(0xe470,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![strategy-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/strategy-thin.svg)
-  static const strategy = PhosphorFlatIconData(0xea3a, 'Thin');
+  static const strategy = IconData(0xea3a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![stripe-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/stripe-logo-thin.svg)
-  static const stripeLogo = PhosphorFlatIconData(0xe698, 'Thin');
+  static const stripeLogo = IconData(0xe698,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![student-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/student-thin.svg)
-  static const student = PhosphorFlatIconData(0xe73e, 'Thin');
+  static const student = IconData(0xe73e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-of-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/subset-of-thin.svg)
-  static const subsetOf = PhosphorFlatIconData(0xedc0, 'Thin');
+  static const subsetOf = IconData(0xedc0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subset-proper-of-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/subset-proper-of-thin.svg)
-  static const subsetProperOf = PhosphorFlatIconData(0xedb6, 'Thin');
+  static const subsetProperOf = IconData(0xedb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/subtitles-thin.svg)
-  static const subtitles = PhosphorFlatIconData(0xe1a8, 'Thin');
+  static const subtitles = IconData(0xe1a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtitles-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/subtitles-slash-thin.svg)
-  static const subtitlesSlash = PhosphorFlatIconData(0xe1a6, 'Thin');
+  static const subtitlesSlash = IconData(0xe1a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/subtract-thin.svg)
-  static const subtract = PhosphorFlatIconData(0xebd6, 'Thin');
+  static const subtract = IconData(0xebd6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subtract-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/subtract-square-thin.svg)
-  static const subtractSquare = PhosphorFlatIconData(0xebd4, 'Thin');
+  static const subtractSquare = IconData(0xebd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![subway-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/subway-thin.svg)
-  static const subway = PhosphorFlatIconData(0xe498, 'Thin');
+  static const subway = IconData(0xe498,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/suitcase-thin.svg)
-  static const suitcase = PhosphorFlatIconData(0xe5ae, 'Thin');
+  static const suitcase = IconData(0xe5ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-rolling-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/suitcase-rolling-thin.svg)
-  static const suitcaseRolling = PhosphorFlatIconData(0xe9b0, 'Thin');
+  static const suitcaseRolling = IconData(0xe9b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![suitcase-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/suitcase-simple-thin.svg)
-  static const suitcaseSimple = PhosphorFlatIconData(0xe5b0, 'Thin');
+  static const suitcaseSimple = IconData(0xe5b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sun-thin.svg)
-  static const sun = PhosphorFlatIconData(0xe472, 'Thin');
+  static const sun = IconData(0xe472,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-dim-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sun-dim-thin.svg)
-  static const sunDim = PhosphorFlatIconData(0xe474, 'Thin');
+  static const sunDim = IconData(0xe474,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sun-horizon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sun-horizon-thin.svg)
-  static const sunHorizon = PhosphorFlatIconData(0xe5b6, 'Thin');
+  static const sunHorizon = IconData(0xe5b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sunglasses-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sunglasses-thin.svg)
-  static const sunglasses = PhosphorFlatIconData(0xe816, 'Thin');
+  static const sunglasses = IconData(0xe816,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-of-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/superset-of-thin.svg)
-  static const supersetOf = PhosphorFlatIconData(0xedb8, 'Thin');
+  static const supersetOf = IconData(0xedb8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![superset-proper-of-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/superset-proper-of-thin.svg)
-  static const supersetProperOf = PhosphorFlatIconData(0xedb4, 'Thin');
+  static const supersetProperOf = IconData(0xedb4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swap-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/swap-thin.svg)
-  static const swap = PhosphorFlatIconData(0xe83c, 'Thin');
+  static const swap = IconData(0xe83c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swatches-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/swatches-thin.svg)
-  static const swatches = PhosphorFlatIconData(0xe5b8, 'Thin');
+  static const swatches = IconData(0xe5b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![swimming-pool-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/swimming-pool-thin.svg)
-  static const swimmingPool = PhosphorFlatIconData(0xecb6, 'Thin');
+  static const swimmingPool = IconData(0xecb6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![sword-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/sword-thin.svg)
-  static const sword = PhosphorFlatIconData(0xe5ba, 'Thin');
+  static const sword = IconData(0xe5ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![synagogue-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/synagogue-thin.svg)
-  static const synagogue = PhosphorFlatIconData(0xecec, 'Thin');
+  static const synagogue = IconData(0xecec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![syringe-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/syringe-thin.svg)
-  static const syringe = PhosphorFlatIconData(0xe968, 'Thin');
+  static const syringe = IconData(0xe968,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![t-shirt-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/t-shirt-thin.svg)
-  static const tShirt = PhosphorFlatIconData(0xe670, 'Thin');
+  static const tShirt = IconData(0xe670,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![table-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/table-thin.svg)
-  static const table = PhosphorFlatIconData(0xe476, 'Thin');
+  static const table = IconData(0xe476,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tabs-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tabs-thin.svg)
-  static const tabs = PhosphorFlatIconData(0xe778, 'Thin');
+  static const tabs = IconData(0xe778,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tag-thin.svg)
-  static const tag = PhosphorFlatIconData(0xe478, 'Thin');
+  static const tag = IconData(0xe478,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-chevron-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tag-chevron-thin.svg)
-  static const tagChevron = PhosphorFlatIconData(0xe672, 'Thin');
+  static const tagChevron = IconData(0xe672,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tag-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tag-simple-thin.svg)
-  static const tagSimple = PhosphorFlatIconData(0xe47a, 'Thin');
+  static const tagSimple = IconData(0xe47a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![target-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/target-thin.svg)
-  static const target = PhosphorFlatIconData(0xe47c, 'Thin');
+  static const target = IconData(0xe47c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![taxi-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/taxi-thin.svg)
-  static const taxi = PhosphorFlatIconData(0xe902, 'Thin');
+  static const taxi = IconData(0xe902,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tea-bag-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tea-bag-thin.svg)
-  static const teaBag = PhosphorFlatIconData(0xe8e6, 'Thin');
+  static const teaBag = IconData(0xe8e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![telegram-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/telegram-logo-thin.svg)
-  static const telegramLogo = PhosphorFlatIconData(0xe5bc, 'Thin');
+  static const telegramLogo = IconData(0xe5bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/television-thin.svg)
-  static const television = PhosphorFlatIconData(0xe754, 'Thin');
+  static const television = IconData(0xe754,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![television-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/television-simple-thin.svg)
-  static const televisionSimple = PhosphorFlatIconData(0xeae6, 'Thin');
+  static const televisionSimple = IconData(0xeae6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tennis-ball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tennis-ball-thin.svg)
-  static const tennisBall = PhosphorFlatIconData(0xe720, 'Thin');
+  static const tennisBall = IconData(0xe720,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tent-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tent-thin.svg)
-  static const tent = PhosphorFlatIconData(0xe8ba, 'Thin');
+  static const tent = IconData(0xe8ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/terminal-thin.svg)
-  static const terminal = PhosphorFlatIconData(0xe47e, 'Thin');
+  static const terminal = IconData(0xe47e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![terminal-window-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/terminal-window-thin.svg)
-  static const terminalWindow = PhosphorFlatIconData(0xeae8, 'Thin');
+  static const terminalWindow = IconData(0xeae8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![test-tube-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/test-tube-thin.svg)
-  static const testTube = PhosphorFlatIconData(0xe7a0, 'Thin');
+  static const testTube = IconData(0xe7a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-a-underline-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-a-underline-thin.svg)
-  static const textAUnderline = PhosphorFlatIconData(0xed34, 'Thin');
+  static const textAUnderline = IconData(0xed34,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-aa-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-aa-thin.svg)
-  static const textAa = PhosphorFlatIconData(0xe6ee, 'Thin');
+  static const textAa = IconData(0xe6ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-center-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-align-center-thin.svg)
-  static const textAlignCenter = PhosphorFlatIconData(0xe480, 'Thin');
+  static const textAlignCenter = IconData(0xe480,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-justify-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-align-justify-thin.svg)
-  static const textAlignJustify = PhosphorFlatIconData(0xe482, 'Thin');
+  static const textAlignJustify = IconData(0xe482,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-align-left-thin.svg)
-  static const textAlignLeft = PhosphorFlatIconData(0xe484, 'Thin');
+  static const textAlignLeft = IconData(0xe484,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-align-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-align-right-thin.svg)
-  static const textAlignRight = PhosphorFlatIconData(0xe486, 'Thin');
+  static const textAlignRight = IconData(0xe486,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-b-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-b-thin.svg)
-  static const textB = PhosphorFlatIconData(0xe5be, 'Thin');
+  static const textB = IconData(0xe5be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-columns-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-columns-thin.svg)
-  static const textColumns = PhosphorFlatIconData(0xec96, 'Thin');
+  static const textColumns = IconData(0xec96,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-h-thin.svg)
-  static const textH = PhosphorFlatIconData(0xe6ba, 'Thin');
+  static const textH = IconData(0xe6ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-five-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-h-five-thin.svg)
-  static const textHFive = PhosphorFlatIconData(0xe6c4, 'Thin');
+  static const textHFive = IconData(0xe6c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-h-four-thin.svg)
-  static const textHFour = PhosphorFlatIconData(0xe6c2, 'Thin');
+  static const textHFour = IconData(0xe6c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-one-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-h-one-thin.svg)
-  static const textHOne = PhosphorFlatIconData(0xe6bc, 'Thin');
+  static const textHOne = IconData(0xe6bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-six-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-h-six-thin.svg)
-  static const textHSix = PhosphorFlatIconData(0xe6c6, 'Thin');
+  static const textHSix = IconData(0xe6c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-h-three-thin.svg)
-  static const textHThree = PhosphorFlatIconData(0xe6c0, 'Thin');
+  static const textHThree = IconData(0xe6c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-h-two-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-h-two-thin.svg)
-  static const textHTwo = PhosphorFlatIconData(0xe6be, 'Thin');
+  static const textHTwo = IconData(0xe6be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-indent-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-indent-thin.svg)
-  static const textIndent = PhosphorFlatIconData(0xea1e, 'Thin');
+  static const textIndent = IconData(0xea1e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-italic-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-italic-thin.svg)
-  static const textItalic = PhosphorFlatIconData(0xe5c0, 'Thin');
+  static const textItalic = IconData(0xe5c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-outdent-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-outdent-thin.svg)
-  static const textOutdent = PhosphorFlatIconData(0xea1c, 'Thin');
+  static const textOutdent = IconData(0xea1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-strikethrough-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-strikethrough-thin.svg)
-  static const textStrikethrough = PhosphorFlatIconData(0xe5c2, 'Thin');
+  static const textStrikethrough = IconData(0xe5c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-subscript-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-subscript-thin.svg)
-  static const textSubscript = PhosphorFlatIconData(0xec98, 'Thin');
+  static const textSubscript = IconData(0xec98,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-superscript-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-superscript-thin.svg)
-  static const textSuperscript = PhosphorFlatIconData(0xec9a, 'Thin');
+  static const textSuperscript = IconData(0xec9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-t-thin.svg)
-  static const textT = PhosphorFlatIconData(0xe48a, 'Thin');
+  static const textT = IconData(0xe48a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-t-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-t-slash-thin.svg)
-  static const textTSlash = PhosphorFlatIconData(0xe488, 'Thin');
+  static const textTSlash = IconData(0xe488,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![text-underline-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/text-underline-thin.svg)
-  static const textUnderline = PhosphorFlatIconData(0xe5c4, 'Thin');
+  static const textUnderline = IconData(0xe5c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![textbox-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/textbox-thin.svg)
-  static const textbox = PhosphorFlatIconData(0xeb0a, 'Thin');
+  static const textbox = IconData(0xeb0a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/thermometer-thin.svg)
-  static const thermometer = PhosphorFlatIconData(0xe5c6, 'Thin');
+  static const thermometer = IconData(0xe5c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-cold-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/thermometer-cold-thin.svg)
-  static const thermometerCold = PhosphorFlatIconData(0xe5c8, 'Thin');
+  static const thermometerCold = IconData(0xe5c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-hot-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/thermometer-hot-thin.svg)
-  static const thermometerHot = PhosphorFlatIconData(0xe5ca, 'Thin');
+  static const thermometerHot = IconData(0xe5ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thermometer-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/thermometer-simple-thin.svg)
-  static const thermometerSimple = PhosphorFlatIconData(0xe5cc, 'Thin');
+  static const thermometerSimple = IconData(0xe5cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![threads-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/threads-logo-thin.svg)
-  static const threadsLogo = PhosphorFlatIconData(0xed9e, 'Thin');
+  static const threadsLogo = IconData(0xed9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![three-d-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/three-d-thin.svg)
-  static const threeD = PhosphorFlatIconData(0xea5a, 'Thin');
+  static const threeD = IconData(0xea5a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/thumbs-down-thin.svg)
-  static const thumbsDown = PhosphorFlatIconData(0xe48c, 'Thin');
+  static const thumbsDown = IconData(0xe48c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![thumbs-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/thumbs-up-thin.svg)
-  static const thumbsUp = PhosphorFlatIconData(0xe48e, 'Thin');
+  static const thumbsUp = IconData(0xe48e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![ticket-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/ticket-thin.svg)
-  static const ticket = PhosphorFlatIconData(0xe490, 'Thin');
+  static const ticket = IconData(0xe490,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tidal-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tidal-logo-thin.svg)
-  static const tidalLogo = PhosphorFlatIconData(0xed1c, 'Thin');
+  static const tidalLogo = IconData(0xed1c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tiktok-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tiktok-logo-thin.svg)
-  static const tiktokLogo = PhosphorFlatIconData(0xeaf2, 'Thin');
+  static const tiktokLogo = IconData(0xeaf2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tilde-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tilde-thin.svg)
-  static const tilde = PhosphorFlatIconData(0xeda8, 'Thin');
+  static const tilde = IconData(0xeda8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![timer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/timer-thin.svg)
-  static const timer = PhosphorFlatIconData(0xe492, 'Thin');
+  static const timer = IconData(0xe492,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tip-jar-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tip-jar-thin.svg)
-  static const tipJar = PhosphorFlatIconData(0xe7e2, 'Thin');
+  static const tipJar = IconData(0xe7e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tipi-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tipi-thin.svg)
-  static const tipi = PhosphorFlatIconData(0xed30, 'Thin');
+  static const tipi = IconData(0xed30,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tire-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tire-thin.svg)
-  static const tire = PhosphorFlatIconData(0xedd2, 'Thin');
+  static const tire = IconData(0xedd2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-left-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/toggle-left-thin.svg)
-  static const toggleLeft = PhosphorFlatIconData(0xe674, 'Thin');
+  static const toggleLeft = IconData(0xe674,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toggle-right-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/toggle-right-thin.svg)
-  static const toggleRight = PhosphorFlatIconData(0xe676, 'Thin');
+  static const toggleRight = IconData(0xe676,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/toilet-thin.svg)
-  static const toilet = PhosphorFlatIconData(0xe79a, 'Thin');
+  static const toilet = IconData(0xe79a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toilet-paper-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/toilet-paper-thin.svg)
-  static const toiletPaper = PhosphorFlatIconData(0xe79c, 'Thin');
+  static const toiletPaper = IconData(0xe79c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![toolbox-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/toolbox-thin.svg)
-  static const toolbox = PhosphorFlatIconData(0xeca0, 'Thin');
+  static const toolbox = IconData(0xeca0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tooth-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tooth-thin.svg)
-  static const tooth = PhosphorFlatIconData(0xe9cc, 'Thin');
+  static const tooth = IconData(0xe9cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tornado-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tornado-thin.svg)
-  static const tornado = PhosphorFlatIconData(0xe88c, 'Thin');
+  static const tornado = IconData(0xe88c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tote-thin.svg)
-  static const tote = PhosphorFlatIconData(0xe494, 'Thin');
+  static const tote = IconData(0xe494,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tote-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tote-simple-thin.svg)
-  static const toteSimple = PhosphorFlatIconData(0xe678, 'Thin');
+  static const toteSimple = IconData(0xe678,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![towel-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/towel-thin.svg)
-  static const towel = PhosphorFlatIconData(0xede6, 'Thin');
+  static const towel = IconData(0xede6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tractor-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tractor-thin.svg)
-  static const tractor = PhosphorFlatIconData(0xec6e, 'Thin');
+  static const tractor = IconData(0xec6e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trademark-thin.svg)
-  static const trademark = PhosphorFlatIconData(0xe9f0, 'Thin');
+  static const trademark = IconData(0xe9f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trademark-registered-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trademark-registered-thin.svg)
-  static const trademarkRegistered = PhosphorFlatIconData(0xe3f4, 'Thin');
+  static const trademarkRegistered = IconData(0xe3f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-cone-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/traffic-cone-thin.svg)
-  static const trafficCone = PhosphorFlatIconData(0xe9a8, 'Thin');
+  static const trafficCone = IconData(0xe9a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-sign-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/traffic-sign-thin.svg)
-  static const trafficSign = PhosphorFlatIconData(0xe67a, 'Thin');
+  static const trafficSign = IconData(0xe67a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![traffic-signal-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/traffic-signal-thin.svg)
-  static const trafficSignal = PhosphorFlatIconData(0xe9aa, 'Thin');
+  static const trafficSignal = IconData(0xe9aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/train-thin.svg)
-  static const train = PhosphorFlatIconData(0xe496, 'Thin');
+  static const train = IconData(0xe496,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-regional-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/train-regional-thin.svg)
-  static const trainRegional = PhosphorFlatIconData(0xe49e, 'Thin');
+  static const trainRegional = IconData(0xe49e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![train-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/train-simple-thin.svg)
-  static const trainSimple = PhosphorFlatIconData(0xe4a0, 'Thin');
+  static const trainSimple = IconData(0xe4a0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tram-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tram-thin.svg)
-  static const tram = PhosphorFlatIconData(0xe9ec, 'Thin');
+  static const tram = IconData(0xe9ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![translate-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/translate-thin.svg)
-  static const translate = PhosphorFlatIconData(0xe4a2, 'Thin');
+  static const translate = IconData(0xe4a2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trash-thin.svg)
-  static const trash = PhosphorFlatIconData(0xe4a6, 'Thin');
+  static const trash = IconData(0xe4a6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trash-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trash-simple-thin.svg)
-  static const trashSimple = PhosphorFlatIconData(0xe4a8, 'Thin');
+  static const trashSimple = IconData(0xe4a8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tray-thin.svg)
-  static const tray = PhosphorFlatIconData(0xe4aa, 'Thin');
+  static const tray = IconData(0xe4aa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tray-arrow-down-thin.svg)
-  static const trayArrowDown = PhosphorFlatIconData(0xe010, 'Thin');
+  static const trayArrowDown = IconData(0xe010,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tray-arrow-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tray-arrow-up-thin.svg)
-  static const trayArrowUp = PhosphorFlatIconData(0xee52, 'Thin');
+  static const trayArrowUp = IconData(0xee52,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![treasure-chest-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/treasure-chest-thin.svg)
-  static const treasureChest = PhosphorFlatIconData(0xede2, 'Thin');
+  static const treasureChest = IconData(0xede2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tree-thin.svg)
-  static const tree = PhosphorFlatIconData(0xe6da, 'Thin');
+  static const tree = IconData(0xe6da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-evergreen-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tree-evergreen-thin.svg)
-  static const treeEvergreen = PhosphorFlatIconData(0xe6dc, 'Thin');
+  static const treeEvergreen = IconData(0xe6dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-palm-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tree-palm-thin.svg)
-  static const treePalm = PhosphorFlatIconData(0xe91a, 'Thin');
+  static const treePalm = IconData(0xe91a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-structure-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tree-structure-thin.svg)
-  static const treeStructure = PhosphorFlatIconData(0xe67c, 'Thin');
+  static const treeStructure = IconData(0xe67c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tree-view-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tree-view-thin.svg)
-  static const treeView = PhosphorFlatIconData(0xee48, 'Thin');
+  static const treeView = IconData(0xee48,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-down-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trend-down-thin.svg)
-  static const trendDown = PhosphorFlatIconData(0xe4ac, 'Thin');
+  static const trendDown = IconData(0xe4ac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trend-up-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trend-up-thin.svg)
-  static const trendUp = PhosphorFlatIconData(0xe4ae, 'Thin');
+  static const trendUp = IconData(0xe4ae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/triangle-thin.svg)
-  static const triangle = PhosphorFlatIconData(0xe4b0, 'Thin');
+  static const triangle = IconData(0xe4b0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![triangle-dashed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/triangle-dashed-thin.svg)
-  static const triangleDashed = PhosphorFlatIconData(0xe4b2, 'Thin');
+  static const triangleDashed = IconData(0xe4b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trolley-thin.svg)
-  static const trolley = PhosphorFlatIconData(0xe5b2, 'Thin');
+  static const trolley = IconData(0xe5b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trolley-suitcase-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trolley-suitcase-thin.svg)
-  static const trolleySuitcase = PhosphorFlatIconData(0xe5b4, 'Thin');
+  static const trolleySuitcase = IconData(0xe5b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![trophy-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/trophy-thin.svg)
-  static const trophy = PhosphorFlatIconData(0xe67e, 'Thin');
+  static const trophy = IconData(0xe67e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/truck-thin.svg)
-  static const truck = PhosphorFlatIconData(0xe4b4, 'Thin');
+  static const truck = IconData(0xe4b4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![truck-trailer-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/truck-trailer-thin.svg)
-  static const truckTrailer = PhosphorFlatIconData(0xe4b6, 'Thin');
+  static const truckTrailer = IconData(0xe4b6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![tumblr-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/tumblr-logo-thin.svg)
-  static const tumblrLogo = PhosphorFlatIconData(0xe8d4, 'Thin');
+  static const tumblrLogo = IconData(0xe8d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitch-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/twitch-logo-thin.svg)
-  static const twitchLogo = PhosphorFlatIconData(0xe5ce, 'Thin');
+  static const twitchLogo = IconData(0xe5ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![twitter-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/twitter-logo-thin.svg)
-  static const twitterLogo = PhosphorFlatIconData(0xe4ba, 'Thin');
+  static const twitterLogo = IconData(0xe4ba,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/umbrella-thin.svg)
-  static const umbrella = PhosphorFlatIconData(0xe684, 'Thin');
+  static const umbrella = IconData(0xe684,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![umbrella-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/umbrella-simple-thin.svg)
-  static const umbrellaSimple = PhosphorFlatIconData(0xe686, 'Thin');
+  static const umbrellaSimple = IconData(0xe686,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![union-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/union-thin.svg)
-  static const union = PhosphorFlatIconData(0xedbe, 'Thin');
+  static const union = IconData(0xedbe,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/unite-thin.svg)
-  static const unite = PhosphorFlatIconData(0xe87e, 'Thin');
+  static const unite = IconData(0xe87e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![unite-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/unite-square-thin.svg)
-  static const uniteSquare = PhosphorFlatIconData(0xe878, 'Thin');
+  static const uniteSquare = IconData(0xe878,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/upload-thin.svg)
-  static const upload = PhosphorFlatIconData(0xe4be, 'Thin');
+  static const upload = IconData(0xe4be,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![upload-simple-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/upload-simple-thin.svg)
-  static const uploadSimple = PhosphorFlatIconData(0xe4c0, 'Thin');
+  static const uploadSimple = IconData(0xe4c0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![usb-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/usb-thin.svg)
-  static const usb = PhosphorFlatIconData(0xe956, 'Thin');
+  static const usb = IconData(0xe956,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-thin.svg)
-  static const user = PhosphorFlatIconData(0xe4c2, 'Thin');
+  static const user = IconData(0xe4c2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-check-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-check-thin.svg)
-  static const userCheck = PhosphorFlatIconData(0xeafa, 'Thin');
+  static const userCheck = IconData(0xeafa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-circle-thin.svg)
-  static const userCircle = PhosphorFlatIconData(0xe4c4, 'Thin');
+  static const userCircle = IconData(0xe4c4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-check-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-circle-check-thin.svg)
-  static const userCircleCheck = PhosphorFlatIconData(0xec38, 'Thin');
+  static const userCircleCheck = IconData(0xec38,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-dashed-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-circle-dashed-thin.svg)
-  static const userCircleDashed = PhosphorFlatIconData(0xec36, 'Thin');
+  static const userCircleDashed = IconData(0xec36,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-gear-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-circle-gear-thin.svg)
-  static const userCircleGear = PhosphorFlatIconData(0xe4c6, 'Thin');
+  static const userCircleGear = IconData(0xe4c6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-circle-minus-thin.svg)
-  static const userCircleMinus = PhosphorFlatIconData(0xe4c8, 'Thin');
+  static const userCircleMinus = IconData(0xe4c8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-circle-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-circle-plus-thin.svg)
-  static const userCirclePlus = PhosphorFlatIconData(0xe4ca, 'Thin');
+  static const userCirclePlus = IconData(0xe4ca,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-focus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-focus-thin.svg)
-  static const userFocus = PhosphorFlatIconData(0xe6fc, 'Thin');
+  static const userFocus = IconData(0xe6fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-gear-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-gear-thin.svg)
-  static const userGear = PhosphorFlatIconData(0xe4cc, 'Thin');
+  static const userGear = IconData(0xe4cc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-list-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-list-thin.svg)
-  static const userList = PhosphorFlatIconData(0xe73c, 'Thin');
+  static const userList = IconData(0xe73c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-minus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-minus-thin.svg)
-  static const userMinus = PhosphorFlatIconData(0xe4ce, 'Thin');
+  static const userMinus = IconData(0xe4ce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-plus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-plus-thin.svg)
-  static const userPlus = PhosphorFlatIconData(0xe4d0, 'Thin');
+  static const userPlus = IconData(0xe4d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-rectangle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-rectangle-thin.svg)
-  static const userRectangle = PhosphorFlatIconData(0xe4d2, 'Thin');
+  static const userRectangle = IconData(0xe4d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-sound-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-sound-thin.svg)
-  static const userSound = PhosphorFlatIconData(0xeca8, 'Thin');
+  static const userSound = IconData(0xeca8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-square-thin.svg)
-  static const userSquare = PhosphorFlatIconData(0xe4d4, 'Thin');
+  static const userSquare = IconData(0xe4d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![user-switch-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/user-switch-thin.svg)
-  static const userSwitch = PhosphorFlatIconData(0xe756, 'Thin');
+  static const userSwitch = IconData(0xe756,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/users-thin.svg)
-  static const users = PhosphorFlatIconData(0xe4d6, 'Thin');
+  static const users = IconData(0xe4d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-four-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/users-four-thin.svg)
-  static const usersFour = PhosphorFlatIconData(0xe68c, 'Thin');
+  static const usersFour = IconData(0xe68c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![users-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/users-three-thin.svg)
-  static const usersThree = PhosphorFlatIconData(0xe68e, 'Thin');
+  static const usersThree = IconData(0xe68e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![van-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/van-thin.svg)
-  static const van = PhosphorFlatIconData(0xe826, 'Thin');
+  static const van = IconData(0xe826,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vault-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/vault-thin.svg)
-  static const vault = PhosphorFlatIconData(0xe76e, 'Thin');
+  static const vault = IconData(0xe76e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-three-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/vector-three-thin.svg)
-  static const vectorThree = PhosphorFlatIconData(0xee62, 'Thin');
+  static const vectorThree = IconData(0xee62,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vector-two-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/vector-two-thin.svg)
-  static const vectorTwo = PhosphorFlatIconData(0xee64, 'Thin');
+  static const vectorTwo = IconData(0xee64,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vibrate-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/vibrate-thin.svg)
-  static const vibrate = PhosphorFlatIconData(0xe4d8, 'Thin');
+  static const vibrate = IconData(0xe4d8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/video-thin.svg)
-  static const video = PhosphorFlatIconData(0xe740, 'Thin');
+  static const video = IconData(0xe740,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/video-camera-thin.svg)
-  static const videoCamera = PhosphorFlatIconData(0xe4da, 'Thin');
+  static const videoCamera = IconData(0xe4da,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-camera-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/video-camera-slash-thin.svg)
-  static const videoCameraSlash = PhosphorFlatIconData(0xe4dc, 'Thin');
+  static const videoCameraSlash = IconData(0xe4dc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![video-conference-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/video-conference-thin.svg)
-  static const videoConference = PhosphorFlatIconData(0xedce, 'Thin');
+  static const videoConference = IconData(0xedce,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vignette-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/vignette-thin.svg)
-  static const vignette = PhosphorFlatIconData(0xeba2, 'Thin');
+  static const vignette = IconData(0xeba2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![vinyl-record-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/vinyl-record-thin.svg)
-  static const vinylRecord = PhosphorFlatIconData(0xecac, 'Thin');
+  static const vinylRecord = IconData(0xecac,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virtual-reality-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/virtual-reality-thin.svg)
-  static const virtualReality = PhosphorFlatIconData(0xe7b8, 'Thin');
+  static const virtualReality = IconData(0xe7b8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![virus-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/virus-thin.svg)
-  static const virus = PhosphorFlatIconData(0xe7d6, 'Thin');
+  static const virus = IconData(0xe7d6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![visor-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/visor-thin.svg)
-  static const visor = PhosphorFlatIconData(0xee2a, 'Thin');
+  static const visor = IconData(0xee2a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![voicemail-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/voicemail-thin.svg)
-  static const voicemail = PhosphorFlatIconData(0xe4de, 'Thin');
+  static const voicemail = IconData(0xe4de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![volleyball-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/volleyball-thin.svg)
-  static const volleyball = PhosphorFlatIconData(0xe726, 'Thin');
+  static const volleyball = IconData(0xe726,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wall-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wall-thin.svg)
-  static const wall = PhosphorFlatIconData(0xe688, 'Thin');
+  static const wall = IconData(0xe688,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wallet-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wallet-thin.svg)
-  static const wallet = PhosphorFlatIconData(0xe68a, 'Thin');
+  static const wallet = IconData(0xe68a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warehouse-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/warehouse-thin.svg)
-  static const warehouse = PhosphorFlatIconData(0xecd4, 'Thin');
+  static const warehouse = IconData(0xecd4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/warning-thin.svg)
-  static const warning = PhosphorFlatIconData(0xe4e0, 'Thin');
+  static const warning = IconData(0xe4e0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/warning-circle-thin.svg)
-  static const warningCircle = PhosphorFlatIconData(0xe4e2, 'Thin');
+  static const warningCircle = IconData(0xe4e2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-diamond-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/warning-diamond-thin.svg)
-  static const warningDiamond = PhosphorFlatIconData(0xe7fc, 'Thin');
+  static const warningDiamond = IconData(0xe7fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![warning-octagon-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/warning-octagon-thin.svg)
-  static const warningOctagon = PhosphorFlatIconData(0xe4e4, 'Thin');
+  static const warningOctagon = IconData(0xe4e4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![washing-machine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/washing-machine-thin.svg)
-  static const washingMachine = PhosphorFlatIconData(0xede8, 'Thin');
+  static const washingMachine = IconData(0xede8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![watch-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/watch-thin.svg)
-  static const watch = PhosphorFlatIconData(0xe4e6, 'Thin');
+  static const watch = IconData(0xe4e6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sawtooth-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wave-sawtooth-thin.svg)
-  static const waveSawtooth = PhosphorFlatIconData(0xea9c, 'Thin');
+  static const waveSawtooth = IconData(0xea9c,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-sine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wave-sine-thin.svg)
-  static const waveSine = PhosphorFlatIconData(0xea9a, 'Thin');
+  static const waveSine = IconData(0xea9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wave-square-thin.svg)
-  static const waveSquare = PhosphorFlatIconData(0xea9e, 'Thin');
+  static const waveSquare = IconData(0xea9e,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wave-triangle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wave-triangle-thin.svg)
-  static const waveTriangle = PhosphorFlatIconData(0xeaa0, 'Thin');
+  static const waveTriangle = IconData(0xeaa0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/waveform-thin.svg)
-  static const waveform = PhosphorFlatIconData(0xe802, 'Thin');
+  static const waveform = IconData(0xe802,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waveform-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/waveform-slash-thin.svg)
-  static const waveformSlash = PhosphorFlatIconData(0xe800, 'Thin');
+  static const waveformSlash = IconData(0xe800,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![waves-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/waves-thin.svg)
-  static const waves = PhosphorFlatIconData(0xe6de, 'Thin');
+  static const waves = IconData(0xe6de,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/webcam-thin.svg)
-  static const webcam = PhosphorFlatIconData(0xe9b2, 'Thin');
+  static const webcam = IconData(0xe9b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webcam-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/webcam-slash-thin.svg)
-  static const webcamSlash = PhosphorFlatIconData(0xecdc, 'Thin');
+  static const webcamSlash = IconData(0xecdc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![webhooks-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/webhooks-logo-thin.svg)
-  static const webhooksLogo = PhosphorFlatIconData(0xecae, 'Thin');
+  static const webhooksLogo = IconData(0xecae,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wechat-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wechat-logo-thin.svg)
-  static const wechatLogo = PhosphorFlatIconData(0xe8d2, 'Thin');
+  static const wechatLogo = IconData(0xe8d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![whatsapp-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/whatsapp-logo-thin.svg)
-  static const whatsappLogo = PhosphorFlatIconData(0xe5d0, 'Thin');
+  static const whatsappLogo = IconData(0xe5d0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wheelchair-thin.svg)
-  static const wheelchair = PhosphorFlatIconData(0xe4e8, 'Thin');
+  static const wheelchair = IconData(0xe4e8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wheelchair-motion-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wheelchair-motion-thin.svg)
-  static const wheelchairMotion = PhosphorFlatIconData(0xe89a, 'Thin');
+  static const wheelchairMotion = IconData(0xe89a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-high-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wifi-high-thin.svg)
-  static const wifiHigh = PhosphorFlatIconData(0xe4ea, 'Thin');
+  static const wifiHigh = IconData(0xe4ea,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-low-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wifi-low-thin.svg)
-  static const wifiLow = PhosphorFlatIconData(0xe4ec, 'Thin');
+  static const wifiLow = IconData(0xe4ec,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-medium-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wifi-medium-thin.svg)
-  static const wifiMedium = PhosphorFlatIconData(0xe4ee, 'Thin');
+  static const wifiMedium = IconData(0xe4ee,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-none-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wifi-none-thin.svg)
-  static const wifiNone = PhosphorFlatIconData(0xe4f0, 'Thin');
+  static const wifiNone = IconData(0xe4f0,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-slash-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wifi-slash-thin.svg)
-  static const wifiSlash = PhosphorFlatIconData(0xe4f2, 'Thin');
+  static const wifiSlash = IconData(0xe4f2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wifi-x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wifi-x-thin.svg)
-  static const wifiX = PhosphorFlatIconData(0xe4f4, 'Thin');
+  static const wifiX = IconData(0xe4f4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wind-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wind-thin.svg)
-  static const wind = PhosphorFlatIconData(0xe5d2, 'Thin');
+  static const wind = IconData(0xe5d2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windmill-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/windmill-thin.svg)
-  static const windmill = PhosphorFlatIconData(0xe9f8, 'Thin');
+  static const windmill = IconData(0xe9f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![windows-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/windows-logo-thin.svg)
-  static const windowsLogo = PhosphorFlatIconData(0xe692, 'Thin');
+  static const windowsLogo = IconData(0xe692,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wine-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wine-thin.svg)
-  static const wine = PhosphorFlatIconData(0xe6b2, 'Thin');
+  static const wine = IconData(0xe6b2,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![wrench-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/wrench-thin.svg)
-  static const wrench = PhosphorFlatIconData(0xe5d4, 'Thin');
+  static const wrench = IconData(0xe5d4,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/x-thin.svg)
-  static const x = PhosphorFlatIconData(0xe4f6, 'Thin');
+  static const x = IconData(0xe4f6,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-circle-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/x-circle-thin.svg)
-  static const xCircle = PhosphorFlatIconData(0xe4f8, 'Thin');
+  static const xCircle = IconData(0xe4f8,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/x-logo-thin.svg)
-  static const xLogo = PhosphorFlatIconData(0xe4bc, 'Thin');
+  static const xLogo = IconData(0xe4bc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![x-square-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/x-square-thin.svg)
-  static const xSquare = PhosphorFlatIconData(0xe4fa, 'Thin');
+  static const xSquare = IconData(0xe4fa,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yarn-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/yarn-thin.svg)
-  static const yarn = PhosphorFlatIconData(0xed9a, 'Thin');
+  static const yarn = IconData(0xed9a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![yin-yang-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/yin-yang-thin.svg)
-  static const yinYang = PhosphorFlatIconData(0xe92a, 'Thin');
+  static const yinYang = IconData(0xe92a,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 
   /// ![youtube-logo-thin](https://raw.githubusercontent.com/phosphor-icons/core/main/assets/thin/youtube-logo-thin.svg)
-  static const youtubeLogo = PhosphorFlatIconData(0xe4fc, 'Thin');
+  static const youtubeLogo = IconData(0xe4fc,
+      fontFamily: _f, fontPackage: _p, matchTextDirection: true);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,50 +5,50 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -63,127 +63,127 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "15.2.0"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.10.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,8 @@ screenshots:
     path: meta/screenshot_duotone.png
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes #61, Fixes #64.

## Problem

Flutter 3.43 marks `IconData` as a `final` class ([breaking change](https://docs.flutter.dev/release/breaking-changes/icondata-class-marked-final)), which breaks the current inheritance hierarchy:

```
Error: The class 'IconData' can't be extended outside of its library because it's a final class.
```

This affects:
- `PhosphorIconData`
- `PhosphorFlatIconData`
- `PhosphorDuotoneIconData`

The package currently fails to compile on Flutter 3.43+.

## Approach

This PR migrates the package away from `IconData` inheritance while preserving the existing public usage patterns as much as possible.

### API compatibility

- `PhosphorIconData` is now a typedef to `IconData`.
- `PhosphorFlatIconData` and `PhosphorDuotoneIconData` have been removed.
- Generated icons are now plain `IconData` instances.
- `PhosphorIcon` still extends `Icon`, so APIs such as `find.byIcon`, `find.widgetWithIcon`, and `IconTheme` integration continue to work unchanged.
- Duotone rendering is preserved through a generated lookup:
```dart
PhosphorIconsDuotone.secondaryFor(primaryIcon)
```
`PhosphorIcon` uses this lookup internally to render the secondary glyph automatically for duotone icons.

## Breaking changes

- Removed `PhosphorFlatIconData`.
- Removed `PhosphorDuotoneIconData`.
- Removed `PhosphorIconData(int codePoint, String style)` constructor.
- Duotone icons rendered directly with Flutter's `Icon` widget will display only the foreground glyph. `PhosphorIcon` continues to render both layers automatically.

The following continue to work unchanged:
- `Icon(PhosphorIcons.x())`
- `Icon(PhosphorIconsRegular.x)`
- `PhosphorIcon(...)`
- `find.byIcon(...)`
- `find.widgetWithIcon(...)`
- `List<IconData>`


## Generator

- `bin/generate_package_icons.dart` updated to emit the new forms. Regenerating reproduces the committed icon files.
- `bin/pubspec.yaml` SDK constraint bumped to `>=3.0.0` (the generator itself no longer runs on Dart 2.x because of upstream `archive` and `http` breaking changes).


## Not included

- Version bump. Left to maintainer discretion.
- `CHANGELOG.md` updates. Existing changelog entries appear to be maintainer-managed.
